### PR TITLE
Replay treestates in DnC

### DIFF
--- a/src/configuration/OptionParser.cpp
+++ b/src/configuration/OptionParser.cpp
@@ -45,6 +45,9 @@ void OptionParser::initialize()
         ( "dnc",
           boost::program_options::bool_switch( &((*_boolOptions)[Options::DNC_MODE]) ),
           "Use the divide-and-conquer solving mode" )
+        ( "restore-tree-states",
+          boost::program_options::bool_switch( &((*_boolOptions)[Options::RESTORE_TREE_STATES]) ),
+          "Restore tree states in dnc mode" )
         ( "input",
           boost::program_options::value<std::string>( &((*_stringOptions)[Options::INPUT_FILE_PATH]) ),
           "Neural netowrk file" )

--- a/src/configuration/Options.cpp
+++ b/src/configuration/Options.cpp
@@ -43,6 +43,7 @@ void Options::initializeDefaultValues()
     */
     _boolOptions[DNC_MODE] = false;
     _boolOptions[PREPROCESSOR_PL_CONSTRAINTS_ADD_AUX_EQUATIONS] = false;
+    _boolOptions[RESTORE_TREE_STATES] = false;
 
     /*
       Int options

--- a/src/configuration/Options.h
+++ b/src/configuration/Options.h
@@ -34,6 +34,9 @@ public:
         // Should DNC mode be on or off
         DNC_MODE,
 
+        // Restore tree states of the parent when handling children in DnC.
+        RESTORE_TREE_STATES,
+
         // Help flag
         HELP,
 

--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -34,7 +34,8 @@ void DnCManager::dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine
                            std::atomic_uint &numUnsolvedSubQueries,
                            std::atomic_bool &shouldQuitSolving,
                            unsigned threadId, unsigned onlineDivides,
-                           float timeoutFactor, DivideStrategy divideStrategy )
+                           float timeoutFactor, DivideStrategy divideStrategy,
+                           bool restoreTreeStates )
 {
     unsigned cpuId = 0;
     getCPUId( cpuId );
@@ -45,7 +46,7 @@ void DnCManager::dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine
                       timeoutFactor, divideStrategy );
     while ( !shouldQuitSolving.load() )
     {
-        worker.popOneSubQueryAndSolve();
+        worker.popOneSubQueryAndSolve( restoreTreeStates );
     }
 }
 
@@ -89,7 +90,7 @@ void DnCManager::freeMemoryIfNeeded()
     }
 }
 
-void DnCManager::solve( unsigned timeoutInSeconds )
+void DnCManager::solve( unsigned timeoutInSeconds, bool restoreTreeStates )
 {
     enum {
         MICROSECONDS_IN_SECOND = 1000000
@@ -141,7 +142,8 @@ void DnCManager::solve( unsigned timeoutInSeconds )
                                         std::ref( _numUnsolvedSubQueries ),
                                         std::ref( shouldQuitSolving ),
                                         threadId, _onlineDivides,
-                                        _timeoutFactor, _divideStrategy ) );
+                                        _timeoutFactor, _divideStrategy,
+                                        restoreTreeStates ) );
     }
 
     // Wait until either all subQueries are solved or a satisfying assignment is

--- a/src/engine/DnCManager.h
+++ b/src/engine/DnCManager.h
@@ -51,7 +51,7 @@ public:
     /*
       Perform the Divide-and-conquer solving
     */
