### PR TITLE
Deploy Maraboupy docs to github pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ after_success:
       bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports";
     fi
 
+
 before_deploy:
   - if [ "$TRAVIS_COMPILER" = "gcc" ]; then
     pip install --user -r maraboupy/docs/requirements.txt --progress-bar off

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,9 +91,9 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: "$GITHUB_PAGES_DEPLOY_TOKEN"
-  #local_dir: maraboupy/docs/_build/html
-  #on:
-  #  branch: master
+  local_dir: maraboupy/docs/_build/html
+  on:
+    branch: master
   #  condition: "$TRAVIS_COMPILER" = "gcc"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ before_deploy:
 
 deploy:
   provider: pages
-  skip_cleanup = true
+  skip_cleanup: true
   github_token: "$GITHUB_PAGES_DEPLOY_TOKEN"
   local_dir: maraboupy/docs/_build/html
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,21 +80,21 @@ after_success:
       bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports";
     fi
 
-before_deploy:
-  - if [ "$TRAVIS_COMPILER" = "gcc" ]; then
-    pip install --user -r maraboupy/docs/requirements.txt --progress-bar off
-    make -C maraboupy/docs html
-    touch maraboupy/docs/_build/html/.nojekyll
-  fi
+#before_deploy:
+#  - if [ "$TRAVIS_COMPILER" = "gcc" ]; then
+#    pip install --user -r maraboupy/docs/requirements.txt --progress-bar off
+#    make -C maraboupy/docs html
+#    touch maraboupy/docs/_build/html/.nojekyll
+#  fi
 
-deploy:
-  provider: pages
-  skip_cleanup = true
-  github_token: $GITHUB_PAGES_DEPLOY_TOKEN
-  local_dir: maraboupy/docs/_build/html
-  on:
-    branch: master
-    condition: $TRAVIS_COMPILER = "gcc"
+#deploy:
+#  provider: pages
+#  skip_cleanup = true
+#  github_token: $GITHUB_PAGES_DEPLOY_TOKEN
+#  local_dir: maraboupy/docs/_build/html
+#  on:
+#    branch: master
+#    condition: $TRAVIS_COMPILER = "gcc"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,19 +82,19 @@ after_success:
 
 before_deploy:
   - if [ "$TRAVIS_COMPILER" = "gcc" ]; then
-    pip install --user -r maraboupy/docs/requirements.txt --progress-bar off;
-    make -C maraboupy/docs html;
-    touch maraboupy/docs/_build/html/.nojekyll;
-  fi
+      pip install --user -r maraboupy/docs/requirements.txt --progress-bar off;
+      make -C maraboupy/docs html;
+      touch maraboupy/docs/_build/html/.nojekyll;
+    fi
 
-deploy:
-  provider: pages
-  skip_cleanup = true
-  github_token: $GITHUB_PAGES_DEPLOY_TOKEN
-  local_dir: maraboupy/docs/_build/html
-  on:
-    branch: master
-    condition: $TRAVIS_COMPILER = "gcc"
+#deploy:
+#  provider: pages
+#  skip_cleanup = true
+#  github_token: $GITHUB_PAGES_DEPLOY_TOKEN
+#  local_dir: maraboupy/docs/_build/html
+#  on:
+#    branch: master
+#    condition: $TRAVIS_COMPILER = "gcc"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,12 +80,12 @@ after_success:
       bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports";
     fi
 
-#before_deploy:
-#  - if [ "$TRAVIS_COMPILER" = "gcc" ]; then
-#    pip install --user -r maraboupy/docs/requirements.txt --progress-bar off
-#    make -C maraboupy/docs html
-#    touch maraboupy/docs/_build/html/.nojekyll
-#  fi
+before_deploy:
+  - if [ "$TRAVIS_COMPILER" = "gcc" ]; then
+    pip install --user -r maraboupy/docs/requirements.txt --progress-bar off
+    make -C maraboupy/docs html
+    touch maraboupy/docs/_build/html/.nojekyll
+  fi
 
 #deploy:
 #  provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ deploy:
   local_dir: maraboupy/docs/_build/html
   on:
     branch: master
-  #  condition: "$TRAVIS_COMPILER" = "gcc"
+    condition: $TRAVIS_COMPILER = gcc
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,6 @@ after_success:
       bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports";
     fi
 
-
 before_deploy:
   - if [ "$TRAVIS_COMPILER" = "gcc" ]; then
     pip install --user -r maraboupy/docs/requirements.txt --progress-bar off
