### PR TITLE
Prevent iterator from incrementing after basic variable found

### DIFF
--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -452,7 +452,8 @@ void Engine::fixViolatedPlConstraintIfPossible()
                 found = true;
             }
         }
-        if (!found){
+        if ( !found )
+        {
             ++it;
         }
     }


### PR DESCRIPTION
When a basic variable is found, iterator it is still incremented one more time before exiting the while loop. This pull request prevents the increment after the basic variable is found.