### PR TITLE
move print statement in NLR construction to logger

### DIFF
--- a/src/configuration/GlobalConfiguration.cpp
+++ b/src/configuration/GlobalConfiguration.cpp
@@ -87,6 +87,7 @@ const bool GlobalConfiguration::TABLEAU_LOGGING = false;
 const bool GlobalConfiguration::SMT_CORE_LOGGING = false;
 const bool GlobalConfiguration::DANTZIGS_RULE_LOGGING = false;
 const bool GlobalConfiguration::BASIS_FACTORIZATION_LOGGING = false;
+const bool GlobalConfiguration::PREPROCESSOR_LOGGING = false;
 const bool GlobalConfiguration::PROJECTED_STEEPEST_EDGE_LOGGING = false;
 const bool GlobalConfiguration::GAUSSIAN_ELIMINATION_LOGGING = false;
 const bool GlobalConfiguration::QUERY_LOADER_LOGGING = false;

--- a/src/configuration/GlobalConfiguration.h
+++ b/src/configuration/GlobalConfiguration.h
@@ -204,6 +204,7 @@ public:
     static const bool SMT_CORE_LOGGING;
     static const bool DANTZIGS_RULE_LOGGING;
     static const bool BASIS_FACTORIZATION_LOGGING;
+    static const bool PREPROCESSOR_LOGGING;
     static const bool PROJECTED_STEEPEST_EDGE_LOGGING;
     static const bool GAUSSIAN_ELIMINATION_LOGGING;
     static const bool QUERY_LOADER_LOGGING;

--- a/src/engine/Preprocessor.cpp
+++ b/src/engine/Preprocessor.cpp
@@ -43,11 +43,11 @@ InputQuery Preprocessor::preprocess( const InputQuery &query, bool attemptVariab
     */
     if ( !_preprocessed._networkLevelReasoner )
     {
-        printf( "PP: constructing an NLR... " );
+        log( "PP: constructing an NLR... " );
         if ( constructNetworkLevelReasoner() )
-            printf( "successful\n" );
+            log( "successful\n" );
         else
-            printf( "unsuccessful\n" );
+            log( "unsuccessful\n" );
     }
 
     /*
@@ -1064,6 +1064,12 @@ bool Preprocessor::constructNetworkLevelReasoner()
     _preprocessed._networkLevelReasoner = nlr;
 
     return true;
+}
+
+void Preprocessor::log( const String &message )
+{
+    if ( GlobalConfiguration::PREPROCESSOR_LOGGING )
+        printf( "PREPROCESSOR: %s\n", message.ascii() );
 }
 
 //

--- a/src/engine/Preprocessor.cpp
+++ b/src/engine/Preprocessor.cpp
@@ -1069,7 +1069,7 @@ bool Preprocessor::constructNetworkLevelReasoner()
 void Preprocessor::log( const String &message )
 {
     if ( GlobalConfiguration::PREPROCESSOR_LOGGING )
-        printf( "PREPROCESSOR: %s\n", message.ascii() );
+        printf( "Preprocessor: %s\n", message.ascii() );
 }
 
 //

--- a/src/engine/Preprocessor.h
+++ b/src/engine/Preprocessor.h
@@ -138,6 +138,10 @@ private:
       For debugging only
     */
     void dumpAllBounds( const String &message );
+
+
+    static void log( const String &message );
+
 };
 
 #endif // __Preprocessor_h__

--- a/src/engine/Preprocessor.h
+++ b/src/engine/Preprocessor.h
@@ -139,7 +139,6 @@ private:
     */
     void dumpAllBounds( const String &message );
 
-
     static void log( const String &message );
 
 };


### PR DESCRIPTION
- Create a log function in the Preprocessor class.
- Move the print statements to logger in the Preprocessor::preprocess method.