### PR TITLE
remove unused private field tempY

### DIFF
--- a/src/basis_factorization/LUFactorization.h
+++ b/src/basis_factorization/LUFactorization.h
@@ -175,7 +175,6 @@ private:
     /*
       Working space
     */
-    double *_tempY;
     double *_LCol;
 
     /*


### PR DESCRIPTION
needed to compile on macOS