@@ -91,11 +90,11 @@ before_deploy:
 deploy:
   provider: pages
   skip_cleanup = true
-  github_token: "$GITHUB_PAGES_DEPLOY_TOKEN"
+  github_token: $GITHUB_PAGES_DEPLOY_TOKEN
   local_dir: maraboupy/docs/_build/html
   on:
     branch: master
-    condition: "$TRAVIS_COMPILER" = "gcc"
+    condition: $TRAVIS_COMPILER = "gcc"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,21 @@ after_success:
       bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports";
     fi
 
+before_deploy:
+  - if [ "$TRAVIS_COMPILER" = "gcc" ]; then
+    pip install --user -r maraboupy/docs/requirements.txt --progress-bar off
+    make -C maraboupy/docs html
+    touch maraboupy/docs/_build/html/.nojekyll
+  fi
+
+deploy:
+  provider: pages
+  skip_cleanup = true
+  local_dir: maraboupy/docs/_build/html
+  on:
+    branch: master
+    condition: "$TRAVIS_COMPILER" = "gcc"
+
 notifications:
   email:
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,10 +91,10 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: "$GITHUB_PAGES_DEPLOY_TOKEN"
-  local_dir: maraboupy/docs/_build/html
-  on:
-    branch: master
-    condition: "$TRAVIS_COMPILER" = "gcc"
+  #local_dir: maraboupy/docs/_build/html
+  #on:
+  #  branch: master
+  #  condition: "$TRAVIS_COMPILER" = "gcc"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ before_deploy:
 deploy:
   provider: pages
   skip_cleanup = true
+  github_token: "$GITHUB_PAGES_DEPLOY_TOKEN"
   local_dir: maraboupy/docs/_build/html
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,19 +82,19 @@ after_success:
 
 before_deploy:
   - if [ "$TRAVIS_COMPILER" = "gcc" ]; then
-    pip install --user -r maraboupy/docs/requirements.txt --progress-bar off
-    make -C maraboupy/docs html
-    touch maraboupy/docs/_build/html/.nojekyll
+    pip install --user -r maraboupy/docs/requirements.txt --progress-bar off;
+    make -C maraboupy/docs html;
+    touch maraboupy/docs/_build/html/.nojekyll;
   fi
 
-#deploy:
-#  provider: pages
-#  skip_cleanup = true
-#  github_token: $GITHUB_PAGES_DEPLOY_TOKEN
-#  local_dir: maraboupy/docs/_build/html
-#  on:
-#    branch: master
-#    condition: $TRAVIS_COMPILER = "gcc"
+deploy:
+  provider: pages
+  skip_cleanup = true
+  github_token: $GITHUB_PAGES_DEPLOY_TOKEN
+  local_dir: maraboupy/docs/_build/html
+  on:
+    branch: master
+    condition: $TRAVIS_COMPILER = "gcc"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,14 +87,14 @@ before_deploy:
       touch maraboupy/docs/_build/html/.nojekyll;
     fi
 
-#deploy:
-#  provider: pages
-#  skip_cleanup = true
-#  github_token: $GITHUB_PAGES_DEPLOY_TOKEN
-#  local_dir: maraboupy/docs/_build/html
-#  on:
-#    branch: master
-#    condition: $TRAVIS_COMPILER = "gcc"
+deploy:
+  provider: pages
+  skip_cleanup = true
+  github_token: "$GITHUB_PAGES_DEPLOY_TOKEN"
+  local_dir: maraboupy/docs/_build/html
+  on:
+    branch: master
+    condition: "$TRAVIS_COMPILER" = "gcc"
 
 notifications:
   email:

--- a/maraboupy/MarabouNetwork.py
+++ b/maraboupy/MarabouNetwork.py
@@ -11,7 +11,7 @@ in the top-level source directory) and their institutional affiliations.
 All rights reserved. See the file COPYING in the top-level source
 directory for licensing information.
 
-MarabouNetwork defines an abstract class to represent neural networks with piecewise linear constraints
+MarabouNetwork defines an abstract class that represents neural networks with piecewise linear constraints
 '''
 
 from maraboupy import MarabouCore

--- a/maraboupy/docs/index.rst
+++ b/maraboupy/docs/index.rst
@@ -14,7 +14,6 @@ constraints, or SAT if a satisfying assignment exists.
 This documentation explains how to setup Maraboupy, shows examples using Maraboupy,
 and provides API documentation.
 
-
 .. _Setup:
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
These changes to travis build the maraboupy documentation using the gcc compiler build. If running on the master branch (such as after merging), deploy runs to send the built html documentation to github pages.