-    void solve( unsigned timeoutInSeconds );
+    void solve( unsigned timeoutInSeconds, bool restoreTreeStates=true );
 
     /*
       Return the DnCExitCode of the DnCManager
@@ -81,7 +81,8 @@ private:
                           std::atomic_uint &numUnsolvedSubQueries,
                           std::atomic_bool &shouldQuitSolving,
                           unsigned threadId, unsigned onlineDivides,
-                          float timeoutFactor, DivideStrategy divideStrategy );
+                          float timeoutFactor, DivideStrategy divideStrategy,
+                          bool restoreTreeStates );
 
     /*
       Create the base engine from the network and property files,

--- a/src/engine/DnCMarabou.cpp
+++ b/src/engine/DnCMarabou.cpp
@@ -97,6 +97,7 @@ void DnCMarabou::run()
     unsigned verbosity = Options::get()->getInt( Options::VERBOSITY );
     unsigned timeoutInSeconds = Options::get()->getInt( Options::TIMEOUT );
     float timeoutFactor = Options::get()->getFloat( Options::TIMEOUT_FACTOR );
+    bool restoreTreeStates = Options::get()->getBool( Options::RESTORE_TREE_STATES );
 
     _dncManager = std::unique_ptr<DnCManager>
       ( new DnCManager( numWorkers, initialDivides, initialTimeout,
@@ -105,7 +106,7 @@ void DnCMarabou::run()
                         verbosity ) );
     struct timespec start = TimeUtils::sampleMicro();
 
-    _dncManager->solve( timeoutInSeconds );
+    _dncManager->solve( timeoutInSeconds, restoreTreeStates );
 
     struct timespec end = TimeUtils::sampleMicro();
 

--- a/src/engine/DnCWorker.cpp
+++ b/src/engine/DnCWorker.cpp
@@ -140,7 +140,7 @@ void DnCWorker::popOneSubQueryAndSolve( bool restoreTreeStates )
                 // Store the SmtCore state
                 if ( restoreTreeStates )
                 {
-                    newSubQuery->_smtState = std::move( newSmtStates[i] );
+                    newSubQuery->_smtState = std::move( newSmtStates[i++] );
                 }
 
                 if ( !_workload->push( std::move( newSubQuery ) ) )

--- a/src/engine/DnCWorker.cpp
+++ b/src/engine/DnCWorker.cpp
@@ -61,8 +61,9 @@ void DnCWorker::setQueryDivider( DivideStrategy divideStrategy )
     }
 }
 
-void DnCWorker::popOneSubQueryAndSolve()
+void DnCWorker::popOneSubQueryAndSolve( bool restoreTreeStates )
 {
+    std::cout << restoreTreeStates << std::endl;
     SubQuery *subQuery = NULL;
     // Boost queue stores the next element into the passed-in pointer
     // and returns true if the pop is successful (aka, the queue is not empty

--- a/src/engine/DnCWorker.cpp
+++ b/src/engine/DnCWorker.cpp
@@ -89,10 +89,7 @@ void DnCWorker::popOneSubQueryAndSolve( bool restoreTreeStates )
 
         bool fullSolveNeeded = true; // denotes whether we need to solve the subquery
         if ( restoreTreeStates && smtState )
-        {
-            std::cout << "Restoring tree states" << std::endl;
             fullSolveNeeded = _engine->restoreSmtState( *smtState );
-        }
         IEngine::ExitCode result = IEngine::NOT_DONE;
         if ( fullSolveNeeded )
         {

--- a/src/engine/DnCWorker.h
+++ b/src/engine/DnCWorker.h
@@ -36,7 +36,7 @@ public:
       Pop one subQuery, solve it and handle the result
       Return true if the DnCWorker should continue running
     */
