### PR TITLE
Set preprocessor's verbosity to 0 in DnC

### DIFF
--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -319,7 +319,7 @@ void DnCManager::printResult()
 bool DnCManager::createEngines()
 {
     // Create the base engine
-    _baseEngine = std::make_shared<Engine>();
+    _baseEngine = std::make_shared<Engine>( _verbosity );
     if ( !_baseEngine->processInputQuery( *_baseInputQuery ) )
         // Solved by preprocessing, we are done!
         return false;

--- a/src/engine/DnCManager.cpp
+++ b/src/engine/DnCManager.cpp
@@ -36,7 +36,8 @@ void DnCManager::dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine
                            std::atomic_uint &numUnsolvedSubQueries,
                            std::atomic_bool &shouldQuitSolving,
                            unsigned threadId, unsigned onlineDivides,
-                           float timeoutFactor, DivideStrategy divideStrategy )
+                           float timeoutFactor, DivideStrategy divideStrategy,
+                           unsigned verbosity )
 {
     unsigned cpuId = 0;
     (void) threadId;
@@ -49,7 +50,7 @@ void DnCManager::dncSolve( WorkerQueue *workload, std::shared_ptr<Engine> engine
 
     DnCWorker worker( workload, engine, std::ref( numUnsolvedSubQueries ),
                       std::ref( shouldQuitSolving ), threadId, onlineDivides,
-                      timeoutFactor, divideStrategy );
+                      timeoutFactor, divideStrategy, verbosity );
     while ( !shouldQuitSolving.load() )
     {
         worker.popOneSubQueryAndSolve();
@@ -152,7 +153,8 @@ void DnCManager::solve( unsigned timeoutInSeconds )
                                         std::ref( _numUnsolvedSubQueries ),
                                         std::ref( shouldQuitSolving ),
                                         threadId, _onlineDivides,
-                                        _timeoutFactor, _divideStrategy ) );
+                                        _timeoutFactor, _divideStrategy,
+                                        _verbosity ) );
     }
 
     // Wait until either all subQueries are solved or a satisfying assignment is
@@ -326,7 +328,7 @@ bool DnCManager::createEngines()
     // Create engines for each thread
     for ( unsigned i = 0; i < _numWorkers; ++i )
     {
-        auto engine = std::make_shared<Engine>( _verbosity );
+        auto engine = std::make_shared<Engine>( 0 );
         engine->setConstraintViolationThreshold( _constraintViolationThreshold );
         _engines.append( engine );
     }

--- a/src/engine/DnCManager.h
+++ b/src/engine/DnCManager.h
@@ -86,7 +86,8 @@ private:
                           std::atomic_uint &numUnsolvedSubQueries,
                           std::atomic_bool &shouldQuitSolving,
                           unsigned threadId, unsigned onlineDivides,
