### PR TITLE
Improved Relu splits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ if (NOT MSVC)
     set(DEBUG_FLAGS ${COMPILE_FLAGS} ${MEMORY_FLAGS} -g)
     set(CXXTEST_FLAGS ${DEBUG_FLAGS}  -Wno-ignored-qualifiers)
 else()
-    set(DEBUG_FLAGS ${COMPILE_FLAGS} ${MEMORY_FLAGS}) 
+    set(DEBUG_FLAGS ${COMPILE_FLAGS} ${MEMORY_FLAGS})
     add_definitions(-DNOMINMAX) # remove min max macros
 endif()
 

--- a/src/engine/ReluConstraint.cpp
+++ b/src/engine/ReluConstraint.cpp
@@ -491,7 +491,7 @@ PiecewiseLinearCaseSplit ReluConstraint::getActiveSplit() const
     if ( _auxVarInUse )
     {
         // Special case: aux var in use.
-        // Because aux = f - b, we just set aux = 0.
+        // Because aux = f - b and aux >= 0, we just add that aux <= 0.
         activePhase.storeBoundTightening( Tightening( _aux, 0.0, Tightening::UB ) );
     }
     else

--- a/src/engine/ReluConstraint.cpp
+++ b/src/engine/ReluConstraint.cpp
@@ -487,11 +487,22 @@ PiecewiseLinearCaseSplit ReluConstraint::getActiveSplit() const
     // Active phase: b >= 0, b - f = 0
     PiecewiseLinearCaseSplit activePhase;
     activePhase.storeBoundTightening( Tightening( _b, 0.0, Tightening::LB ) );
-    Equation activeEquation( Equation::EQ );
-    activeEquation.addAddend( 1, _b );
-    activeEquation.addAddend( -1, _f );
-    activeEquation.setScalar( 0 );
-    activePhase.addEquation( activeEquation );
+
+    if ( _auxVarInUse )
+    {
+        // Special case: aux var in use.
+        // Because aux = f - b, we just set aux = 0.
+        activePhase.storeBoundTightening( Tightening( _aux, 0.0, Tightening::UB ) );
+    }
+    else
+    {
+        Equation activeEquation( Equation::EQ );
+        activeEquation.addAddend( 1, _b );
+        activeEquation.addAddend( -1, _f );
+        activeEquation.setScalar( 0 );
+        activePhase.addEquation( activeEquation );
+    }
+
     return activePhase;
 }
 

--- a/src/engine/tests/Test_ReluConstraint.h
+++ b/src/engine/tests/Test_ReluConstraint.h
@@ -264,6 +264,73 @@ public:
         return true;
     }
 
+    void test_relu_case_splits_with_aux_var()
+    {
+        unsigned b = 1;
+        unsigned f = 4;
+
+        ReluConstraint relu( b, f );
+
+        relu.notifyLowerBound( b, -10 );
+        relu.notifyUpperBound( b, 5 );
+        relu.notifyUpperBound( f, 5 );
+
+        unsigned auxVar = 10;
+        InputQuery inputQuery;
+        inputQuery.setNumberOfVariables( auxVar );
+
+        relu.addAuxiliaryEquations( inputQuery );
+
+        TS_ASSERT( relu.auxVariableInUse() );
+        TS_ASSERT_EQUALS( relu.getAux(), auxVar );
+
+        List<PiecewiseLinearConstraint::Fix> fixes;
+        List<PiecewiseLinearConstraint::Fix>::iterator it;
+
+        List<PiecewiseLinearCaseSplit> splits = relu.getCaseSplits();
+
+        Equation activeEquation, inactiveEquation;
+
+        TS_ASSERT_EQUALS( splits.size(), 2U );
+
+        List<PiecewiseLinearCaseSplit>::iterator split1 = splits.begin();
+        List<PiecewiseLinearCaseSplit>::iterator split2 = split1;
+        ++split2;
+
+        TS_ASSERT( isActiveSplitWithAux( b, auxVar, split1 ) || isActiveSplitWithAux( b, auxVar, split2 ) );
+        TS_ASSERT( isInactiveSplit( b, f, split1 ) || isInactiveSplit( b, f, split2 ) );
+    }
+
+    bool isActiveSplitWithAux( unsigned b, unsigned aux, List<PiecewiseLinearCaseSplit>::iterator &split )
+    {
+        List<Tightening> bounds = split->getBoundTightenings();
+
+        TS_ASSERT_EQUALS( bounds.size(), 2U );
+
+        auto bound = bounds.begin();
+        Tightening bound1 = *bound;
+
+        TS_ASSERT_EQUALS( bound1._variable, b );
+        TS_ASSERT_EQUALS( bound1._value, 0.0 );
+
+        if ( bound1._type != Tightening::LB )
+            return false;
+
+        ++bound;
+
+        Tightening bound2 = *bound;
+
+        TS_ASSERT_EQUALS( bound2._variable, aux );
+        TS_ASSERT_EQUALS( bound2._value, 0.0 );
+
+        if ( bound2._type != Tightening::UB )
+            return false;
+
+        TS_ASSERT( split->getEquations().empty() );
+
+        return true;
+    }
+
     void test_register_as_watcher()
     {
         unsigned b = 1;


### PR DESCRIPTION
In a ReLU's active split, if we already have an auxiliary variable aux = f - b, we don't add a new equation; instead, we make aux strictly 0.