### PR TITLE
Refactor _phaseStatus from individual classes into PiecewiseLinearConstraint

### DIFF
--- a/src/engine/AbsoluteValueConstraint.cpp
+++ b/src/engine/AbsoluteValueConstraint.cpp
@@ -29,7 +29,6 @@ AbsoluteValueConstraint::AbsoluteValueConstraint( unsigned b, unsigned f )
     , _auxVarsInUse( false )
     , _haveEliminatedVariables( false )
 {
-    setPhaseStatus( PhaseStatus::PHASE_NOT_FIXED );
 }
 
 AbsoluteValueConstraint::AbsoluteValueConstraint( const String &serializedAbs )
@@ -65,8 +64,6 @@ AbsoluteValueConstraint::AbsoluteValueConstraint( const String &serializedAbs )
 
         _auxVarsInUse = true;
     }
-
-    setPhaseStatus( PhaseStatus::PHASE_NOT_FIXED );
 }
 
 PiecewiseLinearFunctionType AbsoluteValueConstraint::getType() const
@@ -383,9 +380,9 @@ bool AbsoluteValueConstraint::phaseFixed() const
 
 PiecewiseLinearCaseSplit AbsoluteValueConstraint::getValidCaseSplit() const
 {
-    ASSERT( _phaseStatus != PhaseStatus::PHASE_NOT_FIXED );
+    ASSERT( _phaseStatus != PHASE_NOT_FIXED );
 
-    if ( _phaseStatus == PhaseStatus::PHASE_POSITIVE )
+    if ( _phaseStatus == ABS_PHASE_POSITIVE )
         return getPositiveSplit();
 
     return getNegativeSplit();
@@ -647,14 +644,14 @@ void AbsoluteValueConstraint::fixPhaseIfNeeded()
     // Option 1: b's range is strictly positive
     if ( _lowerBounds.exists( _b ) && _lowerBounds[_b] >= 0 )
     {
-        setPhaseStatus( PHASE_POSITIVE );
+        setPhaseStatus( ABS_PHASE_POSITIVE );
         return;
     }
 
     // Option 2: b's range is strictly negative:
     if ( _upperBounds.exists( _b ) && _upperBounds[_b] <= 0 )
     {
-        setPhaseStatus( PHASE_NEGATIVE );
+        setPhaseStatus( ABS_PHASE_NEGATIVE );
         return;
     }
 
@@ -665,7 +662,7 @@ void AbsoluteValueConstraint::fixPhaseIfNeeded()
     // range
     if ( _upperBounds.exists( _b ) && _lowerBounds[_f] > _upperBounds[_b] )
     {
-        setPhaseStatus( PHASE_NEGATIVE );
+        setPhaseStatus( ABS_PHASE_NEGATIVE );
         return;
     }
 
@@ -673,41 +670,37 @@ void AbsoluteValueConstraint::fixPhaseIfNeeded()
     // range, in absolute value
     if ( _lowerBounds.exists( _b ) && _lowerBounds[_f] > -_lowerBounds[_b] )
     {
-        setPhaseStatus( PHASE_POSITIVE );
+        setPhaseStatus( ABS_PHASE_POSITIVE );
         return;
     }
 
     if ( _auxVarsInUse )
     {
         // Option 5: posAux has become zero, phase is positive
-        if ( _upperBounds.exists( _posAux )
-             && FloatUtils::isZero( _upperBounds[_posAux] ) )
+        if ( _upperBounds.exists( _posAux ) && FloatUtils::isZero( _upperBounds[_posAux] ) )
         {
-            setPhaseStatus( PHASE_POSITIVE );
+            setPhaseStatus( ABS_PHASE_POSITIVE );
             return;
         }
 
         // Option 6: posAux can never be zero, phase is negative
-        if ( _lowerBounds.exists( _posAux )
-             && FloatUtils::isPositive( _lowerBounds[_posAux] ) )
+        if ( _lowerBounds.exists( _posAux ) && FloatUtils::isPositive( _lowerBounds[_posAux] ) )
         {
-            setPhaseStatus( PHASE_NEGATIVE );
+            setPhaseStatus( ABS_PHASE_NEGATIVE );
             return;
         }
 
         // Option 7: negAux has become zero, phase is negative
-        if ( _upperBounds.exists( _negAux )
-             && FloatUtils::isZero( _upperBounds[_negAux] ) )
+        if ( _upperBounds.exists( _negAux ) && FloatUtils::isZero( _upperBounds[_negAux] ) )
         {
-            setPhaseStatus( PHASE_NEGATIVE );
+            setPhaseStatus( ABS_PHASE_NEGATIVE );
             return;
         }
 
         // Option 8: negAux can never be zero, phase is positive
-        if ( _lowerBounds.exists( _negAux )
-             && FloatUtils::isPositive( _lowerBounds[_negAux] ) )
+        if ( _lowerBounds.exists( _negAux ) && FloatUtils::isPositive( _lowerBounds[_negAux] ) )
         {
-            setPhaseStatus( PHASE_POSITIVE );
+            setPhaseStatus( ABS_PHASE_POSITIVE );
             return;
         }
     }
@@ -720,21 +713,16 @@ String AbsoluteValueConstraint::phaseToString( PhaseStatus phase )
     case PHASE_NOT_FIXED:
         return "PHASE_NOT_FIXED";
 
-    case PHASE_POSITIVE:
-        return "PHASE_POSITIVE";
+    case ABS_PHASE_POSITIVE:
+        return "ABS_PHASE_POSITIVE";
 
-    case PHASE_NEGATIVE:
-        return "PHASE_NEGATIVE";
+    case ABS_PHASE_NEGATIVE:
+        return "ABS_PHASE_NEGATIVE";
 
     default:
         return "UNKNOWN";
     }
 };
