### PR TITLE
Polarity based direction heuristics

### DIFF
--- a/src/configuration/GlobalConfiguration.cpp
+++ b/src/configuration/GlobalConfiguration.cpp
@@ -17,6 +17,8 @@
 #include "MString.h"
 #include <cstdio>
 
+// Use the polarity metrics to decide which branch to take first in a case split
+// and how to repair a ReLU constraint.
 const bool GlobalConfiguration::USE_POLARITY_BASED_DIRECTION_HEURISTICS = true;
 
 const double GlobalConfiguration::DEFAULT_EPSILON_FOR_COMPARISONS = 0.0000000001;

--- a/src/configuration/GlobalConfiguration.cpp
+++ b/src/configuration/GlobalConfiguration.cpp
@@ -17,6 +17,8 @@
 #include "MString.h"
 #include <cstdio>
 
+const bool GlobalConfiguration::USE_POLARITY_BASED_DIRECTION_HEURISTICS = true;
+
 const double GlobalConfiguration::DEFAULT_EPSILON_FOR_COMPARISONS = 0.0000000001;
 const unsigned GlobalConfiguration::DEFAULT_DOUBLE_TO_STRING_PRECISION = 10;
 const unsigned GlobalConfiguration::STATISTICS_PRINTING_FREQUENCY = 10000;

--- a/src/configuration/GlobalConfiguration.h
+++ b/src/configuration/GlobalConfiguration.h
@@ -21,6 +21,8 @@ class GlobalConfiguration
 public:
     static void print();
 
+    static const bool USE_POLARITY_BASED_DIRECTION_HEURISTICS;
+
     // The default epsilon used for comparing doubles
     static const double DEFAULT_EPSILON_FOR_COMPARISONS;
 

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -92,6 +92,7 @@ bool Engine::solve( unsigned timeoutInSeconds )
     SignalHandler::getInstance()->initialize();
     SignalHandler::getInstance()->registerClient( this );
 
+    updateDirections();
     storeInitialEngineState();
 
     if ( _verbosity > 0 )
@@ -1922,6 +1923,15 @@ void Engine::checkOverallProgress()
             _lastIterationWithProgress = currentIteration;
         }
     }
+}
+
+void Engine::updateDirections()
+{
+    if ( GlobalConfiguration::USE_POLARITY_BASED_DIRECTION_HEURISTICS )
+        for ( const auto &constraint : _plConstraints )
+            if ( constraint->supportPolarity() &&
+                 constraint->isActive() && !constraint->phaseFixed() )
+                ( (ReluConstraint *) constraint )->updateDirection();
 }
 
 //

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -1931,7 +1931,7 @@ void Engine::updateDirections()
         for ( const auto &constraint : _plConstraints )
             if ( constraint->supportPolarity() &&
                  constraint->isActive() && !constraint->phaseFixed() )
-                ( (ReluConstraint *) constraint )->updateDirection();
+                constraint->updateDirection();
 }
 
 //

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -451,6 +451,13 @@ private:
     double *createConstraintMatrix();
     void addAuxiliaryVariables();
     void augmentInitialBasisIfNeeded( List<unsigned> &initialBasis, const List<unsigned> &basicRows );
+
+    /*
+      Update the preferred direction to perform fixes and the preferred order
+      to handle case splits
+    */
+    void updateDirections();
+
 };
 
 #endif // __Engine_h__

--- a/src/engine/PiecewiseLinearConstraint.h
+++ b/src/engine/PiecewiseLinearConstraint.h
@@ -203,6 +203,15 @@ public:
         return false;
     }
 
+    /*
+      Return true if and only if this piecewise linear constraint supports
+      the polarity metric
+    */
+    virtual bool supportPolarity() const
+    {
+        return false;
+    }
+
 protected:
     bool _constraintActive;
 	Map<unsigned, double> _assignment;

--- a/src/engine/PiecewiseLinearConstraint.h
+++ b/src/engine/PiecewiseLinearConstraint.h
@@ -213,8 +213,7 @@ public:
     }
 
     /*
-      Return true if and only if this piecewise linear constraint supports
-      the polarity metric
+      Update the preferred direction to take first when branching on this PLConstraint
     */
     virtual void updateDirection()
     {

--- a/src/engine/PiecewiseLinearConstraint.h
+++ b/src/engine/PiecewiseLinearConstraint.h
@@ -212,6 +212,14 @@ public:
         return false;
     }
 