-    void popOneSubQueryAndSolve();
+    void popOneSubQueryAndSolve( bool restoreTreeStates=true );
 
 private:
     /*

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -1934,6 +1934,64 @@ void Engine::updateDirections()
                 constraint->updateDirection();
 }
 
+bool Engine::restoreSmtState( SmtState & smtState )
+{
+    try
+    {
+        // Step 1: all implied valid splits at root
+        for ( auto &validSplit : smtState._impliedValidSplitsAtRoot )
+        {
+            applySplit( validSplit );
+            _smtCore.recordImpliedValidSplit( validSplit );
+        }
+
+        tightenBoundsOnConstraintMatrix();
+        applyAllBoundTightenings();
+        // For debugging purposes
+        checkBoundCompliancyWithDebugSolution();
+        do
+            performSymbolicBoundTightening();
+        while ( applyAllValidConstraintCaseSplits() );
+
+        // Step 2: replay the stack
+        for ( auto &stackEntry : smtState._stack )
+        {
+            _smtCore.replayStackEntry( stackEntry );
+            // Do all the bound propagation, and set ReLU constraints to inactive (at
+            // least the one corresponding to the _activeSplit applied above.
+            tightenBoundsOnConstraintMatrix();
+            applyAllBoundTightenings();
+            // For debugging purposes
+            checkBoundCompliancyWithDebugSolution();
+            do
+                performSymbolicBoundTightening();
+            while ( applyAllValidConstraintCaseSplits() );
+
+        }
+    }
+    catch ( const InfeasibleQueryException & )
+    {
+        // The current query is unsat, and we need to pop.
+        // If we're at level 0, the whole query is unsat.
+        if ( !_smtCore.popSplit() )
+        {
+            if ( _verbosity > 0 )
+            {
+                printf( "\nEngine::solve: UNSAT query\n" );
+                _statistics.print();
+            }
+            _exitCode = Engine::UNSAT;
+            return false;
+        }
+    }
+    return true;
+}
+
+void Engine::storeSmtState( SmtState & smtState )
+{
+    _smtCore.storeSmtState( smtState );
+}
+
 //
 // Local Variables:
 // compile-command: "make -C ../.. "

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -128,6 +128,17 @@ public:
     void setVerbosity( unsigned verbosity );
 
     /*
+      Apply the stack to the newly created SmtCore, returns false if UNSAT is
+      found in this process.
+    */
+    bool restoreSmtState( SmtState &smtState );
+
+    /*
+      Store the current stack of the smtCore into smtState
+    */
+    void storeSmtState( SmtState &smtState );
+
+    /*
       PSA: The following two methods are for DnC only and should be used very
       cautiously.
      */

--- a/src/engine/IEngine.h
+++ b/src/engine/IEngine.h
@@ -25,6 +25,7 @@
 class EngineState;
 class Equation;
 class PiecewiseLinearCaseSplit;
