### PR TITLE
improve addMaxConstratins

### DIFF
--- a/src/engine/MaxConstraint.cpp
+++ b/src/engine/MaxConstraint.cpp
@@ -86,7 +86,8 @@ void MaxConstraint::restoreState( const PiecewiseLinearConstraint *state )
 void MaxConstraint::registerAsWatcher( ITableau *tableau )
 {
     tableau->registerToWatchVariable( this, _f );
-    for ( unsigned element : _elements ) {
+    for ( unsigned element : _elements )
+    {
         if ( element == _f )
             continue;
         tableau->registerToWatchVariable( this, element );
@@ -96,7 +97,8 @@ void MaxConstraint::registerAsWatcher( ITableau *tableau )
 void MaxConstraint::unregisterAsWatcher( ITableau *tableau )
 {
     tableau->unregisterToWatchVariable( this, _f );
-    for ( unsigned element : _elements ) {
+    for ( unsigned element : _elements )
+    {
         if ( element == _f )
             continue;
         tableau->unregisterToWatchVariable( this, element );
@@ -105,10 +107,12 @@ void MaxConstraint::unregisterAsWatcher( ITableau *tableau )
 
 void MaxConstraint::notifyVariableValue( unsigned variable, double value )
 {
-    if ( ( _elements.exists ( _f ) || variable != _f ) && ( !_maxIndexSet || _assignment.get( _maxIndex ) < value ) )
+    if ( ( _elements.exists( _f ) || variable != _f )
+         &&
+         ( !_maxIndexSet || _assignment.get( _maxIndex ) < value ) )
 	  {
-        _maxIndex = variable;
-        _maxIndexSet = true;
+          _maxIndex = variable;
+          _maxIndexSet = true;
 	  }
     _assignment[variable] = value;
 }
@@ -131,7 +135,7 @@ void MaxConstraint::notifyLowerBound( unsigned variable, double value )
         List<unsigned> toRemove;
         for ( auto element : _elements )
         {
-			if ( element == variable || element == _f)
+			if ( element == variable || element == _f )
 				continue;
             if ( _upperBounds.exists( element ) &&
                  FloatUtils::lt( _upperBounds[element], value ) )
@@ -260,8 +264,8 @@ List<unsigned> MaxConstraint::getParticipatingVariables() const
     List<unsigned> result;
     for ( auto element : _elements )
         result.append( element );
-    
-    if ( !_elements.exists( _f ))
+
+    if ( !_elements.exists( _f ) )
         result.append( _f );
     return result;
 }
@@ -467,7 +471,7 @@ void MaxConstraint::addAuxiliaryEquations( InputQuery &inputQuery )
         // If element is equal to _f, skip this step.
         // The reason is to avoid adding equations like `1.00x00 -1.00x00 -1.00x01 = 0.00`.
         if ( element == _f )
-            continue; 
+            continue;
 
         // Create an aux variable
         unsigned auxVariable = inputQuery.getNumberOfVariables();

--- a/src/engine/MaxConstraint.cpp
+++ b/src/engine/MaxConstraint.cpp
@@ -94,9 +94,6 @@ void MaxConstraint::registerAsWatcher( ITableau *tableau )
 
 void MaxConstraint::unregisterAsWatcher( ITableau *tableau )
 {
-    // Guy: I think there's a bug here, not related to the recent changes:
-    // the list of _elements can change, and so some of them might not
-    // get propertly unregistered.
     for ( unsigned element : _elements )
         tableau->unregisterToWatchVariable( this, element );
 
@@ -106,11 +103,6 @@ void MaxConstraint::unregisterAsWatcher( ITableau *tableau )
 
 void MaxConstraint::notifyVariableValue( unsigned variable, double value )
 {
-    /*
-      Guy: I'm not sure I understand this condition. If _f is an
-      element, what is the _maxIndex? Is it always _f? Is it the
-      highest element if that's not _f?
-    */
     if ( ( _elements.exists( _f ) || variable != _f )
          &&
          ( !_maxIndexSet || _assignment.get( _maxIndex ) < value ) )

--- a/src/engine/MaxConstraint.cpp
+++ b/src/engine/MaxConstraint.cpp
@@ -280,10 +280,8 @@ void MaxConstraint::resetMaxIndex()
     double maxValue = FloatUtils::negativeInfinity();
     _maxIndexSet = false;
 
-    // Guy: it looks to me like the max index should be set even if
-    // only _f is assigned, if _f is in _elements. What do you think?
     if ( _assignment.empty() ||
-         ( _assignment.size() == 1 && _assignment.begin()->first == _f ) )
+         ( _assignment.size() == 1 && !_elements.exists( _f ) && _assignment.begin()->first == _f ) )
     {
         // If none of the variables has been assigned, the max index is
         // not set

--- a/src/engine/tests/Test_MaxConstraint.h
+++ b/src/engine/tests/Test_MaxConstraint.h
@@ -128,7 +128,7 @@ public:
 
 		max2.notifyVariableValue( f, 5 );
 		max2.notifyVariableValue( 8, 10 );
-		
+
 		TS_ASSERT( !max2.satisfied() );
 
 		// now f = 4
@@ -151,7 +151,7 @@ public:
 
 		TS_ASSERT( max2.satisfied() );
 
-		// now x_7 = 6
+		// now x_7 = 12
 		max2.notifyVariableValue( 7, 12 );
 
 		TS_ASSERT( !max2.satisfied() );
@@ -217,7 +217,7 @@ public:
 
 		//
 		// From here, the test is going to run tests for the case that f is included in elements.
-		// 
+		//
 		elements.insert( f );
 
 		MaxConstraint max2( f, elements );
@@ -230,7 +230,7 @@ public:
 
 		// no possible fix
 		fixes = max2.getPossibleFixes();
-		TS_ASSERT_EQUALS ( fixes.size(), 0U );
+		TS_ASSERT( fixes.empty() );
 
 		// f = 5, x_2 = 6, x_3 = 4
 		max2.notifyVariableValue( f, 5 );
@@ -239,7 +239,7 @@ public:
 
 		// possible fixes: set f to 6, x_2 to 5
 		fixes = max2.getPossibleFixes();
-		TS_ASSERT_EQUALS ( fixes.size(), 2U );
+		TS_ASSERT_EQUALS( fixes.size(), 2U );
 
 		it = fixes.begin();
 		TS_ASSERT_EQUALS( it->_variable, f );
@@ -256,12 +256,11 @@ public:
 
 		// possible fixes: set f to 7
 		fixes = max2.getPossibleFixes();
-		TS_ASSERT_EQUALS ( fixes.size(), 1U );
+		TS_ASSERT_EQUALS( fixes.size(), 1U );
 
 		it = fixes.begin();
 		TS_ASSERT_EQUALS( it->_variable, f );
 		TS_ASSERT_EQUALS( it->_value, 7 );
-
 	}
 
 	void test_max_case_splits()
@@ -280,7 +279,6 @@ public:
 		max.notifyVariableValue( f, 1 );
 		// f = max(x_2 ... x_9)
 		// f = 1
-		
 
 		List<PiecewiseLinearCaseSplit> splits = max.getCaseSplits();
 
@@ -341,7 +339,7 @@ public:
 
 		//
 		// From here, the test is going to run tests for the case that f is included in elements.
-		// 
+		//
 		elements.insert( f );
 		MaxConstraint max2( f, elements );
 
@@ -462,7 +460,7 @@ public:
 
 		//
 		// From here, the test is going to run tests for the case that f is included in elements.
-		// 
+		//
 		MaxConstraint max2( f, elements );
 
 		// all variables initially between 1 and 10
@@ -537,7 +535,7 @@ public:
 
 		//
 		// From here, the test is going to run tests for the case that f is included in elements.
-		// 
+		//
 		Set<unsigned> elements2;
 
 		elements2.insert( 1 );
@@ -742,7 +740,7 @@ public:
 		unsigned f = 1;
 		Set<unsigned> elements;
 		for ( unsigned i = 1; i < 4; ++i )
-			elements.insert( i );		
+			elements.insert( i );
 		MaxConstraint max( f, elements );
 
 		InputQuery inputQuery;

--- a/src/engine/tests/Test_MaxConstraint.h
+++ b/src/engine/tests/Test_MaxConstraint.h
@@ -222,15 +222,6 @@ public:
 
 		MaxConstraint max2( f, elements );
 
-		// f = max(x_1 ... x_9)
-		// f = 7, x_2 = 6, x_3 = 4
-		max2.notifyVariableValue( f, 7 );
-		max2.notifyVariableValue( 2, 6 );
-		max2.notifyVariableValue( 3, 4 );
-
-		// no possible fix
-		fixes = max2.getPossibleFixes();
-		TS_ASSERT( fixes.empty() );
 
 		// f = 5, x_2 = 6, x_3 = 4
 		max2.notifyVariableValue( f, 5 );
@@ -249,18 +240,6 @@ public:
 		TS_ASSERT_EQUALS ( it->_variable, 2U );
 		TS_ASSERT_EQUALS ( it->_value, 5 );
 
-		// f = 5, x_2 = 6, x_3 = 7
-		max2.notifyVariableValue( f, 5 );
-		max2.notifyVariableValue( 2, 6 );
-		max2.notifyVariableValue( 3, 7 );
-
-		// possible fixes: set f to 7
-		fixes = max2.getPossibleFixes();
-		TS_ASSERT_EQUALS( fixes.size(), 1U );
-
-		it = fixes.begin();
-		TS_ASSERT_EQUALS( it->_variable, f );
-		TS_ASSERT_EQUALS( it->_value, 7 );
 	}
 
 	void test_max_case_splits()
@@ -412,6 +391,7 @@ public:
         for( unsigned i = 3; i < 10; i++ )
             max.notifyUpperBound( i, 5 );
 
+		max.notifyVariableValue( 2, 7);
         // now, phase should be fixed to x_2; all other variables should be removed
         TS_ASSERT( max.phaseFixed() );
         TS_ASSERT_EQUALS( max.getParticipatingVariables().size(), 2U );
@@ -461,6 +441,7 @@ public:
             max2.notifyUpperBound( i, 5 );
         max2.notifyUpperBound( f, 5 );
 
+        max2.notifyVariableValue( f, 5);
         // now, phase should be fixed to x_2 and x_3; all other variables should be removed
         TS_ASSERT( max2.phaseFixed() );
         TS_ASSERT_EQUALS( max2.getParticipatingVariables().size(), 3U );

--- a/src/engine/tests/Test_MaxConstraint.h
+++ b/src/engine/tests/Test_MaxConstraint.h
@@ -712,21 +712,6 @@ public:
         TS_TRACE( "TODO: add a test for duplicate" );
     }
 
-	void test_max_add_auxiliary_equations()
-	{
-		unsigned f = 1;
-		Set<unsigned> elements;
-		for ( unsigned i = 1; i < 4; ++i )
-			elements.insert( i );
-		MaxConstraint max( f, elements );
-
-		InputQuery inputQuery;
-
-		max.addAuxiliaryEquations( inputQuery );
-
-		TS_ASSERT_EQUALS( inputQuery.getNumberOfVariables() , 2U );
-	}
-
     void test_serialize_and_unserialize()
     {
         unsigned f = 42;

--- a/src/engine/tests/Test_MaxConstraint.h
+++ b/src/engine/tests/Test_MaxConstraint.h
@@ -19,6 +19,7 @@
 #include "MockTableau.h"
 #include "PiecewiseLinearCaseSplit.h"
 #include "MarabouError.h"
+#include "InputQuery.h"
 
 #include <string.h>
 
@@ -103,6 +104,72 @@ public:
 		max.notifyVariableValue( f, 12 );
 
 		TS_ASSERT( max.satisfied() );
+
+		//
+		// From here, the test is going to run tests for the case that f is included in elements.
+		//
+		elements.insert( f );
+
+		MaxConstraint max2( f, elements );
+
+        TS_ASSERT_THROWS_NOTHING( participatingVariables = max2.getParticipatingVariables() );
+        TS_ASSERT_EQUALS( participatingVariables.size(), 9U );
+
+		it = participatingVariables.begin();
+		for ( unsigned i = 1; i < 10; ++i, ++it )
+			TS_ASSERT( max2.participatingVariable( i ) );
+
+        TS_ASSERT( !max2.participatingVariable( 20 ) );
+        TS_ASSERT( !max2.participatingVariable( 15 ) );
+
+		// f = max(x_1 ... x_9)
+		// f = 5
+		// x_8 = 10
+
+		max2.notifyVariableValue( f, 5 );
+		max2.notifyVariableValue( 8, 10 );
+		
+		TS_ASSERT( !max2.satisfied() );
+
+		// now f = 4
+		max2.notifyVariableValue( f, 4 );
+
+		TS_ASSERT( !max2.satisfied() );
+
+		// now x_8 = 4
+		max2.notifyVariableValue( 8, 4 );
+
+		TS_ASSERT( max2.satisfied() );
+
+		// now x_8 = 6
+		max2.notifyVariableValue( 8, 6 );
+
+		TS_ASSERT( !max2.satisfied() );
+
+		// now f = 6
+		max2.notifyVariableValue( f, 6 );
+
+		TS_ASSERT( max2.satisfied() );
+
+		// now x_7 = 6
+		max2.notifyVariableValue( 7, 12 );
+
+		TS_ASSERT( !max2.satisfied() );
+
+		// now f = 12
+		max2.notifyVariableValue( f, 12 );
+
+		TS_ASSERT( max2.satisfied() );
+
+		// now x_6 = 13
+		max2.notifyVariableValue( 6, 13 );
+
+		TS_ASSERT( !max2.satisfied() );
+
+		// now f = 14
+		max2.notifyVariableValue( f, 14 );
+
+		TS_ASSERT( max2.satisfied() );
 	}
 
 	void test_max_fixes()
@@ -147,6 +214,54 @@ public:
 		++it;
 		TS_ASSERT_EQUALS ( it->_variable, 2U );
 		TS_ASSERT_EQUALS ( it->_value, 5 );
+
+		//
+		// From here, the test is going to run tests for the case that f is included in elements.
+		// 
+		elements.insert( f );
+
+		MaxConstraint max2( f, elements );
+
+		// f = max(x_1 ... x_9)
+		// f = 7, x_2 = 6, x_3 = 4
+		max2.notifyVariableValue( f, 7 );
+		max2.notifyVariableValue( 2, 6 );
+		max2.notifyVariableValue( 3, 4 );
+
+		// no possible fix
+		fixes = max2.getPossibleFixes();
+		TS_ASSERT_EQUALS ( fixes.size(), 0U );
+
+		// f = 5, x_2 = 6, x_3 = 4
+		max2.notifyVariableValue( f, 5 );
+		max2.notifyVariableValue( 2, 6 );
+		max2.notifyVariableValue( 3, 4 );
+
+		// possible fixes: set f to 6, x_2 to 5
+		fixes = max2.getPossibleFixes();
+		TS_ASSERT_EQUALS ( fixes.size(), 2U );
+
+		it = fixes.begin();
+		TS_ASSERT_EQUALS( it->_variable, f );
+		TS_ASSERT_EQUALS( it->_value, 6 );
+
+		++it;
+		TS_ASSERT_EQUALS ( it->_variable, 2U );
+		TS_ASSERT_EQUALS ( it->_value, 5 );
+
+		// f = 5, x_2 = 6, x_3 = 7
+		max2.notifyVariableValue( f, 5 );
+		max2.notifyVariableValue( 2, 6 );
+		max2.notifyVariableValue( 3, 7 );
+
+		// possible fixes: set f to 7
+		fixes = max2.getPossibleFixes();
+		TS_ASSERT_EQUALS ( fixes.size(), 1U );
+
+		it = fixes.begin();
+		TS_ASSERT_EQUALS( it->_variable, f );
+		TS_ASSERT_EQUALS( it->_value, 7 );
+
 	}
 
 	void test_max_case_splits()
@@ -165,9 +280,7 @@ public:
 		max.notifyVariableValue( f, 1 );
 		// f = max(x_2 ... x_9)
 		// f = 1
-		Map<unsigned, double> assignment;
-
-		List<PiecewiseLinearConstraint::Fix> fixes;
+		
 
 		List<PiecewiseLinearCaseSplit> splits = max.getCaseSplits();
 
@@ -205,6 +318,76 @@ public:
             ++cur;
 
             for ( unsigned j = 2; j < 10;  ++j )
+            {
+                if ( i == j ) continue;
+
+                TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+                TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+                TS_ASSERT_EQUALS( cur->_type, Equation::GE );
+
+                auto addend = cur->_addends.begin();
+
+                TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+                TS_ASSERT_EQUALS( addend->_variable, j );
+
+                ++addend;
+
+                TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+                TS_ASSERT_EQUALS( addend->_variable, i );
+
+                ++cur;
+            }
+		}
+
+		//
+		// From here, the test is going to run tests for the case that f is included in elements.
+		// 
+		elements.insert( f );
+		MaxConstraint max2( f, elements );
+
+		for ( unsigned i = 1; i < 10; ++i )
+			max2.notifyVariableValue( i, i );
+
+		// f = max(x_1 ... x_9)
+		// f = 1
+		max2.notifyVariableValue( f, 1 );
+
+		splits = max2.getCaseSplits();
+
+		// there are 9 possible phases
+		TS_ASSERT_EQUALS( splits.size(), 9U );
+
+		split = splits.begin();
+		for ( unsigned i = 1; i < 10; ++i, ++split )
+		{
+            List<Tightening> bounds = split->getBoundTightenings();
+
+            // Since no upper bounds known for any of the variables, no bounds
+            TS_ASSERT_EQUALS( bounds.size(), 0U );
+
+            auto equations = split->getEquations();
+
+            TS_ASSERT_EQUALS( equations.size(), 9U );
+
+            auto cur = equations.begin();
+
+            TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+            TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+            TS_ASSERT_EQUALS( cur->_type, Equation::EQ );
+
+            auto addend = cur->_addends.begin();
+
+            TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+            TS_ASSERT_EQUALS( addend->_variable, i );
+
+            ++addend;
+
+            TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+            TS_ASSERT_EQUALS( addend->_variable, f );
+
+            ++cur;
+
+            for ( unsigned j = 1; j < 10;  ++j )
             {
                 if ( i == j ) continue;
 
@@ -276,6 +459,52 @@ public:
 
         TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
         TS_ASSERT_EQUALS( addend->_variable, f );
+
+		//
+		// From here, the test is going to run tests for the case that f is included in elements.
+		// 
+		MaxConstraint max2( f, elements );
+
+		// all variables initially between 1 and 10
+		for ( unsigned i = 1; i < 10; i++ )
+        {
+			max2.notifyUpperBound( i, 10 );
+			max2.notifyLowerBound( i, 1 );
+		}
+
+		TS_ASSERT( !max2.phaseFixed() );
+
+		// set x_2 to be at least 6, others to be at most 5
+		max2.notifyLowerBound( 2, 6 );
+		for( unsigned i = 3; i < 10; i++ )
+			max2.notifyUpperBound( i, 5 );
+		max2.notifyUpperBound( f, 5 );
+
+		// now, phase should be fixed to x_2; all other variables should be removed
+		TS_ASSERT( max2.phaseFixed() );
+		TS_ASSERT_EQUALS( max2.getParticipatingVariables().size(), 2U );
+
+        max2.notifyVariableValue( 2, 7);
+
+        validSplit = max2.getValidCaseSplit();
+		equations = validSplit.getEquations();
+
+        TS_ASSERT_EQUALS( equations.size(), 1U );
+
+        cur = equations.begin();
+        TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+        TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+        TS_ASSERT_EQUALS( cur->_type, Equation::EQ );
+
+        addend = cur->_addends.begin();
+
+        TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, 2U );
+
+        ++addend;
+
+        TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, f );
 	}
 
 	void test_max_var_elims()
@@ -305,6 +534,37 @@ public:
 		max.notifyLowerBound( 2, 7 );
 		TS_ASSERT( max.getParticipatingVariables().exists( 2 ) );
 		TS_ASSERT( !max.getParticipatingVariables().exists( 3 ) );
+
+		//
+		// From here, the test is going to run tests for the case that f is included in elements.
+		// 
+		Set<unsigned> elements2;
+
+		elements2.insert( 1 );
+		elements2.insert( 2 );
+		elements2.insert( 3 );
+
+		MaxConstraint max2( f, elements2 );
+
+		max2.notifyUpperBound( 2, 8 );
+		max2.notifyLowerBound( 2, 1 );
+		max2.notifyUpperBound( 3, 6 );
+		max2.notifyLowerBound( 3, 1 );
+
+		max2.notifyUpperBound( 1, 6 );
+		max2.notifyLowerBound( 1, 0 );
+		TS_ASSERT( max2.getParticipatingVariables().exists( 1 ) );
+		TS_ASSERT( max2.getParticipatingVariables().exists( 2 ) );
+		TS_ASSERT( max2.getParticipatingVariables().exists( 3 ) );
+
+		max2.notifyLowerBound( 2, 7 );
+		TS_ASSERT( max2.getParticipatingVariables().exists( 1 ) );
+		TS_ASSERT( max2.getParticipatingVariables().exists( 2 ) );
+		TS_ASSERT( !max2.getParticipatingVariables().exists( 3 ) );
+
+		max2.notifyUpperBound( 1, 5 );
+		TS_ASSERT( max2.serializeToString() == "max,1,1,2" );
+		TS_ASSERT( max2.getParticipatingVariables().exists( 2 ) );
 	}
 
     void test_get_entailed_tightenings()
@@ -338,14 +598,49 @@ public:
         TS_ASSERT_EQUALS( it->_variable, 1U );
         TS_ASSERT_EQUALS( it->_value, 1 );
         TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+
+
+		//
+		// From here, the test is going to run tests for the case that f is included in elements.
+		//
+		Set<unsigned> elements2;
+		elements2.insert( 1 );
+		elements2.insert( 2 );
+		elements2.insert( 3 );
+
+		MaxConstraint max2( f, elements2 );
+
+		// No lower bound for 1
+		max2.notifyUpperBound( 1, 7 );
+
+		max2.notifyLowerBound( 2, 1 );
+    	max2.notifyUpperBound( 2, 8 );
+
+        // No lower bound for 3
+    	max2.notifyUpperBound( 3, 6 );
+
+		List<Tightening> tightenings2;
+        TS_ASSERT_THROWS_NOTHING( max2.getEntailedTightenings( tightenings2 ) );
+
+        // expect f to be in the range [1, 7], x2 to be in the range [1, 7]
+        TS_ASSERT_EQUALS( tightenings2.size(), 2U );
+        it = tightenings2.begin();
+
+        TS_ASSERT_EQUALS( it->_variable, 2U );
+        TS_ASSERT_EQUALS( it->_value, 7 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+        ++it;
+
+        TS_ASSERT_EQUALS( it->_variable, 1U );
+        TS_ASSERT_EQUALS( it->_value, 1 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
 	}
 
 	void test_max_obsolete()
     {
 		unsigned f = 1;
 		Set<unsigned> elements;
-
-		MockTableau tableau;
 
 		for ( unsigned i = 2; i < 10; ++i )
 			elements.insert( i );
@@ -364,6 +659,13 @@ public:
 		TS_ASSERT( !max2.constraintObsolete() );
 		max2.eliminateVariable( 1, 0 );
 		TS_ASSERT( max2.constraintObsolete() );
+
+		elements.insert( 1 );
+		MaxConstraint max3( f, elements );
+		for(unsigned i = 2; i < 10; i++ )
+			max3.eliminateVariable( i, 0 );
+
+		TS_ASSERT( max3.constraintObsolete() );
 	}
 
 	void test_register_as_watcher()
@@ -398,10 +700,57 @@ public:
 		}
 	}
 
