### PR TITLE
Polarity in sign constraint

### DIFF
--- a/maraboupy/Marabou.py
+++ b/maraboupy/Marabou.py
@@ -120,7 +120,7 @@ def solve_query(ipq, filename="", verbose=True, options=None):
 def createOptions(numWorkers=1, initialTimeout=5, initialDivides=0, onlineDivides=2,
                   timeoutInSeconds=0, timeoutFactor=1.5, verbosity=2, snc=False,
                   splittingStrategy="auto", sncSplittingStrategy="auto",
-                  restoreTreeState=False ):
+                  restoreTreeStates=False ):
     """Create an options object for how Marabou should solve the query
 
     Args:

--- a/maraboupy/Marabou.py
+++ b/maraboupy/Marabou.py
@@ -118,8 +118,9 @@ def solve_query(ipq, filename="", verbose=True, options=None):
     return [vals, stats]
 
 def createOptions(numWorkers=1, initialTimeout=5, initialDivides=0, onlineDivides=2,
-                  timeoutInSeconds=0, timeoutFactor=1.5, verbosity=2, dnc=False,
-                  splittingStrategy="auto", sncSplittingStrategy="auto" ):
+                  timeoutInSeconds=0, timeoutFactor=1.5, verbosity=2, snc=False,
+                  splittingStrategy="auto", sncSplittingStrategy="auto",
+                  restoreTreeState=False ):
     """Create an options object for how Marabou should solve the query
 
     Args:
