### PR TITLE
Fix bug related to DnC return value

### DIFF
--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -177,7 +177,7 @@ std::pair<std::map<int, double>, Statistics> solve(InputQuery &inputQuery, Marab
             {
                 retStats = Statistics();
                 retStats.timeout();
-                return std::make_pair( ret, Statistics() );
+                return std::make_pair( ret, retStats );
             }
             default:
                 return std::make_pair( ret, Statistics() ); // TODO: meaningful DnCStatistics


### PR DESCRIPTION
When DnC is used through the Python API and times out, a freshly constructed Statistics object is returned. This is problematic as retStats.hasTimedOut() needs to be True. This short PR fixes this bug.