### PR TITLE
SmtCore.cpp compilation issue - "copy from type const Tightening"

### DIFF
--- a/src/engine/SmtCore.cpp
+++ b/src/engine/SmtCore.cpp
@@ -336,7 +336,7 @@ bool SmtCore::splitAllowsStoredSolution( const PiecewiseLinearCaseSplit &split, 
     if ( _debuggingSolution.empty() )
         return true;
 
-    for ( const auto bound : split.getBoundTightenings() )
+    for ( const auto &bound : split.getBoundTightenings() )
     {
         unsigned variable = bound._variable;
 

--- a/src/engine/SmtCore.cpp
+++ b/src/engine/SmtCore.cpp
@@ -451,11 +451,3 @@ bool SmtCore::pickSplitPLConstraint()
         _constraintForSplitting = _engine->pickSplitPLConstraint();
     return _constraintForSplitting != NULL;
 }
-
-//
-// Local Variables:
-// compile-command: "make -C ../.. "
-// tags-file-name: "../../TAGS"
-// c-basic-offset: 4
-// End:
-//


### PR DESCRIPTION
Running "cmake --build ." causes the compiler to throw an error stating
that we should be using a reference instead of copying the "Tightening"
object. This PR just fixes the compilation error.

Marabou/src/engine/SmtCore.cpp:339:22: error: loop
      variable 'bound' of type 'const Tightening' creates a copy from type 'const Tightening'
      [-Werror,-Wrange-loop-analysis]
    for ( const auto bound : split.getBoundTightenings() )
                     ^
Marabou/src/engine/SmtCore.cpp:339:11: note: use
      reference type 'const Tightening &' to prevent copying
    for ( const auto bound : split.getBoundTightenings() )
          ^~~~~~~~~~~~~~~~~~