+class SmtState;
 
 class IEngine
 {
@@ -52,6 +53,18 @@ public:
     virtual void storeState( EngineState &state, bool storeAlsoTableauState ) const = 0;
     virtual void restoreState( const EngineState &state ) = 0;
     virtual void setNumPlConstraintsDisabledByValidSplits( unsigned numConstraints ) = 0;
+
+    /*
+      Apply the stack to the newly created SmtCore, returns false if UNSAT is
+      found in this process.
+    */
+
+    virtual void storeSmtState( SmtState &smtState ) = 0;
+
+    /*
+      Store the current stack of the smtCore into smtState
+    */
+    virtual bool restoreSmtState( SmtState &smtState ) = 0;
 
     /*
       Solve the encoded query.

--- a/src/engine/SmtCore.cpp
+++ b/src/engine/SmtCore.cpp
@@ -389,6 +389,58 @@ PiecewiseLinearConstraint *SmtCore::chooseViolatedConstraintForFixing( List<Piec
     return candidate;
 }
 
+void SmtCore::replayStackEntry( StackEntry * stackEntry )
+{
+    struct timespec start = TimeUtils::sampleMicro();
+
+    if ( _statistics )
+    {
+        _statistics->incNumSplits();
+        _statistics->incNumVisitedTreeStates();
+    }
+
+    // Obtain the current state of the engine
+    EngineState *stateBeforeSplits = new EngineState;
+    stateBeforeSplits->_stateId = _stateId;
+    ++_stateId;
+    _engine->storeState( *stateBeforeSplits, true );
+    stackEntry->_engineState = stateBeforeSplits;
+
+    // Apply all the splits
+    _engine->applySplit( stackEntry->_activeSplit );
+    for ( const auto &impliedSplit : stackEntry->_impliedValidSplits )
+        _engine->applySplit( impliedSplit );
+
+    _stack.append( stackEntry );
+
+    if ( _statistics )
+    {
+        _statistics->setCurrentStackDepth( getStackDepth() );
+        struct timespec end = TimeUtils::sampleMicro();
+        _statistics->addTimeSmtCore( TimeUtils::timePassed( start, end ) );
+    }
+}
+
+void SmtCore::storeSmtState(SmtState & smtState)
+{
+    smtState._impliedValidSplitsAtRoot = _impliedValidSplitsAtRoot;
+
+    for ( auto &stackEntry : _stack )
+        smtState._stack.append( duplicateStackEntry( *stackEntry ) );
+}
+
+StackEntry * SmtCore::duplicateStackEntry(const StackEntry & stackEntry)
+{
+    StackEntry *copy = new StackEntry();
+
+    copy->_activeSplit = stackEntry._activeSplit;
+    copy->_impliedValidSplits = stackEntry._impliedValidSplits;
+    copy->_alternativeSplits = stackEntry._alternativeSplits;
+    copy->_engineState = NULL;
+
+    return copy;
+}
+
 //
 // Local Variables:
 // compile-command: "make -C ../.. "

--- a/src/engine/SmtCore.h
+++ b/src/engine/SmtCore.h
@@ -18,7 +18,9 @@
 
 #include "PiecewiseLinearCaseSplit.h"
 #include "PiecewiseLinearConstraint.h"
+#include "SmtState.h"
 #include "Stack.h"
+#include "StackEntry.h"
 #include "Statistics.h"
 
 class EngineState;
@@ -97,6 +99,16 @@ public:
     PiecewiseLinearConstraint *chooseViolatedConstraintForFixing( List<PiecewiseLinearConstraint *> &_violatedPlConstraints ) const;
 
     /*
+      Replay a stackEntry
+    */
+    void replayStackEntry( StackEntry *stackEntry );
+
+    /*
+      Store the current stack into smtState
+    */
+    void storeSmtState( SmtState &smtState );
+
+    /*
       For debugging purposes only - store a correct possible solution
     */
     void storeDebuggingSolution( const Map<unsigned, double> &debuggingSolution );
@@ -105,18 +117,9 @@ public:
 
 private:
     /*
-      A stack entry consists of the engine state before the split,
-      the active split, the alternative splits (in case of backtrack),
-      and also any implied splits that were discovered subsequently.
+      duplicate the StackEntry
     */
-    struct StackEntry
-    {
-    public:
-        PiecewiseLinearCaseSplit _activeSplit;
-        List<PiecewiseLinearCaseSplit> _impliedValidSplits;
-        List<PiecewiseLinearCaseSplit> _alternativeSplits;
-        EngineState *_engineState;
-    };
+    StackEntry *duplicateStackEntry( const StackEntry &stackEntry );
 
     /*
       Valid splits that were implied by level 0 of the stack.

--- a/src/engine/SmtState.h
+++ b/src/engine/SmtState.h
@@ -1,0 +1,46 @@
+/*********************                                                        */
+/*! \file SmtState.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Guy Katz, Duligur Ibeling
+ ** This file is part of the Marabou project.
+ ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved. See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** [[ Add lengthier description here ]]
+
+ **/
+
+#ifndef __SmtState_h__
+#define __SmtState_h__
+
+#include "List.h"
+#include "Map.h"
+#include "PiecewiseLinearConstraint.h"
+#include "StackEntry.h"
+
+class SmtState
+{
+public:
+    /*
+      Valid splits that were implied by level 0 of the stack.
+    */
+    List<PiecewiseLinearCaseSplit> _impliedValidSplitsAtRoot;
+
+    /*
+      The stack.
+    */
+    List< StackEntry *> _stack;
+};
+
+#endif // __SmtState_h__
+
+//
+// Local Variables:
+// compile-command: "make -C ../.. "
+// tags-file-name: "../../TAGS"
+// c-basic-offset: 4
+// End:
+//

--- a/src/engine/StackEntry.h
+++ b/src/engine/StackEntry.h
@@ -1,0 +1,45 @@
+/*********************                                                        */
+/*! \file StackEntry.h
+** \verbatim
+** Top contributors (to current version):
+**   Guy Katz, Haoze Wu
+** This file is part of the Marabou project.
+** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved. See the file COPYING in the top-level source
+** directory for licensing information.\endverbatim
+**
+** [[ Add lengthier description here ]]
+
+**/
+
+#ifndef __StackEntry_h__
+#define __StackEntry_h__
+
+#include "EngineState.h"
+#include "PiecewiseLinearCaseSplit.h"
+
+/*
+  A stack entry consists of the engine state before the split,
+  the active split, the alternative splits (in case of backtrack),
+  and also any implied splits that were discovered subsequently.
+*/
+struct StackEntry
+{
+public:
+    PiecewiseLinearCaseSplit _activeSplit;
+    List<PiecewiseLinearCaseSplit> _impliedValidSplits;
+    List<PiecewiseLinearCaseSplit> _alternativeSplits;
+    EngineState *_engineState;
+
+};
+
+#endif // __StackEntry_h__
+
+//
+// Local Variables:
+// compile-command: "make -C ../.. "
+// tags-file-name: "../../TAGS"
+// c-basic-offset: 4
+// End:
+//

--- a/src/engine/SubQuery.h
+++ b/src/engine/SubQuery.h
@@ -19,6 +19,7 @@
 #include "List.h"
 #include "MString.h"
 #include "PiecewiseLinearCaseSplit.h"
+#include "SmtState.h"
 
 #include <boost/lockfree/queue.hpp>
 #include <utility>
@@ -30,15 +31,18 @@ struct SubQuery
     {
     }
 
-    SubQuery( const String &queryId, std::unique_ptr<PiecewiseLinearCaseSplit> &split, unsigned timeoutInSeconds )
+    SubQuery( const String &queryId, std::unique_ptr<PiecewiseLinearCaseSplit>
+              &split, unsigned timeoutInSeconds )
         : _queryId( queryId )
         , _split( std::move( split ) )
+        , _smtState ( nullptr )
         , _timeoutInSeconds( timeoutInSeconds )
     {
     }
 
     String _queryId;
     std::unique_ptr<PiecewiseLinearCaseSplit> _split;
+    std::unique_ptr<SmtState> _smtState;
     unsigned _timeoutInSeconds;
 };
 

