### PR TITLE
Move equality and inequality to MarabouNetwork

### DIFF
--- a/maraboupy/MarabouNetwork.py
+++ b/maraboupy/MarabouNetwork.py
@@ -3,7 +3,7 @@
 /*! \file MarabouNetwork.py
  ** \verbatim
  ** Top contributors (to current version):
- **   Christopher Lazarus, Shantanu Thakoor, Andrew Wu
+ **   Christopher Lazarus, Shantanu Thakoor, Andrew Wu, Kyle Julian
  ** This file is part of the Marabou project.
  ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
@@ -17,6 +17,7 @@
 '''
 
 from maraboupy import MarabouCore
+from maraboupy import MarabouUtils
 import numpy as np
 
 class MarabouNetwork:
@@ -127,6 +128,42 @@ class MarabouNetwork:
         """
         # ReLUs
         return x in self.varsParticipatingInConstraints
+
+    def addEquality(self, vars, coeffs, scalar):
+        """Function to add equality constraint to network
+
+        .. math::
+            \sum_i \text{vars}_i \times \text{coeffs}_i = \text{scalar}
+
+        Args:
+            vars (list of int): Variable numbers
+            coeffs (list of float): Coefficients
+            scalar (float): Right hand side constant of equation
+        """
+        assert len(vars)==len(coeffs)
+        e = MarabouUtils.Equation()
+        for i in range(len(vars)):
+            e.addAddend(coeffs[i], vars[i])
+        e.setScalar(scalar)
+        self.addEquation(e)
+
+    def addInequality(self, vars, coeffs, scalar):
+        """Function to add inequality constraint to network
+
+        .. math::
+            \sum_i \text{vars}_i \times \text{coeffs}_i \le \text{scalar}
+
+        Args:
+            vars (list of int): Variable numbers
+            coeffs (list of float): Coefficients
+            scalar (float): Right hand side constant of inequality
+        """
+        assert len(vars)==len(coeffs)
+        e = MarabouUtils.Equation(MarabouCore.Equation.LE)
+        for i in range(len(vars)):
+            e.addAddend(coeffs[i], vars[i])
+        e.setScalar(scalar)
+        self.addEquation(e)
 
     def getMarabouQuery(self):
         """

--- a/maraboupy/MarabouUtils.py
+++ b/maraboupy/MarabouUtils.py
@@ -47,36 +47,3 @@ class Equation:
         """
         self.addendList += [(c, x)]
 
-def addEquality(network, vars, coeffs, scalar):
-    """
-    Function to conveniently add equality constraint to network
-    \sum_i vars_i*coeffs_i = scalar
-    Arguments:
-        network: (MarabouNetwork) to which to add constraint
-        vars: (list) of variable numbers
-        coeffs: (list) of coefficients
-        scalar: (float) representing RHS of equation
-    """
-    assert len(vars)==len(coeffs)
-    e = Equation()
-    for i in range(len(vars)):
-        e.addAddend(coeffs[i], vars[i])
-    e.setScalar(scalar)
-    network.addEquation(e)
-
-def addInequality(network, vars, coeffs, scalar):
-    """
-    Function to conveniently add inequality constraint to network
-    \sum_i vars_i*coeffs_i <= scalar
-    Arguments:
-        network: (MarabouNetwork) to which to add constraint
-        vars: (list) of variable numbers
-        coeffs: (list) of coefficients
-        scalar: (float) representing RHS of equation
-    """
-    assert len(vars)==len(coeffs)
-    e = Equation(MarabouCore.Equation.LE)
-    for i in range(len(vars)):
-        e.addAddend(coeffs[i], vars[i])
-    e.setScalar(scalar)
-    network.addEquation(e)

--- a/maraboupy/test/test_equation.py
+++ b/maraboupy/test/test_equation.py
@@ -5,7 +5,6 @@ warnings.filterwarnings('ignore', category = PendingDeprecationWarning)
 
 import pytest
 from .. import Marabou
-from .. import MarabouUtils
 import numpy as np
 import os
 
@@ -28,7 +27,7 @@ def test_equality_output():
         
         # Add output equality constraints
         outputValue = np.random.random() * 5 + 3
-        MarabouUtils.addEquality(network, [outputVar], [1.0], outputValue)
+        network.addEquality([outputVar], [1.0], outputValue)
 
         # Call to Marabou solver
         vals, _ = network.solve(options = OPT, verbose = False)
@@ -49,7 +48,7 @@ def test_equality_input():
     inputVars = network.inputVars[0][0]
     weights = np.ones(inputVars.shape)/inputVars.size
     averageInputValue = 5.0
-    MarabouUtils.addEquality(network, inputVars, weights, averageInputValue)
+    network.addEquality(inputVars, weights, averageInputValue)
     
     # Lower bound on second output variable
     outputVars = network.outputVars.flatten()
@@ -75,7 +74,7 @@ def test_inequality_output():
         
         # Output inequality constraint
         outputValue = np.random.random() * 90 + 10
-        MarabouUtils.addInequality(network, outputVars, weights, outputValue)
+        network.addInequality(outputVars, weights, outputValue)
 
         # Call to Marabou solver
         vals, _ = network.solve(options = OPT, verbose = False)
@@ -96,7 +95,7 @@ def test_inequality_input():
     inputVars = network.inputVars[0][0]
     weights = np.ones(inputVars.shape)/inputVars.size
     averageInputValue = -5.0
-    MarabouUtils.addInequality(network, inputVars, weights, averageInputValue)
+    network.addInequality(inputVars, weights, averageInputValue)
     
     # Add lower bound on second output variable
     outputVars = network.outputVars.flatten()


### PR DESCRIPTION
I'm not sure why the addEquality and addInequality functions are defined in MarabouUtils. It makes more sense to make them class methods, which allows a user to add equality and inequality constraints without importing MarabouUtils. The updated test file shows that the syntax is a lot more intuitive this way. 

The docstrings for these methods are slightly changed to use the Google style. A future pr will edit all of the docstrings in Maraboupy to use the Google style.