### PR TITLE
Bug fix in getting objective from Gurobi

### DIFF
--- a/src/common/GurobiWrapper.cpp
+++ b/src/common/GurobiWrapper.cpp
@@ -198,13 +198,6 @@ void GurobiWrapper::setCost( const List<Term> &terms )
         }
 
         _model->setObjective( cost, GRB_MINIMIZE );
-
-        // From https://www.gurobi.com/documentation/9.0/refman/py_model_setattr.html
-        // due to our lazy update approach, the change won't actually take effect until you
-        // update the model (using Model.update), optimize the model (using Model.optimize),
-        // or write the model to disk (using Model.write).
-        _model->update();
-        ASSERT( _model->get( GRB_IntAttr_ModelSense ) == 1 );
     }
     catch ( GRBException e )
     {
@@ -228,9 +221,6 @@ void GurobiWrapper::setObjective( const List<Term> &terms )
         }
 
         _model->setObjective( cost, GRB_MAXIMIZE );
-
-        _model->update();
-        ASSERT( _model->get( GRB_IntAttr_ModelSense ) == -1 );
     }
     catch ( GRBException e )
     {
@@ -317,6 +307,12 @@ double GurobiWrapper::getObjectiveBound()
         log( "Failed to get objective bound from Gurobi." );
         if ( e.getErrorCode() == GRB_ERROR_DATA_NOT_AVAILABLE )
         {
+            // From https://www.gurobi.com/documentation/9.0/refman/py_model_setattr.html
+            // due to our lazy update approach, the change won't actually take effect until you
+            // update the model (using Model.update), optimize the model (using Model.optimize),
+            // or write the model to disk (using Model.write).
+            _model->update();
+
             if ( _model->get( GRB_IntAttr_ModelSense ) == 1 )
                 // case Minimize
                 return FloatUtils::negativeInfinity();

--- a/src/common/GurobiWrapper.cpp
+++ b/src/common/GurobiWrapper.cpp
@@ -314,7 +314,7 @@ double GurobiWrapper::getObjectiveBound()
             _model->update();
 
             if ( _model->get( GRB_IntAttr_ModelSense ) == 1 )
-                // case Minimize
+                // case minimize
                 return FloatUtils::negativeInfinity();
             else
                 // case maximize

--- a/src/common/GurobiWrapper.cpp
+++ b/src/common/GurobiWrapper.cpp
@@ -2,7 +2,7 @@
 /*! \file GurobiWrapper.cpp
  ** \verbatim
  ** Top contributors (to current version):
- **   Guy Katz
+ **   Guy Katz, Haoze Andrew Wu
  ** This file is part of the Marabou project.
  ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
@@ -16,6 +16,7 @@
 #ifdef ENABLE_GUROBI
 
 #include "Debug.h"
+#include "FloatUtils.h"
 #include "GlobalConfiguration.h"
 #include "GurobiWrapper.h"
 #include "MStringf.h"
@@ -197,6 +198,13 @@ void GurobiWrapper::setCost( const List<Term> &terms )
         }
 
         _model->setObjective( cost, GRB_MINIMIZE );
+
+        // From https://www.gurobi.com/documentation/9.0/refman/py_model_setattr.html
+        // due to our lazy update approach, the change won't actually take effect until you
+        // update the model (using Model.update), optimize the model (using Model.optimize),
+        // or write the model to disk (using Model.write).
+        _model->update();
+        ASSERT( _model->get( GRB_IntAttr_ModelSense ) == 1 );
     }
     catch ( GRBException e )
     {
@@ -220,6 +228,9 @@ void GurobiWrapper::setObjective( const List<Term> &terms )
         }
 
         _model->setObjective( cost, GRB_MAXIMIZE );
+
+        _model->update();
+        ASSERT( _model->get( GRB_IntAttr_ModelSense ) == -1 );
     }
     catch ( GRBException e )
     {
@@ -297,12 +308,38 @@ void GurobiWrapper::extractSolution( Map<String, double> &values, double &costOr
 
 double GurobiWrapper::getObjectiveBound()
 {
-    return _model->get( GRB_DoubleAttr_ObjBound );
+    try
+    {
+        return _model->get( GRB_DoubleAttr_ObjBound );
+    }
+    catch ( GRBException e )
+    {
+        log( "Failed to get objective bound from Gurobi." );
+        if ( e.getErrorCode() == GRB_ERROR_DATA_NOT_AVAILABLE )
+        {
+            if ( _model->get( GRB_IntAttr_ModelSense ) == 1 )
+                // case Minimize
+                return FloatUtils::negativeInfinity();
+            else
+                // case maximize
+                return FloatUtils::infinity();
+        }
+        throw CommonError( CommonError::GUROBI_EXCEPTION,
+                           Stringf( "Gurobi exception. Gurobi Code: %u, message: %s\n",
+                                    e.getErrorCode(),
+                                    e.getMessage().c_str() ).ascii() );
+    }
 }
 
 void GurobiWrapper::dumpModel( String name )
 {
     _model->write( name.ascii() );
+}
+
+void GurobiWrapper::log( const String &message )
+{
+    if ( GlobalConfiguration::GUROBI_LOGGING )
+        printf( "GurobiWrapper: %s\n", message.ascii() );
 }
 
 #endif // ENABLE_GUROBI

--- a/src/common/GurobiWrapper.h
+++ b/src/common/GurobiWrapper.h
@@ -122,7 +122,6 @@ private:
     Map<String, GRBVar *> _nameToVariable;
     double _timeoutInSeconds;
 
-
     void addConstraint( const List<Term> &terms, double scalar, char sense );
 
     void freeModelIfNeeded();

--- a/src/common/GurobiWrapper.h
+++ b/src/common/GurobiWrapper.h
@@ -122,10 +122,13 @@ private:
     Map<String, GRBVar *> _nameToVariable;
     double _timeoutInSeconds;
 
+
     void addConstraint( const List<Term> &terms, double scalar, char sense );
 
     void freeModelIfNeeded();
     void freeMemoryIfNeeded();
+
+    static void log( const String &message );
 };
 
 #else
@@ -175,6 +178,7 @@ public:
     void setTimeLimit( double ) {};
     double getObjectiveBound() { return 0; };
     void dump() {}
+    static void log( const String & );
 };
 
 #endif // ENABLE_GUROBI

--- a/src/configuration/GlobalConfiguration.cpp
+++ b/src/configuration/GlobalConfiguration.cpp
@@ -79,7 +79,7 @@ const GlobalConfiguration::ExplicitBasisBoundTighteningType GlobalConfiguration:
 const bool GlobalConfiguration::EXPLICIT_BOUND_TIGHTENING_UNTIL_SATURATION = false;
 
 const GlobalConfiguration::MILPSolverBoundTighteningType GlobalConfiguration::MILP_SOLVER_BOUND_TIGHTENING_TYPE =
-    GlobalConfiguration::MILP_ENCODING;
+    GlobalConfiguration::LP_RELAXATION;
 
 const unsigned GlobalConfiguration::REFACTORIZATION_THRESHOLD = 100;
 const GlobalConfiguration::BasisFactorizationType GlobalConfiguration::BASIS_FACTORIZATION_TYPE =

--- a/src/configuration/GlobalConfiguration.cpp
+++ b/src/configuration/GlobalConfiguration.cpp
@@ -79,7 +79,7 @@ const GlobalConfiguration::ExplicitBasisBoundTighteningType GlobalConfiguration:
 const bool GlobalConfiguration::EXPLICIT_BOUND_TIGHTENING_UNTIL_SATURATION = false;
 
 const GlobalConfiguration::MILPSolverBoundTighteningType GlobalConfiguration::MILP_SOLVER_BOUND_TIGHTENING_TYPE =
-    GlobalConfiguration::LP_RELAXATION;
+    GlobalConfiguration::MILP_ENCODING;
 
 const unsigned GlobalConfiguration::REFACTORIZATION_THRESHOLD = 100;
 const GlobalConfiguration::BasisFactorizationType GlobalConfiguration::BASIS_FACTORIZATION_TYPE =
@@ -91,6 +91,7 @@ const unsigned GlobalConfiguration::DNC_DEPTH_THRESHOLD = 5;
 
 #ifdef ENABLE_GUROBI
 const unsigned GlobalConfiguration::GUROBI_NUMBER_OF_THREADS = 1;
+const bool GlobalConfiguration::GUROBI_LOGGING = false;
 #endif // ENABLE_GUROBI
 
 // Logging - note that it is enabled only in Debug mode

--- a/src/configuration/GlobalConfiguration.h
+++ b/src/configuration/GlobalConfiguration.h
@@ -244,6 +244,7 @@ public:
       The number of threads Gurobi spawns
     */
     static const unsigned GUROBI_NUMBER_OF_THREADS;
+    static const bool GUROBI_LOGGING;
 #endif // ENABLE_GUROBI
 
     /*


### PR DESCRIPTION
Before the following command would result in an Gurobi error:

`./Marabou ../resources/nnet/acasxu/ACASXU_experimental_v2a_2_9.nnet ../resources/properties/acas_property_1.txt --milp-timeout=0.001 `

This is because getObjectiveBound is not protected when no satisfying assignment is found. This PR fixes this bug.