### PR TITLE
Preprocess the input query only once in DnC

### DIFF
--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -32,7 +32,7 @@
 #include <thread>
 
 void DnCManager::dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine,
-                           InputQuery *inputQuery,
+                           InputQuery &inputQuery,
                            std::atomic_uint &numUnsolvedSubQueries,
                            std::atomic_bool &shouldQuitSolving,
                            unsigned threadId, unsigned onlineDivides,
@@ -42,7 +42,7 @@ void DnCManager::dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine
     getCPUId( cpuId );
     log( Stringf( "Thread #%u on CPU %u", threadId, cpuId ) );
 
-    engine->processInputQuery( *inputQuery, false );
+    engine->processInputQuery( inputQuery, false );
 
     DnCWorker worker( workload, engine, std::ref( numUnsolvedSubQueries ),
                       std::ref( shouldQuitSolving ), threadId, onlineDivides,
@@ -141,11 +141,10 @@ void DnCManager::solve( unsigned timeoutInSeconds )
     std::list<std::thread> threads;
     for ( unsigned threadId = 0; threadId < _numWorkers; ++threadId )
     {
-        InputQuery *inputQuery = new InputQuery();
         // Get the processed input query from the base engine
-        *inputQuery = *( _baseEngine->getInputQuery() );
+        InputQuery inputQuery = *( _baseEngine->getInputQuery() );
         threads.push_back( std::thread( dncSolve, workload, _engines[ threadId ],
-                                        inputQuery,
+                                        std::ref( inputQuery ),
                                         std::ref( _numUnsolvedSubQueries ),
                                         std::ref( shouldQuitSolving ),
                                         threadId, _onlineDivides,

--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -30,9 +30,6 @@
 #include <chrono>
 #include <cmath>
 #include <thread>
-#include <fstream>
-
-#include "util/util.hh"
 
 void DnCManager::dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine,
                            InputQuery *inputQuery,

--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -32,7 +32,7 @@
 #include <thread>
 
 void DnCManager::dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine,
-                           InputQuery &inputQuery,
+                           std::unique_ptr<InputQuery> inputQuery,
                            std::atomic_uint &numUnsolvedSubQueries,
                            std::atomic_bool &shouldQuitSolving,
                            unsigned threadId, unsigned onlineDivides,
@@ -42,7 +42,7 @@ void DnCManager::dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine
     getCPUId( cpuId );
     log( Stringf( "Thread #%u on CPU %u", threadId, cpuId ) );
 
-    engine->processInputQuery( inputQuery, false );
+    engine->processInputQuery( *inputQuery, false );
 
     DnCWorker worker( workload, engine, std::ref( numUnsolvedSubQueries ),
                       std::ref( shouldQuitSolving ), threadId, onlineDivides,
@@ -142,9 +142,10 @@ void DnCManager::solve( unsigned timeoutInSeconds )
     for ( unsigned threadId = 0; threadId < _numWorkers; ++threadId )
     {
         // Get the processed input query from the base engine
-        InputQuery inputQuery = *( _baseEngine->getInputQuery() );
+        auto inputQuery = std::unique_ptr<InputQuery>
+            ( new InputQuery( *( _baseEngine->getInputQuery() ) ) );
         threads.push_back( std::thread( dncSolve, workload, _engines[ threadId ],
-                                        std::ref( inputQuery ),
+                                        std::move( inputQuery ),
                                         std::ref( _numUnsolvedSubQueries ),
                                         std::ref( shouldQuitSolving ),
                                         threadId, _onlineDivides,

--- a/src/engine/DnCManager.h
+++ b/src/engine/DnCManager.h
@@ -80,7 +80,7 @@ private:
       Create and run a DnCWorker
     */
     static void dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine,
-                          InputQuery &inputQuery,
+                          std::unique_ptr<InputQuery> inputQuery,
                           std::atomic_uint &numUnsolvedSubQueries,
                           std::atomic_bool &shouldQuitSolving,
                           unsigned threadId, unsigned onlineDivides,

--- a/src/engine/DnCManager.h
+++ b/src/engine/DnCManager.h
@@ -80,6 +80,7 @@ private:
       Create and run a DnCWorker
     */
     static void dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine,
+                          InputQuery *inputQuery,
                           std::atomic_uint &numUnsolvedSubQueries,
                           std::atomic_bool &shouldQuitSolving,
                           unsigned threadId, unsigned onlineDivides,

--- a/src/engine/DnCManager.h
+++ b/src/engine/DnCManager.h
@@ -80,7 +80,7 @@ private:
       Create and run a DnCWorker
     */
     static void dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine,
-                          InputQuery *inputQuery,
+                          InputQuery &inputQuery,
                           std::atomic_uint &numUnsolvedSubQueries,
                           std::atomic_bool &shouldQuitSolving,
                           unsigned threadId, unsigned onlineDivides,


### PR DESCRIPTION
Currently in DnC, inputQuery is preprocessed multiple times. 
This PR preprocess the inputQuery once with the baseEngine in DnCManager, and the worker engines only copy over the preprocessed input query.