### PR TITLE
fix bug in dnc evaluate

### DIFF
--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -174,7 +174,7 @@ std::pair<std::map<int, double>, Statistics> solve(InputQuery &inputQuery, Marab
             case DnCManager::SAT:
             {
                 retStats = Statistics();
-                dncManager->getSolution( ret );
+                dncManager->getSolution( ret, inputQuery );
                 break;
             }
             case DnCManager::TIMEOUT:

--- a/maraboupy/test/test_dnc.py
+++ b/maraboupy/test/test_dnc.py
@@ -1,0 +1,90 @@
+# Tests Marabou's DNC option
+import pytest
+from .. import Marabou
+import os
+import numpy as np
+
+# Global settings
+OPT = Marabou.createOptions(verbosity=0, dnc=True, numWorkers=2) # Turn off printing, turn on DNC with two workers
+TOL = 1e-6                                                       # Set tolerance for checking Marabou evaluations
+NETWORK_FOLDER = "../../resources/nnet/acasxu"                   # Folder for test network
+
+def test_dnc_unsat():
+    """
+    Test the 1,1 experimental ACAS Xu network. 
+    Test a small input region with an output constraint that cannot be satisfied.
+    """
+    filename =  "ACASXU_experimental_v2a_1_1.nnet"
+    filename = os.path.join(os.path.dirname(__file__), NETWORK_FOLDER, filename)
+    network = Marabou.read_nnet(filename)
+    centerPoint = [-0.2454504737724233, -0.4774648292756546, 0.0, -0.3181818181818182, 0.0]
+
+    for var, val in zip(network.inputVars[0], centerPoint):
+        network.setLowerBound(var, val - 0.002)
+        network.setUpperBound(var, val + 0.002)
+
+    # Set high lower bound on first output variable
+    outVar = network.outputVars[0][0]
+    network.setLowerBound(outVar, 0.1)
+
+    # Expect UNSAT result
+    vals, stats = network.solve(options = OPT, filename = "", verbose=False)
+    assert len(vals) == 0
+    
+def test_dnc_sat():
+    """
+    Test the 1,1 experimental ACAS Xu network. 
+    Test a small input region with an output constraint that can be satisfied.
+    """
+    filename =  "ACASXU_experimental_v2a_1_1.nnet"
+    filename = os.path.join(os.path.dirname(__file__), NETWORK_FOLDER, filename)
+    network = Marabou.read_nnet(filename)
+    centerPoint = [-0.2454504737724233, -0.4774648292756546, 0.0, -0.3181818181818182, 0.0]
+
+    for var, val in zip(network.inputVars[0], centerPoint):
+        network.setLowerBound(var, val - 0.002)
+        network.setUpperBound(var, val + 0.002)
+
+    # Set a reduced lower bound on first output variable, which can be satisfied
+    outVar = network.outputVars[0][0]
+    network.setLowerBound(outVar, 0.0)
+
+    # Expect SAT result, which should return a dictionary with a value for every network variable
+    vals, stats = network.solve(options = OPT, filename = "", verbose=False)
+    assert len(vals) == network.numVars
+
+def test_dnc_eval():
+    """
+    Test the 1,1 experimental ACAS Xu network. 
+    Evaluate the network at test points with DNC mode activated
+    """
+    filename =  "ACASXU_experimental_v2a_1_1.nnet"
+    testInputs = [
+        [-0.31182839647533234, 0.0, -0.2387324146378273, -0.5, -0.4166666666666667],
+        [-0.16247807039378703, -0.4774648292756546, -0.2387324146378273, -0.3181818181818182, -0.25],
+        [-0.2454504737724233, -0.4774648292756546, 0.0, -0.3181818181818182, 0.0]
+    ]
+    testOutputs = [
+        [0.45556007, 0.44454904, 0.49616356, 0.38924966, 0.50136678],
+        [-0.02158248, -0.01885345, -0.01892334, -0.01892597, -0.01893113],
+        [0.05990158, 0.05273383, 0.10029709, 0.01883183, 0.10521622]
+    ]    
+    evaluateFile(filename, testInputs, testOutputs)
+
+def evaluateFile(filename, testInputs, testOutputs):
+    """ Load network and evaluate testInputs with and without Marabou
+    
+    Args:
+        filename (str): name of network file without path
+        testInputs (list of lists): list of inputs points to test
+        testOutputs (list of lists): list of expected output values for the input points
+    """
+    # Load network relative to this file's location
+    filename = os.path.join(os.path.dirname(__file__), NETWORK_FOLDER, filename)
+    network = Marabou.read_nnet(filename)
+
+    if testOutputs:
+        # Evaluate test points using Marabou and compare to known output
+        for testInput, testOutput in zip(testInputs, testOutputs):
+            marabouEval = network.evaluateWithMarabou([testInput], options = OPT, filename = "").flatten()
+            assert max(abs(marabouEval - testOutput)) < TOL

--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -245,9 +245,9 @@ void DnCManager::getSolution( std::map<int, double> &ret,
                               InputQuery &inputQuery )
 {
     ASSERT( _engineWithSATAssignment != nullptr );
-    EngineState stateWithSolution;
-    _engineWithSATAssignment->storeState( stateWithSolution, true );
-    _baseEngine->restoreState( stateWithSolution );
+    TableauState tableauStateWithSolution;
+    _engineWithSATAssignment->storeTableauState( tableauStateWithSolution );
+    _baseEngine->restoreTableauState( tableauStateWithSolution );
     _baseEngine->extractSolution( inputQuery );
 
     for ( unsigned i = 0; i < inputQuery.getNumberOfVariables(); ++i )

--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -241,15 +241,17 @@ String DnCManager::getResultString()
     }
 }
 
