### PR TITLE
Fixes regarding parallel-performance

### DIFF
--- a/maraboupy/DnCParallelSolver.py
+++ b/maraboupy/DnCParallelSolver.py
@@ -95,7 +95,7 @@ def solve_subproblems(network_name, subproblems, property_path, runtimes,
                         for result in results:
                             val, t_id, runtime, has_TO, num_tree_states = result
                             if has_TO:
-                                runtimes[t_id] = init_to
+                                runtimes[t_id] = -runtime
                             else:
                                 runtimes[t_id] = runtime
                             tree_states[t_id] = num_tree_states


### PR DESCRIPTION
1. Fix a bug regarding logging. This bug does not impact the performance of solved instances, but will crash the program when triggered.
2. When splitting a query, add one of the sub-queries to the original queue.