### PR TITLE
Add Constraint Violation Threshold as an command line option

### DIFF
--- a/src/configuration/OptionParser.cpp
+++ b/src/configuration/OptionParser.cpp
@@ -78,7 +78,7 @@ void OptionParser::initialize()
           "out statistics in the beginning and end, 2: print out statistics during solving." )
         ( "split-threshold",
           boost::program_options::value<int>( &((*_intOptions)[Options::SPLIT_THRESHOLD]) ),
-          "Threshold to split" )
+          "Max number of tries to repair a relu before splitting" )
         ( "timeout-factor",
           boost::program_options::value<float>( &((*_floatOptions)[Options::TIMEOUT_FACTOR]) ),
           "(DNC) The timeout factor" )

--- a/src/configuration/OptionParser.cpp
+++ b/src/configuration/OptionParser.cpp
@@ -76,6 +76,9 @@ void OptionParser::initialize()
           boost::program_options::value<int>( &((*_intOptions)[Options::VERBOSITY]) ),
           "Verbosity of engine::solve(). 0: does not print anything (for DnC), 1: print"
           "out statistics in the beginning and end, 2: print out statistics during solving." )
+        ( "split-threshold",
+          boost::program_options::value<int>( &((*_intOptions)[Options::SPLIT_THRESHOLD]) ),
+          "Threshold to split" )
         ( "timeout-factor",
           boost::program_options::value<float>( &((*_floatOptions)[Options::TIMEOUT_FACTOR]) ),
           "(DNC) The timeout factor" )

--- a/src/configuration/Options.cpp
+++ b/src/configuration/Options.cpp
@@ -53,6 +53,7 @@ void Options::initializeDefaultValues()
     _intOptions[INITIAL_TIMEOUT] = 5;
     _intOptions[VERBOSITY] = 2;
     _intOptions[TIMEOUT] = 0;
+    _boolOptions[SPLIT_THRESHOLD] = 20;
 
     /*
       Float options

--- a/src/configuration/Options.cpp
+++ b/src/configuration/Options.cpp
@@ -53,7 +53,7 @@ void Options::initializeDefaultValues()
     _intOptions[INITIAL_TIMEOUT] = 5;
     _intOptions[VERBOSITY] = 2;
     _intOptions[TIMEOUT] = 0;
-    _boolOptions[SPLIT_THRESHOLD] = 20;
+    _intOptions[SPLIT_THRESHOLD] = 20;
 
     /*
       Float options

--- a/src/configuration/Options.h
+++ b/src/configuration/Options.h
@@ -53,6 +53,8 @@ public:
 
         // Global timeout
         TIMEOUT,
+
+        SPLIT_THRESHOLD,
     };
 
     enum FloatOptions{

--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -18,6 +18,7 @@
 #include "DnCManager.h"
 #include "DnCWorker.h"
 #include "GetCPUData.h"
+#include "GlobalConfiguration.h"
 #include "LargestIntervalDivider.h"
 #include "MStringf.h"
 #include "MarabouError.h"
@@ -65,6 +66,7 @@ DnCManager::DnCManager( unsigned numWorkers, unsigned initialDivides,
     , _timeoutReached( false )
     , _numUnsolvedSubQueries( 0 )
     , _verbosity( verbosity )
+    , _constraintViolationThreshold( GlobalConfiguration::CONSTRAINT_VIOLATION_THRESHOLD )
 {
 }
 
@@ -325,6 +327,7 @@ bool DnCManager::createEngines()
         InputQuery *inputQuery = new InputQuery();
         *inputQuery = *baseInputQuery;
         engine->processInputQuery( *inputQuery );
+        engine->setConstraintViolationThreshold( _constraintViolationThreshold );
         _engines.append( engine );
     }
 
@@ -391,6 +394,11 @@ void DnCManager::log( const String &message )
 {
     if ( GlobalConfiguration::DNC_MANAGER_LOGGING )
         printf( "DnCManager: %s\n", message.ascii() );
+}
+
+void DnCManager::setConstraintViolationThreshold( unsigned threshold )
+{
+    _constraintViolationThreshold = threshold;
 }
 
 //

--- a/src/engine/DnCManager.h
+++ b/src/engine/DnCManager.h
@@ -73,6 +73,8 @@ public:
     */
     void getSolution( std::map<int, double> &ret );
 
+    void setConstraintViolationThreshold( unsigned threshold );
+
 private:
     /*
       Create and run a DnCWorker
@@ -188,6 +190,12 @@ private:
       The level of verbosity
     */
     unsigned _verbosity;
+
+    /*
+      The constraint violation threshold for each worker engine
+    */
+    unsigned _constraintViolationThreshold;
+
 };
 
 #endif // __DnCManager_h__

--- a/src/engine/DnCMarabou.cpp
+++ b/src/engine/DnCMarabou.cpp
@@ -98,11 +98,22 @@ void DnCMarabou::run()
     unsigned timeoutInSeconds = Options::get()->getInt( Options::TIMEOUT );
     float timeoutFactor = Options::get()->getFloat( Options::TIMEOUT_FACTOR );
 
+    int splitThreshold = Options::get()->getInt( Options::SPLIT_THRESHOLD );
+    if ( splitThreshold < 0 )
+    {
+        printf( "Invalid constraint violation threshold value %d,"
+                " using default value %u.\n\n", splitThreshold,
+                GlobalConfiguration::CONSTRAINT_VIOLATION_THRESHOLD );
+        splitThreshold = GlobalConfiguration::CONSTRAINT_VIOLATION_THRESHOLD;
+    }
+
     _dncManager = std::unique_ptr<DnCManager>
       ( new DnCManager( numWorkers, initialDivides, initialTimeout,
                         onlineDivides, timeoutFactor,
                         DivideStrategy::LargestInterval, &_inputQuery,
                         verbosity ) );
