### PR TITLE
Fix to initialize `_rhsIsAllZeros` in case `b` isn't zero when adding an Equation

### DIFF
--- a/src/engine/Tableau.cpp
+++ b/src/engine/Tableau.cpp
@@ -1817,6 +1817,9 @@ unsigned Tableau::addEquation( const Equation &equation )
     // Populate the new row of b
     _b[_m - 1] = equation._scalar;
 
+    if ( !FloatUtils::isZero( _b[_m - 1] ) )
+        _rhsIsAllZeros = false;
+    
     /*
       Attempt to make the auxiliary variable the new basic variable.
       This usually works.


### PR DESCRIPTION
When adding an equation to the tableau, if the scalar of the equation isn't zero. hence `b[m-1]`, we should set the indicator `_rhsIsAllZeros` to false.