### PR TITLE
Statistics Bug fix

### DIFF
--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -69,9 +69,9 @@ std::pair<std::map<int, double>, Statistics> solve(InputQuery inputQuery, std::s
         output=redirectOutputToFile(redirect);
     try{
         Engine engine;
-        if(!engine.processInputQuery(inputQuery)) return std::make_pair(ret, retStats);
+        if(!engine.processInputQuery(inputQuery)) return std::make_pair(ret, *(engine.getStatistics()));
         
-        if(!engine.solve()) return std::make_pair(ret, retStats);
+        if(!engine.solve()) return std::make_pair(ret, *(engine.getStatistics()));
         
         engine.extractSolution(inputQuery);
         retStats = *(engine.getStatistics());


### PR DESCRIPTION
# Minor bug fix

- fixes a bug that caused the Statistics object to be initialized with the default constructor when a query is UNSAT. The variable was declared but not initialized because of try-catch control flow. This made all the members of Statistics initialize to their default values yielding the object uninformative.