### PR TITLE
close file descriptor before return

### DIFF
--- a/src/input_parsers/AcasNnet.cpp
+++ b/src/input_parsers/AcasNnet.cpp
@@ -162,6 +162,7 @@ AcasNnet *load_network(const char* filename)
 
 
     delete[] buffer;
+    fclose(fstream);
 
     //return a pointer to the neural network
     return nnet;


### PR DESCRIPTION
Missing fclose call in AcasNnet.cpp load_network function.