### PR TITLE
Fixed arguments supplied to MarabouNetworkTF

### DIFF
--- a/maraboupy/Marabou.py
+++ b/maraboupy/Marabou.py
@@ -25,4 +25,4 @@ def read_tf(filename, inputName=None, outputName=None):
     Returns:
         marabouNetworkTF: (MarabouNetworkTF) representing network
     """
-    return MarabouNetworkTF(filename)
+    return MarabouNetworkTF(filename, inputName, outputName)


### PR DESCRIPTION
Fixed bug where names of input and output operation in Tensorflow graph were not being used correctly.