### PR TITLE
Support single op used as input by multiple ops; implement var+var op

### DIFF
--- a/maraboupy/MarabouNetworkTF.py
+++ b/maraboupy/MarabouNetworkTF.py
@@ -271,12 +271,14 @@ class MarabouNetworkTF(MarabouNetwork.MarabouNetwork):
         Or eliminate one of the two variables in every other relation
         """
         biasAddUpdates = dict()
+        participations = [rel[0] for rel in self.biasAddRelations] + \
+                            [rel[1] for rel in self.biasAddRelations]
         for (x, xprime, c) in self.biasAddRelations:
             # x = xprime + c
             # replace x only if it does not occur anywhere else in the system
             if self.lowerBoundExists(x) or self.upperBoundExists(x) or \
                     self.participatesInPLConstraint(x) or \
-                    len([rel for rel in self.biasAddRelations if rel[0]==x]) > 1:
+                    len([p for p in participations if p == x]) > 1:
                 e = MarabouUtils.Equation()
                 e.addAddend(1.0, x)
                 e.addAddend(-1.0, xprime)


### PR DESCRIPTION
1) Earlier, if we had something like
`x1 = input+1; x2 = input + 2; x3 = x1 + x2`

we would get an error, there was an implicit assumption that network is a tree and not a DAG. Fixed this.

2) Implemented a way to see whether a given op represents something dependent on input (i.e., is a variable) or independent (i.e., is a constant). Based on this, implemented appropriate add and biasAdd functions.