+    /*
+      Return true if and only if this piecewise linear constraint supports
+      the polarity metric
+    */
+    virtual void updateDirection()
+    {
+    }
+
 protected:
     bool _constraintActive;
 	Map<unsigned, double> _assignment;

--- a/src/engine/ReluConstraint.cpp
+++ b/src/engine/ReluConstraint.cpp
@@ -32,6 +32,7 @@ ReluConstraint::ReluConstraint( unsigned b, unsigned f )
     : _b( b )
     , _f( f )
     , _auxVarInUse( false )
+    , _direction( PhaseStatus::PHASE_NOT_FIXED )
     , _haveEliminatedVariables( false )
 {
     setPhaseStatus( PhaseStatus::PHASE_NOT_FIXED );
@@ -275,14 +276,30 @@ List<PiecewiseLinearConstraint::Fix> ReluConstraint::getPossibleFixes() const
         }
         else
         {
-            fixes.append( PiecewiseLinearConstraint::Fix( _b, fValue ) );
-            fixes.append( PiecewiseLinearConstraint::Fix( _f, 0 ) );
+            if ( _direction == PHASE_INACTIVE )
+            {
+                fixes.append( PiecewiseLinearConstraint::Fix( _f, 0 ) );
+                fixes.append( PiecewiseLinearConstraint::Fix( _b, fValue ) );
+            }
+            else
+            {
+                fixes.append( PiecewiseLinearConstraint::Fix( _b, fValue ) );
+                fixes.append( PiecewiseLinearConstraint::Fix( _f, 0 ) );
+            }
         }
     }
     else
     {
-        fixes.append( PiecewiseLinearConstraint::Fix( _b, 0 ) );
-        fixes.append( PiecewiseLinearConstraint::Fix( _f, bValue ) );
+        if ( _direction == PHASE_ACTIVE )
+        {
+            fixes.append( PiecewiseLinearConstraint::Fix( _f, bValue ) );
+            fixes.append( PiecewiseLinearConstraint::Fix( _b, 0 ) );
+        }
+        else
+        {
+            fixes.append( PiecewiseLinearConstraint::Fix( _b, 0 ) );
+            fixes.append( PiecewiseLinearConstraint::Fix( _f, bValue ) );
+        }
     }
 
     return fixes;
@@ -414,6 +431,19 @@ List<PiecewiseLinearCaseSplit> ReluConstraint::getCaseSplits() const
         throw MarabouError( MarabouError::REQUESTED_CASE_SPLITS_FROM_FIXED_CONSTRAINT );
 
     List<PiecewiseLinearCaseSplit> splits;
+
+    if ( _direction == PHASE_INACTIVE )
+    {
+        splits.append( getInactiveSplit() );
+        splits.append( getActiveSplit() );
+        return splits;
+    }
+    else if ( _direction == PHASE_ACTIVE )
+    {
+        splits.append( getActiveSplit() );
+        splits.append( getInactiveSplit() );
+        return splits;
+    }
 
     // If we have existing knowledge about the assignment, use it to
     // influence the order of splits
@@ -819,6 +849,11 @@ bool ReluConstraint::supportsSymbolicBoundTightening() const
     return true;
 }
 
+bool ReluConstraint::supportPolarity() const
+{
+    return true;
+}
+
 bool ReluConstraint::auxVariableInUse() const
 {
     return _auxVarInUse;
@@ -828,6 +863,22 @@ unsigned ReluConstraint::getAux() const
 {
     return _aux;
 }
+
+double ReluConstraint::computePolarity() const
+{
+    double currentLb = _lowerBounds[_b];
+    double currentUb = _upperBounds[_b];
+    if ( currentLb >= 0 || currentUb <= 0 ) return 1;
+    double width = currentUb - currentLb;
+    double sum = currentUb + currentLb;
+    return sum / width;
+}
+
+void ReluConstraint::updateDirection()
+{
+    _direction = ( computePolarity() > 0 ) ? PHASE_ACTIVE : PHASE_INACTIVE;
+}
+
 
 //
 // Local Variables:

--- a/src/engine/ReluConstraint.cpp
+++ b/src/engine/ReluConstraint.cpp
@@ -438,7 +438,7 @@ List<PiecewiseLinearCaseSplit> ReluConstraint::getCaseSplits() const
         splits.append( getActiveSplit() );
         return splits;
     }
