### PR TITLE
Remove aux variables from maraboupy

### DIFF
--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -113,11 +113,16 @@ PYBIND11_MODULE(MarabouCore, m) {
         .def("getLowerBound", &InputQuery::getLowerBound)
         .def("setNumberOfVariables", &InputQuery::setNumberOfVariables)
         .def("addEquation", &InputQuery::addEquation);
-    py::class_<Equation>(m, "Equation")
-        .def(py::init())
-        .def("addAddend", &Equation::addAddend)
-        .def("setScalar", &Equation::setScalar)
-        .def("markAuxiliaryVariable", &Equation::markAuxiliaryVariable);
+    py::class_<Equation> eq(m, "Equation");
+    eq.def(py::init());
+    eq.def(py::init<Equation::EquationType>());
+    eq.def("addAddend", &Equation::addAddend);
+    eq.def("setScalar", &Equation::setScalar);
+    py::enum_<Equation::EquationType>(eq, "EquationType")
+        .value("EQ", Equation::EquationType::EQ)
+        .value("GE", Equation::EquationType::GE)
+        .value("LE", Equation::EquationType::LE)
+        .export_values();
     py::class_<Statistics>(m, "Statistics")
         .def("getMaxStackDepth", &Statistics::getMaxStackDepth)
         .def("getNumPops", &Statistics::getNumPops)

--- a/maraboupy/MarabouNetwork.py
+++ b/maraboupy/MarabouNetwork.py
@@ -121,11 +121,10 @@ class MarabouNetwork:
         ipq.setNumberOfVariables(self.numVars)
         
         for e in self.equList:
-            eq = MarabouCore.Equation()
+            eq = MarabouCore.Equation(e.EquationType)
             for (c, v) in e.addendList:
                 assert v < self.numVars
                 eq.addAddend(c, v)
-            eq.markAuxiliaryVariable(e.auxVar)
             eq.setScalar(e.scalar)
             ipq.addEquation(eq)
 
@@ -165,10 +164,9 @@ class MarabouNetwork:
         vals, stats = MarabouCore.solve(ipq, filename)
         if verbose:
             if len(vals)==0:
-                    print("UNSAT")
+                print("UNSAT")
             else:
                 print("SAT")
-               #print(vals)
                 for i in range(self.inputVars.size):
                     print("input {} = {}".format(i, vals[self.inputVars.item(i)]))
 

--- a/maraboupy/MarabouNetworkTF.py
+++ b/maraboupy/MarabouNetworkTF.py
@@ -215,10 +215,6 @@ class MarabouNetworkTF(MarabouNetwork.MarabouNetwork):
                     e.addAddend(B[k][j], A[i][k])
                 e.addAddend(-1, curValues[i][j])
                 e.setScalar(0.0)
-                aux = self.getNewVariable()
-                self.setLowerBound(aux, 0.0)
-                self.setUpperBound(aux, 0.0)
-                e.markAuxiliaryVariable(aux)
                 self.addEquation(e)
 
     def biasAddEquations(self, op):
@@ -259,10 +255,6 @@ class MarabouNetworkTF(MarabouNetwork.MarabouNetwork):
                 e.addAddend(1.0, x)
                 e.addAddend(-1.0, xprime)
                 e.setScalar(c)
-                aux = self.getNewVariable()
-                self.setLowerBound(aux, 0.0)
-                self.setUpperBound(aux, 0.0)
-                e.markAuxiliaryVariable(aux)
                 self.addEquation(e)
             else:
                 biasAddUpdates[x] = (xprime, c)
@@ -329,10 +321,6 @@ class MarabouNetworkTF(MarabouNetwork.MarabouNetwork):
                     # Add output variable
                     e.addAddend(-1, curValues[0][i][j][k])
                     e.setScalar(0.0)
-                    aux = self.getNewVariable()
-                    self.setLowerBound(aux, 0.0)
-                    self.setUpperBound(aux, 0.0)
-                    e.markAuxiliaryVariable(aux)
                     self.addEquation(e)
 
     def reluEquations(self, op):
@@ -354,15 +342,6 @@ class MarabouNetworkTF(MarabouNetwork.MarabouNetwork):
         ### Generate actual equations ###
         for i in range(len(prev)):
             self.addRelu(prev[i], cur[i])
-        #     e = MarabouUtils.Equation()
-        #     e.addAddend(1.0, prev[i])
-        #     e.addAddend(-1.0, cur[i])
-        #     e.setScalar(0.0)
-        #     aux = self.getNewVariable()
-        #     e.addAddend(1.0, aux)
-        #     e.markAuxiliaryVariable(aux)
-        #     self.setLowerBound(aux, 0.0)
-        #     self.addEquation(e)
         for f in cur:
             self.setLowerBound(f, 0.0)
 

--- a/maraboupy/MarabouUtils.py
+++ b/maraboupy/MarabouUtils.py
@@ -1,16 +1,18 @@
+from . import MarabouCore
+
 class Equation:
     """
     Python class to conveniently represent MarabouCore.Equation
     """
-    def __init__(self):
+    def __init__(self, EquationType=MarabouCore.Equation.EQ):
         """
         Construct empty equation
         """
         self.addendList = []
         self.participatingVariables = set()
-        self.auxVar = None
         self.scalar = None
-    
+        self.EquationType = EquationType
+
     def setScalar(self, x):
         """
         Set scalar of equation
@@ -28,14 +30,6 @@ class Equation:
         """
         self.addendList += [(c, x)]
         self.participatingVariables.update([x])
-
-    def markAuxiliaryVariable(self, aux):
-        """
-        Mark variable as auxiliary for this equation
-        Arguments:
-            aux: (int) variable number of variable to mark
-        """
-        self.auxVar = aux
 
     def getParticipatingVariables(self):
         """
@@ -61,7 +55,6 @@ class Equation:
         """
         assert self.participatingVariable(x)
         assert not self.participatingVariable(xprime)
-        assert self.auxVar != x and self.auxVar != xprime
         for i in range(len(self.addendList)):
             if self.addendList[i][1] == x:
                 coeff = self.addendList[i][0]
@@ -85,10 +78,6 @@ def addEquality(network, vars, coeffs, scalar):
     for i in range(len(vars)):
         e.addAddend(coeffs[i], vars[i])
     e.setScalar(scalar)
-    aux = network.getNewVariable()
-    network.setLowerBound(aux, 0.0)
-    network.setUpperBound(aux, 0.0)
-    e.markAuxiliaryVariable(aux)
     network.addEquation(e)
 
 def addInequality(network, vars, coeffs, scalar):
@@ -102,12 +91,8 @@ def addInequality(network, vars, coeffs, scalar):
         scalar: (float) representing RHS of equation
     """
     assert len(vars)==len(coeffs)
-    e = Equation()
+    e = Equation(MarabouCore.Equation.LE)
     for i in range(len(vars)):
         e.addAddend(coeffs[i], vars[i])
     e.setScalar(scalar)
-    aux = network.getNewVariable()
-    network.setLowerBound(aux, 0.0)
-    e.markAuxiliaryVariable(aux)
-    e.addAddend(1.0, aux)
     network.addEquation(e)

--- a/maraboupy/examples/MarabouCoreExample.py
+++ b/maraboupy/examples/MarabouCoreExample.py
@@ -6,9 +6,9 @@ from maraboupy import MarabouCore
 #   0   <= x2f
 #   1/2 <= x3  <= 1
 #
-#  x0 - x1b = 0        -->  x0 - x1b + x6 = 0
-#  x0 + x2b = 0        -->  x0 + x2b + x7 = 0
-#  x1f + x2f - x3 = 0  -->  x1f + x2f - x3 + x8 = 0
+#  x0 - x1b = 0
+#  x0 + x2b = 0
+#  x1f + x2f - x3 = 0
 #
 #  x2f = Relu(x2b)
 #  x3f = Relu(x3b)
@@ -24,7 +24,7 @@ large = 10.0
 
 inputQuery = MarabouCore.InputQuery()
 
-inputQuery.setNumberOfVariables(9)
+inputQuery.setNumberOfVariables(6)
 
 inputQuery.setLowerBound(0, 0)
 inputQuery.setUpperBound(0, 1)
@@ -44,36 +44,23 @@ inputQuery.setUpperBound(4, large)
 inputQuery.setLowerBound(5, 0.5)
 inputQuery.setUpperBound(5, 1)
 
-inputQuery.setLowerBound(6, 0)
-inputQuery.setUpperBound(6, 0)
-inputQuery.setLowerBound(7, 0)
-inputQuery.setUpperBound(7, 0)
-inputQuery.setLowerBound(8, 0)
-inputQuery.setUpperBound(8, 0)
-
 equation1 = MarabouCore.Equation()
 equation1.addAddend(1, 0)
 equation1.addAddend(-1, 1)
-equation1.addAddend(1, 6)
 equation1.setScalar(0)
-equation1.markAuxiliaryVariable(6)
 inputQuery.addEquation(equation1)
 
 equation2 = MarabouCore.Equation()
 equation2.addAddend(1, 0)
 equation2.addAddend(1, 3)
-equation2.addAddend(1, 7)
 equation2.setScalar(0)
-equation2.markAuxiliaryVariable(7)
 inputQuery.addEquation(equation2)
 
 equation3 = MarabouCore.Equation()
 equation3.addAddend(1, 2)
 equation3.addAddend(1, 4)
 equation3.addAddend(-1, 5)
-equation3.addAddend(1, 8)
 equation3.setScalar(0)
-equation3.markAuxiliaryVariable(8)
 inputQuery.addEquation(equation3)
 
 MarabouCore.addReluConstraint(inputQuery,1,2)


### PR DESCRIPTION
To keep Maraboupy up-to-date with the Marabou, this pull request

- Removes aux variables from equations
- Changes inequalities to use the Equation.LE type instead of adding slack variables
- Updates example python scripts