-
-void AbsoluteValueConstraint::setPhaseStatus( PhaseStatus phaseStatus )
-{
-    _phaseStatus = phaseStatus;
-}
 
 //
 // Local Variables:

--- a/src/engine/AbsoluteValueConstraint.h
+++ b/src/engine/AbsoluteValueConstraint.h
@@ -22,12 +22,6 @@ class AbsoluteValueConstraint : public PiecewiseLinearConstraint
 {
 
 public:
-    enum PhaseStatus {
-        PHASE_NOT_FIXED = 0,
-        PHASE_POSITIVE = 1,
-        PHASE_NEGATIVE = 2,
-    };
-
     /*
       The f variable is the absolute value of the b variable:
       f = | b |
@@ -163,13 +157,6 @@ private:
       True iff _b or _f have been eliminated.
     */
     bool _haveEliminatedVariables;
-
-    /*
-      The phase status of this constraint: positive, negative, or not
-      yet fixed.
-    */
-    PhaseStatus _phaseStatus;
-    void setPhaseStatus( PhaseStatus phaseStatus );
 
     static String phaseToString( PhaseStatus phase );
 

--- a/src/engine/PiecewiseLinearConstraint.cpp
+++ b/src/engine/PiecewiseLinearConstraint.cpp
@@ -18,6 +18,7 @@
 
 PiecewiseLinearConstraint::PiecewiseLinearConstraint()
     : _constraintActive( true )
+    , _phaseStatus( PHASE_NOT_FIXED )
     , _score( FloatUtils::negativeInfinity() )
     , _constraintBoundTightener( NULL )
     , _statistics( NULL )

--- a/src/engine/PiecewiseLinearConstraint.h
+++ b/src/engine/PiecewiseLinearConstraint.h
@@ -39,7 +39,7 @@ enum PhaseStatus : unsigned {
     ABS_PHASE_NEGATIVE = 4,
     SIGN_PHASE_POSITIVE = 5,
     SIGN_PHASE_NEGATIVE = 6
-;
+};
 
 class PiecewiseLinearConstraint : public ITableau::VariableWatcher
 {

--- a/src/engine/PiecewiseLinearConstraint.h
+++ b/src/engine/PiecewiseLinearConstraint.h
@@ -265,7 +265,8 @@ public:
 
 protected:
     bool _constraintActive;
-	Map<unsigned, double> _assignment;
+    PhaseStatus _phaseStatus;
+    Map<unsigned, double> _assignment;
     Map<unsigned, double> _lowerBounds;
     Map<unsigned, double> _upperBounds;
 
@@ -282,6 +283,20 @@ protected:
       Statistics collection
     */
     Statistics *_statistics;
+
+    /*
+      Set the phase status of the constraint. Uses the global PhaseStatus
+      enumeration and is initialized to PHASE_NOT_FIXED for all constraints.
+     */
+    void setPhaseStatus( PhaseStatus phase )
+    {
+        _phaseStatus = phase;
+    };
+
+    PhaseStatus getPhaseStatus() const
+    {
+        return _phaseStatus;
+    };
 };
 
 #endif // __PiecewiseLinearConstraint_h__

--- a/src/engine/PiecewiseLinearConstraint.h
+++ b/src/engine/PiecewiseLinearConstraint.h
@@ -31,6 +31,17 @@ class ITableau;
 class InputQuery;
 class String;
 
+enum PhaseStatus : unsigned {
+    PHASE_NOT_FIXED = 0,
+    RELU_PHASE_ACTIVE = 1,
+    RELU_PHASE_INACTIVE = 2,
+    ABS_PHASE_POSITIVE = 3,
+    ABS_PHASE_NEGATIVE = 4,
+    SIGN_PHASE_POSITIVE = 5,
+    SIGN_PHASE_NEGATIVE = 6
+
+};
+
 class PiecewiseLinearConstraint : public ITableau::VariableWatcher
 {
 public:

--- a/src/engine/PiecewiseLinearConstraint.h
+++ b/src/engine/PiecewiseLinearConstraint.h
@@ -39,8 +39,7 @@ enum PhaseStatus : unsigned {
     ABS_PHASE_NEGATIVE = 4,
     SIGN_PHASE_POSITIVE = 5,
     SIGN_PHASE_NEGATIVE = 6
-
-};
+;
 
 class PiecewiseLinearConstraint : public ITableau::VariableWatcher
 {

--- a/src/engine/ReluConstraint.h
+++ b/src/engine/ReluConstraint.h
@@ -23,12 +23,6 @@
 class ReluConstraint : public PiecewiseLinearConstraint
 {
 public:
-    enum PhaseStatus {
-        PHASE_NOT_FIXED = 0,
-        PHASE_ACTIVE = 1,
-        PHASE_INACTIVE = 2,
-    };
-
     /*
       The f variable is the relu output on the b variable:
       f = relu( b )
@@ -158,11 +152,6 @@ public:
     unsigned getF() const;
 
     /*
-      Get the current phase status.
-    */
-    PhaseStatus getPhaseStatus() const;
-
-    /*
       Check if the aux variable is in use and retrieve it
     */
     bool auxVariableInUse() const;
@@ -195,7 +184,6 @@ public:
 
 private:
     unsigned _b, _f;
-    PhaseStatus _phaseStatus;
     bool _auxVarInUse;
     unsigned _aux;
 
@@ -209,11 +197,6 @@ private:
     PiecewiseLinearCaseSplit getActiveSplit() const;
 
     bool _haveEliminatedVariables;
-
-    /*
-      Set the phase status.
-    */
-    void setPhaseStatus( PhaseStatus phaseStatus );
 
     static String phaseToString( PhaseStatus phase );
 

--- a/src/engine/SignConstraint.cpp
+++ b/src/engine/SignConstraint.cpp
@@ -29,10 +29,9 @@
 SignConstraint::SignConstraint( unsigned b, unsigned f )
     : _b( b )
     , _f( f )
-    , _direction( PhaseStatus::PHASE_NOT_FIXED )
+    , _direction( PHASE_NOT_FIXED )
     , _haveEliminatedVariables( false )
 {
-    setPhaseStatus( PhaseStatus::PHASE_NOT_FIXED );
 }
 
 SignConstraint::SignConstraint( const String &serializedSign )
@@ -51,8 +50,6 @@ SignConstraint::SignConstraint( const String &serializedSign )
     _f = atoi( var->ascii() );
     ++var;
     _b = atoi( var->ascii() );
-
-    setPhaseStatus( PhaseStatus::PHASE_NOT_FIXED );
 }
 
 PiecewiseLinearFunctionType SignConstraint::getType() const
@@ -113,18 +110,18 @@ bool SignConstraint::satisfied() const
 
 List<PiecewiseLinearCaseSplit> SignConstraint::getCaseSplits() const
 {
-    if ( _phaseStatus != PhaseStatus::PHASE_NOT_FIXED )
+    if ( _phaseStatus != PHASE_NOT_FIXED )
         throw MarabouError( MarabouError::REQUESTED_CASE_SPLITS_FROM_FIXED_CONSTRAINT );
 
     List <PiecewiseLinearCaseSplit> splits;
 
-    if ( _direction == PHASE_NEGATIVE )
+    if ( _direction == SIGN_PHASE_NEGATIVE )
     {
       splits.append( getNegativeSplit() );
       splits.append( getPositiveSplit() );
       return splits;
     }
-    if ( _direction == PHASE_POSITIVE )
+    if ( _direction == SIGN_PHASE_POSITIVE )
     {
       splits.append( getPositiveSplit() );
       splits.append( getNegativeSplit() );
@@ -176,14 +173,14 @@ PiecewiseLinearCaseSplit SignConstraint::getPositiveSplit() const
 
 bool SignConstraint::phaseFixed() const
 {
-    return _phaseStatus != PhaseStatus::PHASE_NOT_FIXED;
+    return _phaseStatus != PHASE_NOT_FIXED;
 }
 
 PiecewiseLinearCaseSplit SignConstraint::getValidCaseSplit() const
 {
-    ASSERT( _phaseStatus != PhaseStatus::PHASE_NOT_FIXED );
+    ASSERT( _phaseStatus != PHASE_NOT_FIXED );
 
-    if ( _phaseStatus == PhaseStatus::PHASE_POSITIVE )
+    if ( _phaseStatus == PhaseStatus::SIGN_PHASE_POSITIVE )
         return getPositiveSplit();
 
     return getNegativeSplit();
@@ -221,11 +218,11 @@ String SignConstraint::phaseToString( PhaseStatus phase )
         case PHASE_NOT_FIXED:
             return "PHASE_NOT_FIXED";
 
-        case PHASE_POSITIVE:
-            return "PHASE_POSITIVE";
+        case SIGN_PHASE_POSITIVE:
+            return "SIGN_PHASE_POSITIVE";
 
-        case PHASE_NEGATIVE:
-            return "PHASE_NEGATIVE";
+        case SIGN_PHASE_NEGATIVE:
+            return "SIGN_PHASE_NEGATIVE";
 
         default:
             return "UNKNOWN";
@@ -254,7 +251,7 @@ void SignConstraint::notifyLowerBound( unsigned variable, double bound )
 
     if ( variable == _f && FloatUtils::gt( bound, -1 ) )
     {
-        setPhaseStatus( PhaseStatus::PHASE_POSITIVE );
+        setPhaseStatus( PhaseStatus::SIGN_PHASE_POSITIVE );
         if ( _constraintBoundTightener )
         {
             _constraintBoundTightener->registerTighterLowerBound( _f, 1 );
@@ -263,7 +260,7 @@ void SignConstraint::notifyLowerBound( unsigned variable, double bound )
     }
     else if ( variable == _b && !FloatUtils::isNegative( bound ) )
     {
-        setPhaseStatus( PhaseStatus::PHASE_POSITIVE );
+        setPhaseStatus( PhaseStatus::SIGN_PHASE_POSITIVE );
         if ( _constraintBoundTightener )
         {
             _constraintBoundTightener->registerTighterLowerBound( _f, 1 );
@@ -285,7 +282,7 @@ void SignConstraint::notifyUpperBound( unsigned variable, double bound )
 
     if ( variable == _f && FloatUtils::lt( bound, 1 ) )
     {
-        setPhaseStatus( PhaseStatus::PHASE_NEGATIVE );
+        setPhaseStatus( PhaseStatus::SIGN_PHASE_NEGATIVE );
         if ( _constraintBoundTightener )
         {
             _constraintBoundTightener->registerTighterUpperBound( _f, -1 );
@@ -294,7 +291,7 @@ void SignConstraint::notifyUpperBound( unsigned variable, double bound )
     }
     else if ( variable == _b && FloatUtils::isNegative( bound ) )
     {
-        setPhaseStatus( PhaseStatus::PHASE_NEGATIVE );
+        setPhaseStatus( PhaseStatus::SIGN_PHASE_NEGATIVE );
         if ( _constraintBoundTightener )
         {
             _constraintBoundTightener->registerTighterUpperBound( _f, -1 );
@@ -403,22 +400,22 @@ void SignConstraint::eliminateVariable( __attribute__((unused)) unsigned variabl
 
                   if ( FloatUtils::areEqual( fixedValue, 1 ) )
                   {
-                      ASSERT( _phaseStatus != PHASE_NEGATIVE );
+                      ASSERT( _phaseStatus != SIGN_PHASE_NEGATIVE );
                   }
                   else if (FloatUtils::areEqual( fixedValue, -1 ) )
                   {
-                      ASSERT( _phaseStatus != PHASE_POSITIVE );
+                      ASSERT( _phaseStatus != SIGN_PHASE_POSITIVE );
                   }
               }
               else if ( variable == _b )
               {
                   if ( FloatUtils::gte( fixedValue, 0 ) )
                   {
-                      ASSERT( _phaseStatus != PHASE_NEGATIVE );
+                      ASSERT( _phaseStatus != SIGN_PHASE_NEGATIVE );
                   }
                   else if ( FloatUtils::lt( fixedValue, 0 ) )
                   {
-                      ASSERT( _phaseStatus != PHASE_POSITIVE );
+                      ASSERT( _phaseStatus != SIGN_PHASE_POSITIVE );
                   }
               }
         });
@@ -468,10 +465,10 @@ double SignConstraint::computePolarity() const
 void SignConstraint::updateDirection()
 {
     _direction = ( FloatUtils::isNegative( computePolarity() ) ) ?
-        PHASE_NEGATIVE : PHASE_POSITIVE;
+        SIGN_PHASE_NEGATIVE : SIGN_PHASE_POSITIVE;
 }
 
-SignConstraint::PhaseStatus SignConstraint::getDirection() const
+PhaseStatus SignConstraint::getDirection() const
 {
   return _direction;
 }

--- a/src/engine/SignConstraint.h
+++ b/src/engine/SignConstraint.h
@@ -27,12 +27,6 @@
 class SignConstraint : public PiecewiseLinearConstraint
 {
 public:
-    enum PhaseStatus {
-        PHASE_NOT_FIXED = 0,
-        PHASE_POSITIVE = 1,
-        PHASE_NEGATIVE = 2,
-    };
-
     /*
       The f variable is the sign output on the b variable:
       f = sign( b )
@@ -177,11 +171,10 @@ public:
 
 private:
     unsigned _b, _f;
-    PhaseStatus _phaseStatus;
 
     /*
       Denotes which case split to handle first.
-      And which phase status to repair a relu into.
+      And which phase status to repair a constraint into.
     */
     PhaseStatus _direction;
 

--- a/src/engine/tests/Test_ReluConstraint.h
+++ b/src/engine/tests/Test_ReluConstraint.h
@@ -1141,7 +1141,7 @@ public:
         inactivePhase.storeBoundTightening( Tightening( b, 0.0, Tightening::UB ) );
         inactivePhase.storeBoundTightening( Tightening( f, 0.0, Tightening::UB ) );
 
-        // b in [1, 2], polarity should be 1, and direction should be PHASE_ACTIVE
+        // b in [1, 2], polarity should be 1, and direction should be RELU_PHASE_ACTIVE
         {
             ReluConstraint relu( b, f );
             relu.notifyLowerBound( b, 1 );
@@ -1149,9 +1149,9 @@ public:
             TS_ASSERT( relu.computePolarity() == 1 );
 
             relu.updateDirection();
-            TS_ASSERT( relu.getDirection() == ReluConstraint::PHASE_ACTIVE );
+            TS_ASSERT( relu.getDirection() == RELU_PHASE_ACTIVE );
         }
-        // b in [-2, 0], polarity should be -1, and direction should be PHASE_INACTIVE
+        // b in [-2, 0], polarity should be -1, and direction should be RELU_PHASE_INACTIVE
         {
             ReluConstraint relu( b, f );
             relu.notifyLowerBound( b, -2 );
@@ -1159,9 +1159,9 @@ public:
             TS_ASSERT( relu.computePolarity() == -1 );
 
             relu.updateDirection();
-            TS_ASSERT( relu.getDirection() == ReluConstraint::PHASE_INACTIVE );
+            TS_ASSERT( relu.getDirection() == RELU_PHASE_INACTIVE );
         }
-        // b in [-2, 2], polarity should be 0, the direction should be PHASE_INACTIVE,
+        // b in [-2, 2], polarity should be 0, the direction should be RELU_PHASE_INACTIVE,
         // the inactive case should be the first element of the returned list by
         // the getCaseSplits(), and getPossibleFix should return the inactive fix first
         {
@@ -1171,7 +1171,7 @@ public:
             TS_ASSERT( relu.computePolarity() == 0 );
 
             relu.updateDirection();
-            TS_ASSERT( relu.getDirection() == ReluConstraint::PHASE_INACTIVE );
+            TS_ASSERT( relu.getDirection() == RELU_PHASE_INACTIVE );
 
             auto splits = relu.getCaseSplits();
             auto it = splits.begin();
@@ -1192,7 +1192,7 @@ public:
             TS_ASSERT_EQUALS( itFix->_value, 1 );
 
         }
-        // b in [-2, 3], polarity should be 0.2, the direction should be PHASE_ACTIVE,
+        // b in [-2, 3], polarity should be 0.2, the direction should be RELU_PHASE_ACTIVE,
         // the active case should be the first element of the returned list by
         // the getCaseSplits(), and getPossibleFix should return the active fix first
         {
@@ -1202,7 +1202,7 @@ public:
             TS_ASSERT( relu.computePolarity() == 0.2 );
 
             relu.updateDirection();
-            TS_ASSERT( relu.getDirection() == ReluConstraint::PHASE_ACTIVE );
+            TS_ASSERT( relu.getDirection() == RELU_PHASE_ACTIVE );
 
             auto splits = relu.getCaseSplits();
             auto it = splits.begin();

--- a/src/engine/tests/Test_SignConstraint.h
+++ b/src/engine/tests/Test_SignConstraint.h
@@ -937,7 +937,7 @@ public:
         unsigned b = 1;
         unsigned f = 4;
 
-        // b in [1, 2], polarity should be 1, and direction should be PHASE_POSITIVE
+        // b in [1, 2], polarity should be 1, and direction should be SIGN_PHASE_POSITIVE
         {
             SignConstraint sign( b, f );
             sign.notifyLowerBound( b, 1 );
@@ -945,9 +945,9 @@ public:
             TS_ASSERT( sign.computePolarity() == 1 );
 
             sign.updateDirection();
-            TS_ASSERT( sign.getDirection() == SignConstraint::PHASE_POSITIVE );
+            TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
         }
-        // b in [-2, 0], polarity should be -1, and direction should be PHASE_NEGATIVE
+        // b in [-2, 0], polarity should be -1, and direction should be SIGN_PHASE_NEGATIVE
         {
             SignConstraint sign( b, f );
             sign.notifyLowerBound( b, -2 );
@@ -955,9 +955,9 @@ public:
             TS_ASSERT( sign.computePolarity() == -1 );
 
             sign.updateDirection();
-            TS_ASSERT( sign.getDirection() == SignConstraint::PHASE_NEGATIVE );
+            TS_ASSERT( sign.getDirection() == SIGN_PHASE_NEGATIVE );
         }
-        // b in [-2, 2], polarity should be 0, the direction should be PHASE_NEGATIVE,
+        // b in [-2, 2], polarity should be 0, the direction should be SIGN_PHASE_NEGATIVE,
         // the inactive case should be the first element of the returned list by
         // the getCaseSplits()
         {
@@ -967,13 +967,13 @@ public:
             TS_ASSERT( sign.computePolarity() == 0 );
 
             sign.updateDirection();
-            TS_ASSERT( sign.getDirection() == SignConstraint::PHASE_POSITIVE );
+            TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
 
             auto splits = sign.getCaseSplits();
             auto it = splits.begin();
             TS_ASSERT( isPositiveSplit( b, f, it ) );
         }
-        // b in [-2, 3], polarity should be 0.2, the direction should be PHASE_POSITIVE,
+        // b in [-2, 3], polarity should be 0.2, the direction should be SIGN_PHASE_POSITIVE,
         // the active case should be the first element of the returned list by
         // the getCaseSplits()
         {
@@ -983,7 +983,7 @@ public:
             TS_ASSERT( sign.computePolarity() == 0.2 );
 
             sign.updateDirection();
-            TS_ASSERT( sign.getDirection() == SignConstraint::PHASE_POSITIVE );
+            TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
 
             auto splits = sign.getCaseSplits();
             auto it = splits.begin();

--- a/src/nlr/Layer.cpp
+++ b/src/nlr/Layer.cpp
@@ -693,13 +693,13 @@ void Layer::computeSymbolicBoundsForRelu()
           1. If the ReLU's variable has been externally fixed
           2. lbLb >= 0 (ACTIVE) or ubUb <= 0 (INACTIVE)
         */
-        ReluConstraint::PhaseStatus reluPhase = ReluConstraint::PHASE_NOT_FIXED;
+        PhaseStatus reluPhase = PHASE_NOT_FIXED;
 
         // Has the f variable been eliminated or fixed?
         if ( FloatUtils::isPositive( _lb[i] ) )
-            reluPhase = ReluConstraint::PHASE_ACTIVE;
+            reluPhase = RELU_PHASE_ACTIVE;
         else if ( FloatUtils::isZero( _ub[i] ) )
-            reluPhase = ReluConstraint::PHASE_INACTIVE;
+            reluPhase = RELU_PHASE_INACTIVE;
 
         ASSERT( _neuronToActivationSources.exists( i ) );
         NeuronIndex sourceIndex = *_neuronToActivationSources[i].begin();
@@ -732,14 +732,14 @@ void Layer::computeSymbolicBoundsForRelu()
         // Has the b variable been fixed?
         if ( !FloatUtils::isNegative( sourceLb ) )
         {
-            reluPhase = ReluConstraint::PHASE_ACTIVE;
+            reluPhase = RELU_PHASE_ACTIVE;
         }
         else if ( !FloatUtils::isPositive( sourceUb ) )
         {
-            reluPhase = ReluConstraint::PHASE_INACTIVE;
+            reluPhase = RELU_PHASE_INACTIVE;
         }
 
-        if ( reluPhase == ReluConstraint::PHASE_NOT_FIXED )
+        if ( reluPhase == PHASE_NOT_FIXED )
         {
             // If we got here, we know that lbLb < 0 and ubUb
             // > 0 There are four possible cases, depending on
@@ -782,7 +782,7 @@ void Layer::computeSymbolicBoundsForRelu()
         else
         {
             // The phase of this ReLU is fixed!
-            if ( reluPhase == ReluConstraint::PHASE_ACTIVE )
+            if ( reluPhase == RELU_PHASE_ACTIVE )
             {
                 // Active ReLU, bounds are propagated as is
             }
@@ -854,13 +854,13 @@ void Layer::computeSymbolicBoundsForSign()
           1. If the Sign's variable has been externally fixed
           2. lbLb >= 0 (Positive) or ubUb < 0 (Negative)
         */
-        SignConstraint::PhaseStatus signPhase = SignConstraint::PHASE_NOT_FIXED;
+        PhaseStatus signPhase = PHASE_NOT_FIXED;
 
         // Has the f variable been eliminated or fixed?
         if ( !FloatUtils::isNegative( _lb[i] ) )
-            signPhase = SignConstraint::PHASE_POSITIVE;
+            signPhase = SIGN_PHASE_POSITIVE;
         else if ( FloatUtils::isNegative( _ub[i] ) )
-            signPhase = SignConstraint::PHASE_NEGATIVE;
+            signPhase = SIGN_PHASE_NEGATIVE;
 
         ASSERT( _neuronToActivationSources.exists( i ) );
         NeuronIndex sourceIndex = *_neuronToActivationSources[i].begin();
@@ -893,14 +893,14 @@ void Layer::computeSymbolicBoundsForSign()
         // Has the b variable been fixed?
         if ( !FloatUtils::isNegative( sourceLb ) )
         {
-            signPhase = SignConstraint::PHASE_POSITIVE;
+            signPhase = SIGN_PHASE_POSITIVE;
         }
         else if ( FloatUtils::isNegative( sourceUb ) )
         {
-            signPhase = SignConstraint::PHASE_NEGATIVE;
+            signPhase = SIGN_PHASE_NEGATIVE;
         }
 
-        if ( signPhase == SignConstraint::PHASE_NOT_FIXED )
+        if ( signPhase == PHASE_NOT_FIXED )
         {
             // If we got here, we know that lbLb < 0 and ubUb
             // > 0
@@ -972,7 +972,7 @@ void Layer::computeSymbolicBoundsForSign()
         {
             // The phase of this Sign is fixed!
             double constant =
-                ( signPhase == SignConstraint::PHASE_POSITIVE ) ? 1 : -1;
+                ( signPhase == SIGN_PHASE_POSITIVE ) ? 1 : -1;
 
             _symbolicLbOfLb[i] = constant;
             _symbolicUbOfLb[i] = constant;
@@ -1033,7 +1033,7 @@ void Layer::computeSymbolicBoundsForAbsoluteValue()
             continue;
         }
 
-        AbsoluteValueConstraint::PhaseStatus absPhase = AbsoluteValueConstraint::PHASE_NOT_FIXED;
+        PhaseStatus absPhase = PHASE_NOT_FIXED;
 
         ASSERT( _neuronToActivationSources.exists( i ) );
         NeuronIndex sourceIndex = *_neuronToActivationSources[i].begin();
@@ -1061,11 +1061,11 @@ void Layer::computeSymbolicBoundsForAbsoluteValue()
         _symbolicUbOfUb[i] = sourceLayer->getSymbolicUbOfUb( sourceIndex._neuron );
 
         if ( sourceLb >= 0 )
-            absPhase = AbsoluteValueConstraint::PHASE_POSITIVE;
+            absPhase = ABS_PHASE_POSITIVE;
         else if ( sourceUb <= 0 )
-            absPhase = AbsoluteValueConstraint::PHASE_NEGATIVE;
+            absPhase = ABS_PHASE_NEGATIVE;
 
-        if ( absPhase == AbsoluteValueConstraint::PHASE_NOT_FIXED )
+        if ( absPhase == PHASE_NOT_FIXED )
         {
             // If we got here, we know that lbOfLb < 0 < ubOfUb. In this case,
             // we do naive concretization: lb is 0, ub is the max between
@@ -1087,7 +1087,7 @@ void Layer::computeSymbolicBoundsForAbsoluteValue()
         else
         {
             // The phase of this AbsoluteValueConstraint is fixed!
-            if ( absPhase == AbsoluteValueConstraint::PHASE_POSITIVE )
+            if ( absPhase == ABS_PHASE_POSITIVE )
             {
                 // Positive AbsoluteValue, bounds are propagated as is
             }


### PR DESCRIPTION
This PR:
* introduces a joint PhaseStatus enumeration for all PiecewiseLinearConstraints
* refactors _phaseStatus member from derived classes into PiecewiseLinearConstraint
* refactors usage of local PhaseStatus enumerations with the global enumeration
* removes local PhaseStatus enumerations

To add new classes inheriting PiecewiseLinearConstraint their phase status elements need to be added to the PhaseStatus enumeration. Classes like Disjunction or MaxConstraint use PhaseStatus enumeration as an unsigned value instead of the label.