### PR TITLE
implementing addReluConstraint()

### DIFF
--- a/src/engine/InputQuery.cpp
+++ b/src/engine/InputQuery.cpp
@@ -14,6 +14,7 @@
 #include "MStringf.h"
 #include "ReluplexError.h"
 #include "FloatUtils.h"
+#include "ReluConstraint.h"
 
 InputQuery::InputQuery()
 {
@@ -115,6 +116,12 @@ double InputQuery::getSolutionValue( unsigned variable ) const
                              Stringf( "Variable: %u", variable ).ascii() );
 
     return _solution.get( variable );
+}
+
+void InputQuery::addReluConstraint(unsigned var1, unsigned var2)
+{
+    PiecewiseLinearConstraint* r = new ReluConstraint(var1, var2);
+    addPiecewiseLinearConstraint(r);
 }
 
 void InputQuery::addPiecewiseLinearConstraint( PiecewiseLinearConstraint *constraint )

--- a/src/engine/InputQuery.h
+++ b/src/engine/InputQuery.h
@@ -42,6 +42,7 @@ public:
     const List<Equation> &getEquations() const;
 	List<Equation> &getEquations();
 
+    void addReluConstraint(unsigned var1, unsigned var2);
     void addPiecewiseLinearConstraint( PiecewiseLinearConstraint *constraint );
     const List<PiecewiseLinearConstraint *> &getPiecewiseLinearConstraints() const;
 	List<PiecewiseLinearConstraint *> &getPiecewiseLinearConstraints();


### PR DESCRIPTION
-implemented method that adds the Relu constraints given two variables
-avoids exposing PiecewiseLinearConstraint to the shared library