### PR TITLE
fix -Wmisleading-indentation warnings

### DIFF
--- a/src/basis_factorization/ForrestTomlinFactorization.cpp
+++ b/src/basis_factorization/ForrestTomlinFactorization.cpp
@@ -118,7 +118,7 @@ ForrestTomlinFactorization::~ForrestTomlinFactorization()
     List<LPElement *>::iterator lpIt;
     for ( lpIt = _LP.begin(); lpIt != _LP.end(); ++lpIt )
         delete *lpIt;
-	_LP.clear();
+    _LP.clear();
 }
 
 void ForrestTomlinFactorization::pushEtaMatrix( unsigned /* columnIndex */, const double */* column */ )
@@ -365,7 +365,7 @@ void ForrestTomlinFactorization::clearFactorization()
     List<LPElement *>::iterator lpIt;
     for ( lpIt = _LP.begin(); lpIt != _LP.end(); ++lpIt )
         delete *lpIt;
-	_LP.clear();
+    _LP.clear();
 
     _Q.resetToIdentity();
     _R.resetToIdentity();

--- a/src/basis_factorization/LUFactorization.cpp
+++ b/src/basis_factorization/LUFactorization.cpp
@@ -37,7 +37,7 @@ LUFactorization::LUFactorization( unsigned m )
     for ( unsigned row = 0; row < _m; ++row )
         _B0[row * _m + row] = 1.0;
 
-	_U = new double[m*m];
+    _U = new double[m*m];
 	if ( !_U )
         throw BasisFactorizationError( BasisFactorizationError::ALLOCATION_FAILED, "LUFactorization::U" );
 
@@ -91,7 +91,7 @@ void LUFactorization::freeIfNeeded()
     for ( element = _LP.begin(); element != _LP.end(); ++element )
         delete *element;
 
-	_LP.clear();
+    _LP.clear();
 }
 
 const double *LUFactorization::getU() const
@@ -136,7 +136,7 @@ void LUFactorization::LMultiplyRight( const EtaMatrix *L, double *X ) const
     if ( FloatUtils::isZero( sum ) )
         sum = 0.0;
 
-	X[L->_columnIndex] = sum;
+    X[L->_columnIndex] = sum;
 }
 
 void LUFactorization::LMultiplyLeft( const EtaMatrix *L, double *X ) const
@@ -360,7 +360,7 @@ void LUFactorization::clearLPU()
     List<LPElement *>::iterator element;
     for ( element = _LP.begin(); element != _LP.end(); ++element )
         delete *element;
-	_LP.clear();
+    _LP.clear();
 
 	std::fill_n( _U, _m*_m, 0 );
 }

--- a/src/engine/Preprocessor.cpp
+++ b/src/engine/Preprocessor.cpp
@@ -60,7 +60,7 @@ InputQuery Preprocessor::preprocess( const InputQuery &query, bool attemptVariab
     if ( attemptVariableElimination )
         eliminateFixedVariables();
 
-	return _preprocessed;
+    return _preprocessed;
 }
 
 bool Preprocessor::processEquations()


### PR DESCRIPTION
I only fixed the indentation issues in this commit, not GCC 7.2.0's other complaint (throwing from destructors). The other warnings are in cxxtest code and it did not seem like the correct solution to modify the third-party code. Another interesting aspect is that my build output implies GCC is issuing these warnings because it is compiling as C++11. The top level makefiles set C++0x, so maybe somewhere down the recursive build the flags are being lost and GCC 7.2.0 is defaulting to C++11.