@@ -132,9 +133,11 @@ def createOptions(numWorkers=1, initialTimeout=5, initialDivides=0, onlineDivide
         timeoutInSeconds (int, optional): Timeout duration for Marabouin seconds, defaults to 0
         timeoutFactor (float, optional): Timeout factor for DNC mode, defaults to 1.5
         verbosity (int, optional): Verbosity level for Marabou, defaults to 2
-        dnc (bool, optional): If DNC mode should be used, defaults to False
-        splittingStrategy (string, optional): Specifies which partitioning strategy to use (auto/largest-interval/relu-violation/polarity/earliest-relu).
+        snc (bool, optional): If SnC mode should be used, defaults to False
+        splittingStrategy (string, optional): Specifies which partitioning strategy to use (auto/largest-interval/relu-violation/polarity/earliest-relu)
         sncSplittingStrategy (string, optional): Specifies which partitioning strategy to use in the DNC mode (auto/largest-interval/polarity).
+        restoreTreeStates (bool, optional): Whether to restore tree states in dnc mode,defaults to False
+
     Returns:
         :class:`~maraboupy.MarabouCore.Options`
     """
@@ -146,7 +149,8 @@ def createOptions(numWorkers=1, initialTimeout=5, initialDivides=0, onlineDivide
     options._timeoutInSeconds = timeoutInSeconds
     options._timeoutFactor = timeoutFactor
     options._verbosity = verbosity
-    options._dnc = dnc
+    options._snc = snc
     options._splittingStrategy = splittingStrategy
     options._sncSplittingStrategy = sncSplittingStrategy
+    options._restoreTreeStates = restoreTreeStates
     return options

--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -123,8 +123,8 @@ void createInputQuery(InputQuery &inputQuery, std::string networkFilePath, std::
 
 struct MarabouOptions {
     MarabouOptions()
-        : _dnc( Options::get()->getBool( Options::DNC_MODE ) )
-        , _restoreTreeStates( options::get()->getBool( Options::RESTORE_TREE_STATES ) )
+        : _snc( Options::get()->getBool( Options::DNC_MODE ) )
+        , _restoreTreeStates( Options::get()->getBool( Options::RESTORE_TREE_STATES ) )
         , _numWorkers( Options::get()->getInt( Options::NUM_WORKERS ) )
         , _initialTimeout( Options::get()->getInt( Options::INITIAL_TIMEOUT ) )
         , _initialDivides( Options::get()->getInt( Options::NUM_INITIAL_DIVIDES ) )
@@ -139,7 +139,7 @@ struct MarabouOptions {
   void setOptions()
   {
     // Bool options
-    Options::get()->setBool( Options::DNC_MODE, _dnc );
+    Options::get()->setBool( Options::DNC_MODE, _snc );
     Options::get()->setBool( Options::RESTORE_TREE_STATES, _restoreTreeStates );
 
     // int options
@@ -158,7 +158,7 @@ struct MarabouOptions {
     Options::get()->setString( Options::SNC_SPLITTING_STRATEGY, _sncSplittingStrategyString );
   }
 
-    bool _dnc;
+    bool _snc;
     bool _restoreTreeStates;
     unsigned _numWorkers;
     unsigned _initialTimeout;
@@ -342,7 +342,7 @@ PYBIND11_MODULE(MarabouCore, m) {
         .def_readwrite("_timeoutFactor", &MarabouOptions::_timeoutFactor)
         .def_readwrite("_verbosity", &MarabouOptions::_verbosity)
         .def_readwrite("_snc", &MarabouOptions::_snc)
-        .def_readwrite("_restoretreestates", &MarabouOptions::_restoreTreeStates)
+        .def_readwrite("_restoreTreeStates", &MarabouOptions::_restoreTreeStates)
         .def_readwrite("_splittingStrategy", &MarabouOptions::_splittingStrategyString)
         .def_readwrite("_sncSplittingStrategy", &MarabouOptions::_sncSplittingStrategyString);
     py::enum_<PiecewiseLinearFunctionType>(m, "PiecewiseLinearFunctionType")

--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -124,6 +124,7 @@ void createInputQuery(InputQuery &inputQuery, std::string networkFilePath, std::
 struct MarabouOptions {
     MarabouOptions()
         : _dnc( Options::get()->getBool( Options::DNC_MODE ) )
+        , _restoreTreeStates( options::get()->getBool( Options::RESTORE_TREE_STATES ) )
         , _numWorkers( Options::get()->getInt( Options::NUM_WORKERS ) )
         , _initialTimeout( Options::get()->getInt( Options::INITIAL_TIMEOUT ) )
         , _initialDivides( Options::get()->getInt( Options::NUM_INITIAL_DIVIDES ) )
@@ -139,6 +140,7 @@ struct MarabouOptions {
   {
     // Bool options
     Options::get()->setBool( Options::DNC_MODE, _dnc );
+    Options::get()->setBool( Options::RESTORE_TREE_STATES, _restoreTreeStates );
 
     // int options
     Options::get()->setInt( Options::NUM_WORKERS, _numWorkers );
@@ -157,6 +159,7 @@ struct MarabouOptions {
   }
 
     bool _dnc;
+    bool _restoreTreeStates;
     unsigned _numWorkers;
     unsigned _initialTimeout;
     unsigned _initialDivides;
@@ -338,7 +341,8 @@ PYBIND11_MODULE(MarabouCore, m) {
         .def_readwrite("_timeoutInSeconds", &MarabouOptions::_timeoutInSeconds)
         .def_readwrite("_timeoutFactor", &MarabouOptions::_timeoutFactor)
         .def_readwrite("_verbosity", &MarabouOptions::_verbosity)
-        .def_readwrite("_dnc", &MarabouOptions::_dnc)
+        .def_readwrite("_snc", &MarabouOptions::_snc)
+        .def_readwrite("_restoretreestates", &MarabouOptions::_restoreTreeStates)
         .def_readwrite("_splittingStrategy", &MarabouOptions::_splittingStrategyString)
         .def_readwrite("_sncSplittingStrategy", &MarabouOptions::_sncSplittingStrategyString);
     py::enum_<PiecewiseLinearFunctionType>(m, "PiecewiseLinearFunctionType")

--- a/maraboupy/examples/4_DncExample.py
+++ b/maraboupy/examples/4_DncExample.py
@@ -29,6 +29,6 @@ net.setLowerBound(net.outputVars[0][0], .5)
 
 # %%
 # Solve the query with DNC mode turned on, which should return satisfying variable values
-options = Marabou.createOptions(dnc=True, verbosity=0, initialDivides=2);
+options = Marabou.createOptions(snc=True, verbosity=0, initialDivides=2);
 vals, stats = net.solve(options=options)
 assert len(vals) > 0

--- a/maraboupy/test/test_dnc.py
+++ b/maraboupy/test/test_dnc.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 
 # Global settings
-OPT = Marabou.createOptions(verbosity=0, dnc=True, numWorkers=2) # Turn off printing, turn on DNC with two workers
+OPT = Marabou.createOptions(verbosity=0, snc=True, numWorkers=2) # Turn off printing, turn on DNC with two workers
 TOL = 1e-6                                                       # Set tolerance for checking Marabou evaluations
 NETWORK_FOLDER = "../../resources/nnet/acasxu"                   # Folder for test network
 

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -2117,8 +2117,8 @@ PiecewiseLinearConstraint *Engine::pickSplitPLConstraintSnC( SnCDivideStrategy s
 
     ENGINE_LOG( Stringf( "Done updating scores..." ).ascii() );
     ENGINE_LOG( Stringf( ( candidatePLConstraint ?
-                           "Unable to pick using the current strategy..." :
-                           "Picked..." ) ).ascii() );
+                           "Picked..." :
+                           "Unable to pick using the current strategy..." ) ).ascii() );
     return candidatePLConstraint;
 }
 

--- a/src/engine/SignConstraint.cpp
+++ b/src/engine/SignConstraint.cpp
@@ -29,6 +29,7 @@
 SignConstraint::SignConstraint( unsigned b, unsigned f )
     : _b( b )
     , _f( f )
+    , _direction( PhaseStatus::PHASE_NOT_FIXED )
     , _haveEliminatedVariables( false )
 {
     setPhaseStatus( PhaseStatus::PHASE_NOT_FIXED );
@@ -116,6 +117,19 @@ List<PiecewiseLinearCaseSplit> SignConstraint::getCaseSplits() const
         throw MarabouError( MarabouError::REQUESTED_CASE_SPLITS_FROM_FIXED_CONSTRAINT );
 
     List <PiecewiseLinearCaseSplit> splits;
+
+    if ( _direction == PHASE_NEGATIVE )
+    {
+      splits.append( getNegativeSplit() );
+      splits.append( getPositiveSplit() );
+      return splits;
+    }
+    if ( _direction == PHASE_POSITIVE )
+    {
+      splits.append( getPositiveSplit() );
+      splits.append( getNegativeSplit() );
+      return splits;
+    }
 
     // If we have existing knowledge about the assignment, use it to
     // influence the order of splits
@@ -438,4 +452,35 @@ void SignConstraint::dump( String &output ) const
     output += Stringf( "f in [%s, %s]\n",
                        _lowerBounds.exists( _f ) ? Stringf( "%lf", _lowerBounds[_f] ).ascii() : "-inf",
                        _upperBounds.exists( _f ) ? Stringf( "%lf", _upperBounds[_f] ).ascii() : "inf" );
+}
+
+double SignConstraint::computePolarity() const
+{
+  double currentLb = _lowerBounds[_b];
+  double currentUb = _upperBounds[_b];
+  if ( currentLb >= 0 ) return 1;
+  if ( currentUb <= 0 ) return -1;
+  double width = currentUb - currentLb;
+  double sum = currentUb + currentLb;
+  return sum / width;
+}
+
+void SignConstraint::updateDirection()
+{
+  _direction = ( computePolarity() > 0 ) ? PHASE_POSITIVE : PHASE_NEGATIVE;
+}
+
+SignConstraint::PhaseStatus SignConstraint::getDirection() const
+{
+  return _direction;
+}
+
+void SignConstraint::updateScoreBasedOnPolarity()
+{
+  _score = std::abs( computePolarity() );
+}
+
+bool SignConstraint::supportPolarity() const
+{
+  return true;
 }

--- a/src/engine/SignConstraint.cpp
+++ b/src/engine/SignConstraint.cpp
@@ -458,8 +458,8 @@ double SignConstraint::computePolarity() const
 {
   double currentLb = _lowerBounds[_b];
   double currentUb = _upperBounds[_b];
-  if ( currentLb >= 0 ) return 1;
-  if ( currentUb <= 0 ) return -1;
+  if ( !FloatUtils::isNegative( currentLb ) ) return 1;
+  if ( FloatUtils::isNegative( currentUb ) ) return -1;
   double width = currentUb - currentLb;
   double sum = currentUb + currentLb;
   return sum / width;
@@ -467,7 +467,8 @@ double SignConstraint::computePolarity() const
 
 void SignConstraint::updateDirection()
 {
-  _direction = ( computePolarity() > 0 ) ? PHASE_POSITIVE : PHASE_NEGATIVE;
+    _direction = ( FloatUtils::isNegative( computePolarity() ) ) ?
+        PHASE_NEGATIVE : PHASE_POSITIVE;
 }
 
 SignConstraint::PhaseStatus SignConstraint::getDirection() const

--- a/src/engine/SignConstraint.h
+++ b/src/engine/SignConstraint.h
@@ -157,7 +157,7 @@ public:
     the bound of the input to this ReLU is with respect to 0.
     Let LB be the lowerbound, and UB be the upperbound.
     If LB >= 0, polarity is 1.
-    If UB <= 0, polarity is -1.
+    If UB < 0, polarity is -1.
     If LB < 0, and UB > 0, polarity is ( LB + UB ) / (UB - LB).
 
     We divide the sum by the width of the interval so that the polarity is

--- a/src/engine/SignConstraint.h
+++ b/src/engine/SignConstraint.h
@@ -150,9 +150,40 @@ public:
     unsigned getB() const;
     unsigned getF() const;
 
+  bool supportPolarity() const;
+
+  /*
+    Return the polarity of the Sign Constraint, which computes how symmetric
+    the bound of the input to this ReLU is with respect to 0.
+    Let LB be the lowerbound, and UB be the upperbound.
+    If LB >= 0, polarity is 1.
+    If UB <= 0, polarity is -1.
+    If LB < 0, and UB > 0, polarity is ( LB + UB ) / (UB - LB).
+
+    We divide the sum by the width of the interval so that the polarity is
+    always between -1 and 1. The closer it is to 0, the more symmetric the
+    bound is.
+  */
+  double computePolarity() const;
+
+  /*
+    Update the preferred direction for fixing and handling case split
+  */
+  void updateDirection();
+
+  PhaseStatus getDirection() const;
+
+  void updateScoreBasedOnPolarity();
+
 private:
     unsigned _b, _f;
     PhaseStatus _phaseStatus;
+
+    /*
+      Denotes which case split to handle first.
+      And which phase status to repair a relu into.
+    */
+    PhaseStatus _direction;
 
     PiecewiseLinearCaseSplit getNegativeSplit() const;
     PiecewiseLinearCaseSplit getPositiveSplit() const;

--- a/src/engine/tests/Test_SignConstraint.h
+++ b/src/engine/tests/Test_SignConstraint.h
@@ -967,7 +967,7 @@ public:
             TS_ASSERT( sign.computePolarity() == 0 );
 
             sign.updateDirection();
-            TS_ASSERT( sign.getDirection() == SignConstraint::PHASE_NEGATIVE );
+            TS_ASSERT( sign.getDirection() == SignConstraint::PHASE_POSITIVE );
 
             auto splits = sign.getCaseSplits();
             auto it = splits.begin();

--- a/src/engine/tests/Test_SignConstraint.h
+++ b/src/engine/tests/Test_SignConstraint.h
@@ -931,4 +931,63 @@ public:
         TS_ASSERT_EQUALS( originalSign.serializeToString(),
                           recoveredSign.serializeToString() );
     }
+
+      void test_polarity()
+    {
+        unsigned b = 1;
+        unsigned f = 4;
+
+        // b in [1, 2], polarity should be 1, and direction should be PHASE_POSITIVE
+        {
+            SignConstraint sign( b, f );
+            sign.notifyLowerBound( b, 1 );
+            sign.notifyUpperBound( b, 2 );
+            TS_ASSERT( sign.computePolarity() == 1 );
+
+            sign.updateDirection();
+            TS_ASSERT( sign.getDirection() == SignConstraint::PHASE_POSITIVE );
+        }
+        // b in [-2, 0], polarity should be -1, and direction should be PHASE_NEGATIVE
+        {
+            SignConstraint sign( b, f );
+            sign.notifyLowerBound( b, -2 );
+            sign.notifyUpperBound( b, 0 );
+            TS_ASSERT( sign.computePolarity() == -1 );
+
+            sign.updateDirection();
+            TS_ASSERT( sign.getDirection() == SignConstraint::PHASE_NEGATIVE );
+        }
+        // b in [-2, 2], polarity should be 0, the direction should be PHASE_NEGATIVE,
+        // the inactive case should be the first element of the returned list by
+        // the getCaseSplits()
+        {
+            SignConstraint sign( b, f );
+            sign.notifyLowerBound( b, -2 );
+            sign.notifyUpperBound( b, 2 );
+            TS_ASSERT( sign.computePolarity() == 0 );
+
+            sign.updateDirection();
+            TS_ASSERT( sign.getDirection() == SignConstraint::PHASE_NEGATIVE );
+
+            auto splits = sign.getCaseSplits();
+            auto it = splits.begin();
+            TS_ASSERT( isNegativeSplit( b, f, it ) );
+        }
+        // b in [-2, 3], polarity should be 0.2, the direction should be PHASE_POSITIVE,
+        // the active case should be the first element of the returned list by
+        // the getCaseSplits()
+        {
+            SignConstraint sign( b, f );
+            sign.notifyLowerBound( b, -2 );
+            sign.notifyUpperBound( b, 3 );
+            TS_ASSERT( sign.computePolarity() == 0.2 );
+
+            sign.updateDirection();
+            TS_ASSERT( sign.getDirection() == SignConstraint::PHASE_POSITIVE );
+
+            auto splits = sign.getCaseSplits();
+            auto it = splits.begin();
+            TS_ASSERT( isPositiveSplit( b, f, it ) );
+        }
+    }
 };

--- a/src/engine/tests/Test_SignConstraint.h
+++ b/src/engine/tests/Test_SignConstraint.h
@@ -971,7 +971,7 @@ public:
 
             auto splits = sign.getCaseSplits();
             auto it = splits.begin();
-            TS_ASSERT( isNegativeSplit( b, f, it ) );
+            TS_ASSERT( isPositiveSplit( b, f, it ) );
         }
         // b in [-2, 3], polarity should be 0.2, the direction should be PHASE_POSITIVE,
         // the active case should be the first element of the returned list by


### PR DESCRIPTION
Currently for BNNs, only input splitting is supported in SnC mode. This PR extends the notion of polarity to Sign constraint, thus enabling the same branching heuristic as relu-splitting used in SnC for BNNs. 