--- a/src/engine/tests/MockEngine.h
+++ b/src/engine/tests/MockEngine.h
@@ -19,6 +19,7 @@
 #include "IEngine.h"
 #include "List.h"
 #include "PiecewiseLinearCaseSplit.h"
+#include "PiecewiseLinearConstraint.h"
 
 class MockEngine : public IEngine
 {
@@ -30,7 +31,7 @@ public:
 
         lastStoredState = NULL;
     }
-
+    
     ~MockEngine()
     {
     }
@@ -141,6 +142,19 @@ public:
     List<unsigned> getInputVariables() const
     {
         return _inputVariables;
+    }
+
+    mutable SmtState *lastRestoredSmtState;
+    bool restoreSmtState( SmtState &smtState )
+    {
+        lastRestoredSmtState = &smtState;
+        return true;
+    }
+
+    mutable SmtState *lastStoredSmtState;
+    void storeSmtState( SmtState &smtState )
+    {
+        lastStoredSmtState = &smtState;
     }
 };
 


### PR DESCRIPTION
Add option "--restore-tree-states". When turned on, in the DnC mode, the sub-queries will inherit it's (timed out) parent's tree state instead of starting from scratch.

Compared with no restore tree states on 180 ACAS benchmarks with a 30 minutes timeout:
solve 2 more SAT and 1 more UNSAT. ~20% wall time reduction on commonly solved instances.