+	void test_register_as_watcher2()
+	{
+		unsigned f = 1;
+		Set<unsigned> elements;
+
+		MockTableau tableau;
+
+		for ( unsigned i = 1; i < 10; ++i )
+			elements.insert( i );
+
+		MaxConstraint max( f, elements );
+
+		TS_ASSERT_THROWS_NOTHING( max.registerAsWatcher( &tableau ) );
+		TS_ASSERT_EQUALS( tableau.lastRegisteredVariableToWatcher.size(), 9U );
+		for ( int i = 1; i < 10; ++i )
+		{
+			TS_ASSERT_EQUALS( tableau.lastRegisteredVariableToWatcher[i].size(), 1U );
+			TS_ASSERT( tableau.lastRegisteredVariableToWatcher[i].exists( &max ) );
+		}
+		tableau.lastRegisteredVariableToWatcher.clear();
+
+		TS_ASSERT_THROWS_NOTHING( max.unregisterAsWatcher( &tableau ) );
+
+		TS_ASSERT( tableau.lastRegisteredVariableToWatcher.empty() );
+		TS_ASSERT_EQUALS( tableau.lastUnregisteredVariableToWatcher.size(), 9U );
+		for ( int i = 1; i < 10; ++i )
+		{
+            TS_ASSERT_EQUALS( tableau.lastUnregisteredVariableToWatcher[i].size(), 1U );
+            TS_ASSERT( tableau.lastUnregisteredVariableToWatcher[i].exists( &max ) );
+		}
+	}
+
     void test_max_duplicate()
     {
         TS_TRACE( "TODO: add a test for duplicate" );
     }
