### PR TITLE
Fix evaluateWithMarabou when system is UNSAT

### DIFF
--- a/maraboupy/MarabouNetwork.py
+++ b/maraboupy/MarabouNetwork.py
@@ -270,7 +270,7 @@ class MarabouNetwork:
             options (:class:`~maraboupy.MarabouCore.Options`): Object for specifying Marabou options, defaults to None
 
         Returns:
-            (np array): Values representing the output of the network
+            (np array): Values representing the output of the network or None if system is UNSAT
         """
         # Make sure inputValues is a list of np arrays and not list of lists
         inputValues = [np.array(inVal) for inVal in inputValues]
@@ -293,6 +293,11 @@ class MarabouNetwork:
         if options == None:
             options = MarabouCore.Options()
         outputDict, _ = MarabouCore.solve(ipq, options, filename)
+
+        # When the query is UNSAT an empty dictionary is returned
+        if outputDict == {}:
+            return None
+
         outputValues = outputVars.reshape(-1).astype(np.float64)
         for i in range(len(outputValues)):
             outputValues[i] = outputDict[outputValues[i]]
@@ -309,7 +314,7 @@ class MarabouNetwork:
             filename (str): Path to redirect output if using Marabou solver, defaults to "evaluateWithMarabou.log"
 
         Returns:
-            (np array): Values representing the output of the network
+            (np array): Values representing the output of the network or None if output cannot be computed
         """
         if useMarabou:
             return self.evaluateWithMarabou(inputValues, filename=filename, options=options)

--- a/maraboupy/test/test_nnet.py
+++ b/maraboupy/test/test_nnet.py
@@ -116,6 +116,25 @@ def test_acas_2_9_normalize():
     ]
     evaluateFile(filename, testInputs, testOutputs, normalize = True)
 
+def test_evaluateUNSAT():
+    """
+    When an UNSAT system is evaluated, evaluateWithMarabou should return None
+    """
+    filename = "acasxu/ACASXU_experimental_v2a_2_9.nnet"
+    filename = os.path.join(os.path.dirname(__file__), NETWORK_FOLDER, filename)
+    network = Marabou.read_nnet(filename, normalize = True)
+
+    # Add a constraint that makes the system UNSAT at the evaluation point
+    # The sum of output values must be less than -100
+    outputVars = network.outputVars[0]
+    outputWeights = [1.0] * len(outputVars)
+    network.addInequality(outputVars, outputWeights, -100.0)
+
+    # Evaluate network at test point, which should return None because the system is UNSAT
+    testInput = [1000.0, 0.0, -1.5, 100.0, 100.0]
+    marabouEval = network.evaluateWithMarabou([testInput], options=OPT, filename="")
+    assert marabouEval is None
+
 def evaluateFile(filename, testInputs, testOutputs, normalize = False, normInput = False, denormOutput = False):
     """
     Load network and evaluate testInputs with and without Marabou


### PR DESCRIPTION
Instead of throwing KeyError exception when given an UNSAT system, evaluateWithMarabou (and so evaluate as well) now returns None.