+    _dncManager->setConstraintViolationThreshold( splitThreshold );
+
     struct timespec start = TimeUtils::sampleMicro();
 
     _dncManager->solve( timeoutInSeconds );

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -1925,11 +1925,6 @@ void Engine::checkOverallProgress()
     }
 }
 
-void Engine::setConstraintViolationThreshold( unsigned threshold )
-{
-    _smtCore.setConstraintViolationThreshold( threshold );
-}
-
 void Engine::updateDirections()
 {
     if ( GlobalConfiguration::USE_POLARITY_BASED_DIRECTION_HEURISTICS )
@@ -1937,6 +1932,11 @@ void Engine::updateDirections()
             if ( constraint->supportPolarity() &&
                  constraint->isActive() && !constraint->phaseFixed() )
                 constraint->updateDirection();
+}
+
+void Engine::setConstraintViolationThreshold( unsigned threshold )
+{
+    _smtCore.setConstraintViolationThreshold( threshold );
 }
 
 //

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -1924,6 +1924,12 @@ void Engine::checkOverallProgress()
     }
 }
 
+void Engine::setConstraintViolationThreshold( unsigned threshold )
+{
+    _smtCore.setConstraintViolationThreshold( threshold );
+}
+
+//
 //
 // Local Variables:
 // compile-command: "make -C ../.. "

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -128,6 +128,11 @@ public:
     void setVerbosity( unsigned verbosity );
 
     /*
+      Set the constraint violation threshold of SmtCore
+     */
+    void setConstraintViolationThreshold( unsigned threshold );
+
+    /*
       PSA: The following two methods are for DnC only and should be used very
       cautiously.
      */

--- a/src/engine/Marabou.cpp
+++ b/src/engine/Marabou.cpp
@@ -102,6 +102,12 @@ void Marabou::prepareInputQuery()
             printf( "Property: None\n" );
 
         printf( "\n" );
+
+        /*
+          Step 3: extract options
+        */
+        unsigned splitThreshold = Options::get()->getInt( Options::SPLIT_THRESHOLD );
+        _engine.setConstraintViolationThreshold( splitThreshold );
     }
 }
 

--- a/src/engine/Marabou.cpp
+++ b/src/engine/Marabou.cpp
@@ -15,6 +15,7 @@
  **/
 
 #include "AcasParser.h"
+#include "GlobalConfiguration.h"
 #include "File.h"
 #include "MStringf.h"
 #include "Marabou.h"
@@ -106,7 +107,14 @@ void Marabou::prepareInputQuery()
         /*
           Step 3: extract options
         */
-        unsigned splitThreshold = Options::get()->getInt( Options::SPLIT_THRESHOLD );
+        int splitThreshold = Options::get()->getInt( Options::SPLIT_THRESHOLD );
+        if ( splitThreshold < 0 )
+        {
+            printf( "Invalid constraint violation threshold value %d,"
+                    " using default value %u.\n\n", splitThreshold,
+                    GlobalConfiguration::CONSTRAINT_VIOLATION_THRESHOLD );
+            splitThreshold = GlobalConfiguration::CONSTRAINT_VIOLATION_THRESHOLD;
+        }
         _engine.setConstraintViolationThreshold( splitThreshold );
     }
 }

--- a/src/engine/SmtCore.cpp
+++ b/src/engine/SmtCore.cpp
@@ -28,6 +28,8 @@ SmtCore::SmtCore( IEngine *engine )
     , _needToSplit( false )
     , _constraintForSplitting( NULL )
     , _stateId( 0 )
+    , _constraintViolationThreshold
+      ( GlobalConfiguration::CONSTRAINT_VIOLATION_THRESHOLD )
 {
 }
 
@@ -54,7 +56,8 @@ void SmtCore::reportViolatedConstraint( PiecewiseLinearConstraint *constraint )
 
     ++_constraintToViolationCount[constraint];
 
-    if ( _constraintToViolationCount[constraint] >= GlobalConfiguration::CONSTRAINT_VIOLATION_THRESHOLD )
+    if ( _constraintToViolationCount[constraint] >=
+         _constraintViolationThreshold )
     {
         _needToSplit = true;
         _constraintForSplitting = constraint;
@@ -354,6 +357,11 @@ bool SmtCore::splitAllowsStoredSolution( const PiecewiseLinearCaseSplit &split, 
     }
 
     return true;
+}
+
+void SmtCore::setConstraintViolationThreshold( unsigned threshold )
+{
+    _constraintViolationThreshold = threshold;
 }
 
 PiecewiseLinearConstraint *SmtCore::chooseViolatedConstraintForFixing( List<PiecewiseLinearConstraint *> &_violatedPlConstraints ) const

--- a/src/engine/SmtCore.h
+++ b/src/engine/SmtCore.h
@@ -96,6 +96,8 @@ public:
     */
     PiecewiseLinearConstraint *chooseViolatedConstraintForFixing( List<PiecewiseLinearConstraint *> &_violatedPlConstraints ) const;
 
+    void setConstraintViolationThreshold( unsigned threshold );
+
     /*
       For debugging purposes only - store a correct possible solution
     */
@@ -161,6 +163,11 @@ private:
       debugging purposes.
     */
     unsigned _stateId;
+
+    /*
+      Split when some relu has been violated for this many times
+    */
+    unsigned _constraintViolationThreshold;
 };
 
 #endif // __SmtCore_h__


### PR DESCRIPTION
Give users the ability to change the constraint violation threshold.
Usage:
`./Marabou [network] [property] --split-threshold=1`
On ACAS benchmarks (property 1-4) with a 30 minutes timeout, 
split-threshold=1 solves 9 more SAT and 5 more UNSAT than split-threshold=20.