-void DnCManager::getSolution( std::map<int, double> &ret )
+void DnCManager::getSolution( std::map<int, double> &ret,
+                              InputQuery &inputQuery )
 {
     ASSERT( _engineWithSATAssignment != nullptr );
+    EngineState stateWithSolution;
+    _engineWithSATAssignment->storeState( stateWithSolution, true );
+    _baseEngine->restoreState( stateWithSolution );
+    _baseEngine->extractSolution( inputQuery );
 
-    InputQuery *inputQuery = _engineWithSATAssignment->getInputQuery();
-    _engineWithSATAssignment->extractSolution( *( inputQuery ) );
-
-    for ( unsigned i = 0; i < inputQuery->getNumberOfVariables(); ++i )
-        ret[i] = inputQuery->getSolutionValue( i );
+    for ( unsigned i = 0; i < inputQuery.getNumberOfVariables(); ++i )
+        ret[i] = inputQuery.getSolutionValue( i );
 
     return;
 }

--- a/src/engine/DnCManager.h
+++ b/src/engine/DnCManager.h
@@ -73,7 +73,7 @@ public:
     /*
       Store the solution into the map
     */
-    void getSolution( std::map<int, double> &ret );
+    void getSolution( std::map<int, double> &ret, InputQuery &inputQuery );
 
     void setConstraintViolationThreshold( unsigned threshold );
 

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -1219,6 +1219,17 @@ void Engine::reportPlViolation()
     _smtCore.reportViolatedConstraint( _plConstraintToFix );
 }
 
+void Engine::storeTableauState( TableauState &state ) const
+{
+    _tableau->storeState( state );
+}
+
+void Engine::restoreTableauState( const TableauState &state )
+{
+    ENGINE_LOG( "\tRestoring tableau state" );
+    _tableau->restoreState( state );
+}
+
 void Engine::storeState( EngineState &state, bool storeAlsoTableauState ) const
 {
     if ( storeAlsoTableauState )

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -76,6 +76,8 @@ public:
     /*
       Methods for storing and restoring the state of the engine.
     */
+    void storeTableauState( TableauState &state ) const;
+    void restoreTableauState( const TableauState &state );
     void storeState( EngineState &state, bool storeAlsoTableauState ) const;
     void restoreState( const EngineState &state );
     void setNumPlConstraintsDisabledByValidSplits( unsigned numConstraints );


### PR DESCRIPTION
Fixing issue https://github.com/NeuralNetworkVerification/Marabou/issues/330. 
The issue is that when some worker finds a SAT instance and returns a mapping from variable indices to assignments, it is using variable indices after preprocessing. This is because the worker itself does not preprocess the query but directly take in the preprocessed query, so it does not store the mapping from original variable index to the new index.
This information is stored in DnCManager._baseEngine. Therefore, we copy the tableau state of DnCManager._engineWithSATAssignment into DnCManager._baseEngine and extract solutions from the latter object, instead of the former object.