-    else if ( _direction == PHASE_ACTIVE )
+    if ( _direction == PHASE_ACTIVE )
     {
         splits.append( getActiveSplit() );
         splits.append( getInactiveSplit() );
@@ -868,7 +868,8 @@ double ReluConstraint::computePolarity() const
 {
     double currentLb = _lowerBounds[_b];
     double currentUb = _upperBounds[_b];
-    if ( currentLb >= 0 || currentUb <= 0 ) return 1;
+    if ( currentLb >= 0 ) return 1;
+    if (  currentUb <= 0 ) return -1;
     double width = currentUb - currentLb;
     double sum = currentUb + currentLb;
     return sum / width;

--- a/src/engine/ReluConstraint.cpp
+++ b/src/engine/ReluConstraint.cpp
@@ -869,7 +869,7 @@ double ReluConstraint::computePolarity() const
     double currentLb = _lowerBounds[_b];
     double currentUb = _upperBounds[_b];
     if ( currentLb >= 0 ) return 1;
-    if (  currentUb <= 0 ) return -1;
+    if ( currentUb <= 0 ) return -1;
     double width = currentUb - currentLb;
     double sum = currentUb + currentLb;
     return sum / width;
@@ -878,6 +878,11 @@ double ReluConstraint::computePolarity() const
 void ReluConstraint::updateDirection()
 {
     _direction = ( computePolarity() > 0 ) ? PHASE_ACTIVE : PHASE_INACTIVE;
+}
+
+ReluConstraint::PhaseStatus ReluConstraint::getDirection() const
+{
+    return _direction;
 }
 
 //

--- a/src/engine/ReluConstraint.h
+++ b/src/engine/ReluConstraint.h
@@ -165,7 +165,17 @@ public:
     bool supportPolarity() const;
 
     /*
-      Return the polarity of the current ReLU
+      Return the polarity of this ReLU, which computes how symmetric
+      the bound of the input to this ReLU is with respect to 0.
+      Let LB be the lowerbound, and UB be the upperbound.
+      If LB >= 0, polarity is 1.
+      If UB <= 0, polarity is -1.
+      If LB < 0, and UB > 0, polarity is ( LB + UB ) / (UB - LB).
+
+      We divide the sum by the width of the interval so that the polarity is
+      always between -1 and 1. The closer it is to 0, the more symmetric the
+      bound is.
+
     */
     double computePolarity() const;
 

--- a/src/engine/ReluConstraint.h
+++ b/src/engine/ReluConstraint.h
@@ -162,11 +162,31 @@ public:
     */
     bool supportsSymbolicBoundTightening() const;
 
+    bool supportPolarity() const;
+
+    /*
+      Return the polarity of the current ReLU
+    */
+    double computePolarity() const;
+
+    /*
+      Update the preferring direction for fixing and handling case split
+    */
+    void updateDirection();
+
+
 private:
     unsigned _b, _f;
     PhaseStatus _phaseStatus;
     bool _auxVarInUse;
     unsigned _aux;
+
+    /*
+      Denotes which case split to handle first.
+      And which phase status to repair a relu into.
+    */
+    PhaseStatus _direction;
+
 
     PiecewiseLinearCaseSplit getInactiveSplit() const;
     PiecewiseLinearCaseSplit getActiveSplit() const;

--- a/src/engine/ReluConstraint.h
+++ b/src/engine/ReluConstraint.h
@@ -175,15 +175,15 @@ public:
       We divide the sum by the width of the interval so that the polarity is
       always between -1 and 1. The closer it is to 0, the more symmetric the
       bound is.
-
     */
     double computePolarity() const;
 
     /*
-      Update the preferring direction for fixing and handling case split
+      Update the preferred direction for fixing and handling case split
     */
     void updateDirection();
 
+    PhaseStatus getDirection() const;
 
 private:
     unsigned _b, _f;
@@ -196,7 +196,6 @@ private:
       And which phase status to repair a relu into.
     */
     PhaseStatus _direction;
-
 
     PiecewiseLinearCaseSplit getInactiveSplit() const;
     PiecewiseLinearCaseSplit getActiveSplit() const;

--- a/src/engine/tests/Test_ReluConstraint.h
+++ b/src/engine/tests/Test_ReluConstraint.h
@@ -1056,7 +1056,108 @@ public:
             TS_ASSERT( tightenings.exists( Tightening( b, -1, Tightening::UB ) ) );
         }
     }