+
+	void test_max_add_auxiliary_equations()
+	{
+		unsigned f = 1;
+		Set<unsigned> elements;
+		for ( unsigned i = 1; i < 4; ++i )
+			elements.insert( i );		
+		MaxConstraint max( f, elements );
+
+		InputQuery inputQuery;
+
+		max.addAuxiliaryEquations( inputQuery );
+
+		TS_ASSERT_EQUALS( inputQuery.getNumberOfVariables() , 2U );
+	}
 
     void test_serialize_and_unserialize()
     {


### PR DESCRIPTION
Signed-off-by: tagomaru <tagomaru@users.noreply.github.com>

This PR is going to improve _addMaxConstraints_ function.

### As-Is
It supports only the case of _max([A, B], C])._

### To-Be
It supports the case of _max([A, B, C], C)_ as well.


### Sample NNET:
```
// simple_model 
2,2,3,3,
2,2,3,
0,
-100000.0,-100000.0,
100000.0,100000.0,
0.0,0.0,0.0,
1.0,1.0,1.0,
1.0,1.0,
-1.0,-1.0,
0.0,
0.0,
2.0,-1.0,
-1.0,1.0,
1.0,-1.0,
0.0,
0.0,
0.0,
```
### Test for the above net
Command:
```
nnet_file_name = "./simple_model.nnet"
net = marabou.read_nnet(nnet_file_name)

net.addMaxConstraint(set(net.outputVars[0]), net.outputVars[0][0])
net.setLowerBound(net.outputVars[0][0], 2)
net.setUpperBound(net.inputVars[0][0], 1)

vals, stats = net.solve()
```

The result:
```
sat
input 0 = 1.0
input 1 = -0.0
output 0 = 2.0
output 1 = -1.0
output 2 = 1.0
```

![image](https://user-images.githubusercontent.com/17696068/91681956-ea359c80-eb04-11ea-9709-c37ed3147865.png)


