### PR TITLE
fixing the issue of MILPEncoder

### DIFF
--- a/src/engine/MILPEncoder.cpp
+++ b/src/engine/MILPEncoder.cpp
@@ -70,7 +70,7 @@ void MILPEncoder::encodeEquation( GurobiWrapper &gurobi, const Equation &equatio
 {
     List<GurobiWrapper::Term> terms;
     double scalar = equation._scalar;
-    for ( const auto& term : equation._addends )
+    for ( const auto &term : equation._addends )
         terms.append( GurobiWrapper::Term
                       ( term._coefficient,
                         Stringf( "x%u", term._variable ) ) );

--- a/src/engine/MILPEncoder.cpp
+++ b/src/engine/MILPEncoder.cpp
@@ -70,7 +70,7 @@ void MILPEncoder::encodeEquation( GurobiWrapper &gurobi, const Equation &equatio
 {
     List<GurobiWrapper::Term> terms;
     double scalar = equation._scalar;
-    for ( const auto term : equation._addends )
+    for ( const auto& term : equation._addends )
         terms.append( GurobiWrapper::Term
                       ( term._coefficient,
                         Stringf( "x%u", term._variable ) ) );


### PR DESCRIPTION
Signed-off-by: tagomaru <tagomaru@users.noreply.github.com>

This PR is going to fix the compile issue of MILPEncoder.cpp.
I got the below error on macOS.

```
$ cmake --build . 
[  0%] Building CXX object CMakeFiles/MarabouHelper.dir/src/engine/MILPEncoder.cpp.o
/Users/XXX/Documents/work/Marabou/src/engine/MILPEncoder.cpp:73:22: error: loop variable 'term' of type 'const Equation::Addend' creates a copy from
      type 'const Equation::Addend' [-Werror,-Wrange-loop-analysis]
    for ( const auto term : equation._addends )
                     ^
/Users/XXX/Documents/work/Marabou/src/engine/MILPEncoder.cpp:73:11: note: use reference type 'const Equation::Addend &' to prevent copying
    for ( const auto term : equation._addends )
          ^~~~~~~~~~~~~~~~~
                     &
1 error generated.
```

I think this problem does not happen on Ubuntu and Windows.