-                          float timeoutFactor, DivideStrategy divideStrategy );
+                          float timeoutFactor, DivideStrategy divideStrategy,
+                          unsigned verbosity );
 
     /*
       Create the base engine from the network and property files,

--- a/src/engine/DnCMarabou.cpp
+++ b/src/engine/DnCMarabou.cpp
@@ -127,7 +127,6 @@ void DnCMarabou::run()
 
 void DnCMarabou::displayResults( unsigned long long microSecondsElapsed ) const
 {
-    std::cout << "Total Time: " << microSecondsElapsed / 1000000 << std::endl;
     _dncManager->printResult();
     String resultString = _dncManager->getResultString();
     // Create a summary file, if requested

--- a/src/engine/DnCWorker.cpp
+++ b/src/engine/DnCWorker.cpp
@@ -33,7 +33,8 @@ DnCWorker::DnCWorker( WorkerQueue *workload, std::shared_ptr<IEngine> engine,
                       std::atomic_uint &numUnsolvedSubQueries,
                       std::atomic_bool &shouldQuitSolving,
                       unsigned threadId, unsigned onlineDivides,
-                      float timeoutFactor, DivideStrategy divideStrategy )
+                      float timeoutFactor, DivideStrategy divideStrategy,
+                      unsigned verbosity )
     : _workload( workload )
     , _engine( engine )
     , _numUnsolvedSubQueries( &numUnsolvedSubQueries )
@@ -41,6 +42,7 @@ DnCWorker::DnCWorker( WorkerQueue *workload, std::shared_ptr<IEngine> engine,
     , _threadId( threadId )
     , _onlineDivides( onlineDivides )
     , _timeoutFactor( timeoutFactor )
+    , _verbosity( verbosity )
 {
     setQueryDivider( divideStrategy );
 
@@ -86,7 +88,9 @@ void DnCWorker::popOneSubQueryAndSolve()
         _engine->solve( timeoutInSeconds );
 
         IEngine::ExitCode result = _engine->getExitCode();
-        printProgress( queryId, result );
+
+        if ( _verbosity > 0 )
+            printProgress( queryId, result );
         // Switch on the result
         if ( result == IEngine::UNSAT )
         {

--- a/src/engine/DnCWorker.h
+++ b/src/engine/DnCWorker.h
@@ -30,7 +30,7 @@ public:
                std::atomic_uint &numUnsolvedSubqueries,
                std::atomic_bool &shouldQuitSolving, unsigned threadId,
                unsigned onlineDivides, float timeoutFactor,
-               DivideStrategy divideStrategy );
+               DivideStrategy divideStrategy, unsigned verbosity );
 
     /*
       Pop one subQuery, solve it and handle the result
@@ -80,6 +80,7 @@ private:
     unsigned _threadId;
     unsigned _onlineDivides;
     float _timeoutFactor;
+    unsigned _verbosity;
 };
 
 #endif // __DnCWorker_h__

--- a/src/engine/tests/Test_DnCWorker.h
+++ b/src/engine/tests/Test_DnCWorker.h
@@ -123,9 +123,10 @@ public:
         unsigned onlineDivides = 2;
         float timeoutFactor = 1;
         DivideStrategy divideStrategy = DivideStrategy::LargestInterval;
+        unsigned verbosity = 0;
         DnCWorker dncWorker( _workload, _engine, numUnsolvedSubQueries,
                              shouldQuitSolving, threadId, onlineDivides,
-                             timeoutFactor, divideStrategy );
+                             timeoutFactor, divideStrategy, verbosity );
 
         dncWorker.popOneSubQueryAndSolve();
         TS_ASSERT( _engine->getExitCode() == IEngine::TIMEOUT );
@@ -149,7 +150,7 @@ public:
         shouldQuitSolving= false;
 		dncWorker = DnCWorker( _workload, _engine, numUnsolvedSubQueries,
                                shouldQuitSolving, threadId, onlineDivides,
-                               timeoutFactor, divideStrategy );
+                               timeoutFactor, divideStrategy, verbosity );
 
         dncWorker.popOneSubQueryAndSolve();
         TS_ASSERT( _engine->getExitCode() == IEngine::UNSAT );
@@ -175,7 +176,7 @@ public:
 
         dncWorker = DnCWorker( _workload, _engine, numUnsolvedSubQueries,
                                shouldQuitSolving, threadId, onlineDivides,
-                               timeoutFactor, divideStrategy );
+                               timeoutFactor, divideStrategy, verbosity );
 
         dncWorker.popOneSubQueryAndSolve();
         TS_ASSERT( _engine->getExitCode() == IEngine::UNSAT );
@@ -199,7 +200,7 @@ public:
         shouldQuitSolving=( false );
 		dncWorker = DnCWorker( _workload, _engine, numUnsolvedSubQueries,
                              shouldQuitSolving, threadId, onlineDivides,
-                              timeoutFactor, divideStrategy );
+                               timeoutFactor, divideStrategy, verbosity );
 
         dncWorker.popOneSubQueryAndSolve();
         TS_ASSERT( _engine->getExitCode() == IEngine::SAT );
@@ -222,7 +223,7 @@ public:
         shouldQuitSolving =  true;
 		dncWorker = DnCWorker( _workload, _engine, numUnsolvedSubQueries,
                                shouldQuitSolving, threadId, onlineDivides,
-                               timeoutFactor, divideStrategy );
+                               timeoutFactor, divideStrategy, verbosity );
         dncWorker.popOneSubQueryAndSolve();
         TS_ASSERT( _engine->getExitCode() == IEngine::QUIT_REQUESTED );
         TS_ASSERT( numUnsolvedSubQueries.load() == 1 );
@@ -241,9 +242,10 @@ public:
         _engine->setExitCode( IEngine::ERROR );
          numUnsolvedSubQueries= 1;
         shouldQuitSolving = false;
+
 		dncWorker = DnCWorker( _workload, _engine, numUnsolvedSubQueries,
                                shouldQuitSolving, threadId, onlineDivides,
-                               timeoutFactor, divideStrategy );
+                               timeoutFactor, divideStrategy, verbosity );
 
         dncWorker.popOneSubQueryAndSolve();
         TS_ASSERT( _engine->getExitCode() == IEngine::ERROR );


### PR DESCRIPTION
Change the verbosity behavior of the DnC mode:
Verbosity=0: dnc mode suppresses printing of dnc worker's progress and has the same outlook as the sequential mode.
Verbosity > 1: dnc mode prints out dnc worker's progress and never print out statistics of individual worker Engine because they are not interpretable in a parallel setting.