+
+    void test_polarity()
+    {
+        unsigned b = 1;
+        unsigned f = 4;
+
+        PiecewiseLinearCaseSplit activePhase;
+        activePhase.storeBoundTightening( Tightening( b, 0.0, Tightening::LB ) );
+        Equation activeEquation( Equation::EQ );
+        activeEquation.addAddend( 1, b );
+        activeEquation.addAddend( -1, f );
+        activeEquation.setScalar( 0 );
+        activePhase.addEquation( activeEquation );
+
+        PiecewiseLinearCaseSplit inactivePhase;
+        inactivePhase.storeBoundTightening( Tightening( b, 0.0, Tightening::UB ) );
+        inactivePhase.storeBoundTightening( Tightening( f, 0.0, Tightening::UB ) );
+
+        // b in [1, 2], polarity should be 1, and direction should be PHASE_ACTIVE
+        {
+            ReluConstraint relu( b, f );
+            relu.notifyLowerBound( b, 1 );
+            relu.notifyUpperBound( b, 2 );
+            TS_ASSERT( relu.computePolarity() == 1 );
+
+            relu.updateDirection();
+            TS_ASSERT( relu.getDirection() == ReluConstraint::PHASE_ACTIVE );
+        }
+        // b in [-2, 0], polarity should be -1, and direction should be PHASE_INACTIVE
+        {
+            ReluConstraint relu( b, f );
+            relu.notifyLowerBound( b, -2 );
+            relu.notifyUpperBound( b, 0 );
+            TS_ASSERT( relu.computePolarity() == -1 );
+
+            relu.updateDirection();
+            TS_ASSERT( relu.getDirection() == ReluConstraint::PHASE_INACTIVE );
+        }
+        // b in [-2, 2], polarity should be 0, the direction should be PHASE_INACTIVE,
+        // the inactive case should be the first element of the returned list by
+        // the getCaseSplits(), and getPossibleFix should return the inactive fix first
+        {
+            ReluConstraint relu( b, f );
+            relu.notifyLowerBound( b, -2 );
+            relu.notifyUpperBound( b, 2 );
+            TS_ASSERT( relu.computePolarity() == 0 );
+
+            relu.updateDirection();
+            TS_ASSERT( relu.getDirection() == ReluConstraint::PHASE_INACTIVE );
+
+            auto splits = relu.getCaseSplits();
+            auto it = splits.begin();
+            TS_ASSERT( *it == inactivePhase );
+
+            List<PiecewiseLinearConstraint::Fix> fixes;
+            List<PiecewiseLinearConstraint::Fix>::iterator itFix;
+
+            relu.notifyVariableValue( b, -1 );
+            relu.notifyVariableValue( f, 1 );
+
+            fixes = relu.getPossibleFixes();
+            itFix = fixes.begin();
+            TS_ASSERT_EQUALS( itFix->_variable, f );
+            TS_ASSERT_EQUALS( itFix->_value, 0 );
+            ++itFix;
+            TS_ASSERT_EQUALS( itFix->_variable, b );
+            TS_ASSERT_EQUALS( itFix->_value, 1 );
+
+        }
+        // b in [-2, 3], polarity should be 0.2, the direction should be PHASE_ACTIVE,
+        // the active case should be the first element of the returned list by
+        // the getCaseSplits(), and getPossibleFix should return the active fix first
+        {
+            ReluConstraint relu( b, f );
+            relu.notifyLowerBound( b, -2 );
+            relu.notifyUpperBound( b, 3 );
+            TS_ASSERT( relu.computePolarity() == 0.2 );
+
+            relu.updateDirection();
+            TS_ASSERT( relu.getDirection() == ReluConstraint::PHASE_ACTIVE );
+
+            auto splits = relu.getCaseSplits();
+            auto it = splits.begin();
+            TS_ASSERT( *it == activePhase );
+
+            List<PiecewiseLinearConstraint::Fix> fixes;
+            List<PiecewiseLinearConstraint::Fix>::iterator itFix;
+
+            relu.notifyVariableValue( b, -1 );
+            relu.notifyVariableValue( f, 1 );
+
+            fixes = relu.getPossibleFixes();
+            itFix = fixes.begin();
+            TS_ASSERT_EQUALS( itFix->_variable, b );
+            TS_ASSERT_EQUALS( itFix->_value, 1 );
+            ++itFix;
+            TS_ASSERT_EQUALS( itFix->_variable, f );
+            TS_ASSERT_EQUALS( itFix->_value, 0 );
+        }
+    }
 };
+
 
 //
 // Local Variables:


### PR DESCRIPTION
Add method to compute the polarity of a Relu and bias the fixing and case split order based on it.
Tested on 60 acas benchmarks and 40 MNIST benchmarks. 
Solved 11 more SAT and 3 more UNSAT with a 20 minutes timeout compared to the current master.
