### PR TITLE
Fix error in get-openBLAS.

### DIFF
--- a/tools/get-openBLAS.sh
+++ b/tools/get-openBLAS.sh
@@ -4,11 +4,11 @@ mydir="${0%/*}"
 
 cd $mydir
 
-echo "downloding openBLAS"
-wget http://github.com/xianyi/OpenBLAS/archive/v0.3.9.tar.gz
-echo "unzipping openBLAS"
+echo "Downloding openBLAS"
+wget http://github.com/xianyi/OpenBLAS/archive/v0.3.9.tar.gz -O v0.3.9.tar.gz
+echo "Unzipping openBLAS"
 tar -xzf v0.3.9.tar.gz >> /dev/null
-echo "installing openBLAS"
+echo "Installing openBLAS"
 cd OpenBLAS-0.3.9
 make NO_SHARED=1 CBLAS_ONLY=1 USE_THREAD=0 >> /dev/null
 mkdir installed/


### PR DESCRIPTION
The current version of `get-openBLAS.sh` doesn't specify an output filename for `wget`. The result is that, on MacOS, the file is saved to `v0.3.9` without the `.tar.gz` extension. This causes the subsequent `tar` command to fail.

This patch changes the script to explicitly save the file as `v0.3.9.tar.gz`.