### PR TITLE
Use v1.13 lcov, since the default v1.12 is buggy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,13 @@ addons:
     - python3
     - python3-pip
     - python3-setuptools
-    - lcov
 
 install:
+  - if [ "$TRAVIS_COMPILER" = "gcc" ]; then
+      wget https://github.com/linux-test-project/lcov/archive/v1.13.zip;
+      unzip v1.13.zip;
+      export PATH=$PATH:`pwd`/lcov-1.13/bin;
+    fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then if [[ ! -d "C:\Python3" || ! -f "C:\Python3\python" ]]; then choco install python3 --version=3.5.4 --params "/InstallDir:C:\Python3"; fi fi
   - $PY_CMD -m pip install --user --upgrade pip
   - $PY_CMD -m pip install --user --upgrade setuptools
@@ -40,12 +44,6 @@ matrix:
       - ctest -L regress[0-1] -j 2
       - cd ..
       - $PY_CMD -m pytest --cov=maraboupy maraboupy/test
-      - lcov --capture --directory . --output-file coverage.info
-      - lcov --remove coverage.info '/usr/*' '*/tools/*' '*.cc' '*/tests/*' '*Test_*.h' --output-file coverage.info 
-      - lcov --list coverage.info 
-      # Uploading report to CodeCov
-      - bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
-
 
     - os: linux
       dist: xenial
@@ -58,7 +56,7 @@ matrix:
       - ctest -L system -j 2
       - ctest -L regress0 -j 2
       - cd ..
-      - $PY_CMD -m pytest --cov=maraboupy maraboupy/test
+      - $PY_CMD -m pytest maraboupy/test
 
     - os: windows
       script:
@@ -70,10 +68,16 @@ matrix:
       - ctest -L regress0 -j 2 # does not work ...
       - cd ..
       - cp maraboupy/Release/* maraboupy
-      - $PY_CMD -m pytest --cov=maraboupy maraboupy/test
+      - $PY_CMD -m pytest maraboupy/test
 
 after_success:
-  - codecov
+  - if [ "$TRAVIS_COMPILER" = "gcc" ]; then
+      codecov;
+      lcov --capture --directory . --output-file coverage.info;
+      lcov --remove coverage.info '/usr/*' '*/tools/*' '*.cc' '*/tests/*' '*Test_*.h' --output-file coverage.info;
+      lcov --list coverage.info;
+      bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports";
+    fi
 
 notifications:
   email:


### PR DESCRIPTION
Lcov sometimes fails with the error "cannot write to coverage.info!". The error could be caused by lcov v1.12 being installed by apt, which has been shown to have some bugs: https://stackoverflow.com/questions/37675961/error-while-code-coverage-report-using-lcov

These issues were fixed in version 1.13, so these changes update the lcov version used by travis. Also, this pr rearranges Travis a bit so that codecov runs in "after_success" only for the gcc build, and lcov is only installed for the gcc build as well. Code coverage is removed from the other build's python tests since we only need to run coverage once.