### PR TITLE
Fix in property parser

### DIFF
--- a/src/input_parsers/PropertyParser.cpp
+++ b/src/input_parsers/PropertyParser.cpp
@@ -26,8 +26,8 @@ static double extractScalar( const String &token )
     double value = std::stod( token.ascii(), &end );
     if ( end != token.length() )
     {
-	throw InputParserError( InputParserError::UNEXPECTED_INPUT, Stringf( "Token %s not a scalar",
-									    token.ascii() ).ascii() );
+	throw InputParserError( InputParserError::UNEXPECTED_INPUT, Stringf( "%s not a scalar",
+									     token.ascii() ).ascii() );
     }
     return value;
 }

--- a/src/input_parsers/PropertyParser.cpp
+++ b/src/input_parsers/PropertyParser.cpp
@@ -26,7 +26,8 @@ static double extractScalar( const String &token )
     double value = std::stod( token.ascii(), &end );
     if ( end != token.length() )
     {
-	throw InputParserError( InputParserError::UNEXPECTED_INPUT, "Failed to extract scalar" );
+	throw InputParserError( InputParserError::UNEXPECTED_INPUT, Stringf( "Token %s not a scalar",
+									    token.ascii() ).ascii() );
     }
     return value;
 }

--- a/src/input_parsers/PropertyParser.cpp
+++ b/src/input_parsers/PropertyParser.cpp
@@ -20,23 +20,21 @@
 #include "PropertyParser.h"
 #include <regex>
 
-static bool isScalar( const String &token )
-{
-    const std::regex floatRegex( "[-+]?[0-9]*\\.?[0-9]+" );
-    return std::regex_match( token.ascii(), floatRegex );
-}
-
 static double extractScalar( const String &token )
 {
-    return atof( token.ascii() );
+    std::string::size_type end;
+    double value = std::stod( token.ascii(), &end );
+    if ( end != token.length() )
+    {
+	throw InputParserError( InputParserError::UNEXPECTED_INPUT, "Failed to extract scalar" );
+    }
+    return value;
 }
 
 void PropertyParser::parse( const String &propertyFilePath, InputQuery &inputQuery )
 {
     if ( !File::exists( propertyFilePath ) )
     {
-        printf( "Error: the specified property file (%s) doesn't exist!\n", propertyFilePath.ascii() );
-        throw InputParserError( InputParserError::FILE_DOESNT_EXIST, propertyFilePath.ascii() );
     }
 
     File propertyFile( propertyFilePath );
@@ -66,12 +64,6 @@ void PropertyParser::processSingleLine( const String &line, InputQuery &inputQue
         throw InputParserError( InputParserError::UNEXPECTED_INPUT, line.ascii() );
 
     auto it = tokens.rbegin();
-    if ( !isScalar( *it ) )
-    {
-        Stringf message( "Right handside must be scalar in the line: %s", line.ascii() );
-        throw InputParserError( InputParserError::UNEXPECTED_INPUT, message.ascii() );
-    }
-
     double scalar = extractScalar( *it );
     ++it;
     Equation::EquationType type = extractRelationSymbol( *it );

--- a/src/input_parsers/PropertyParser.cpp
+++ b/src/input_parsers/PropertyParser.cpp
@@ -35,6 +35,8 @@ void PropertyParser::parse( const String &propertyFilePath, InputQuery &inputQue
 {
     if ( !File::exists( propertyFilePath ) )
     {
+	printf( "Error: the specified property file (%s) doesn't exist!\n", propertyFilePath.ascii() );
+	throw InputParserError( InputParserError::FILE_DOESNT_EXIST, propertyFilePath.ascii() );
     }
 
     File propertyFile( propertyFilePath );

--- a/src/input_parsers/PropertyParser.cpp
+++ b/src/input_parsers/PropertyParser.cpp
@@ -18,7 +18,6 @@
 #include "InputParserError.h"
 #include "MStringf.h"
 #include "PropertyParser.h"
-#include <regex>
 
 static double extractScalar( const String &token )
 {


### PR DESCRIPTION
The check for scalar on the right hand side throws error on scientific notations. This PR fixes that. 