### PR TITLE
Add Marabou dir to pythonpath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ after_success:
 before_deploy:
   - if [ "$TRAVIS_COMPILER" = "gcc" ]; then
       pip install --user -r maraboupy/docs/requirements.txt --progress-bar off;
+      export PYTHONPATH=$PYTHONPATH:`pwd`
       make -C maraboupy/docs html;
       touch maraboupy/docs/_build/html/.nojekyll;
     fi


### PR DESCRIPTION
The autodocumentation doesn't build correctly if the Marabou folder is not added to the PYTHONPATH environment variable. The python tests run without changing this variable because we run the tests from the root Marabou directory, but building the documentation must be done in the maraboupy/docs folder. 

This PR should fix the issue so that pages like this won't be empty: https://neuralnetworkverification.github.io/Marabou/API/0_Marabou.html