### PR TITLE
Optimization for partially-connected neural network's equations

### DIFF
--- a/src/engine/Preprocessor.cpp
+++ b/src/engine/Preprocessor.cpp
@@ -38,6 +38,21 @@ InputQuery Preprocessor::preprocess( const InputQuery &query, bool attemptVariab
     _preprocessed = query;
 
     /*
+      Remove all addends with zero as coefficient in equations
+    */
+    for ( Equation &equation : _preprocessed.getEquations() )
+    {
+        List<Equation::Addend>::iterator addend = equation._addends.begin();
+        while ( addend != equation._addends.end() )
+        {
+            if ( addend->_coefficient == 0 )
+                addend = equation._addends.erase( addend );
+            else
+                addend++;
+        }
+    }
+
+    /*
       Next, make sure all equations are of type EQUALITY. If not, turn them
       into one.
     */


### PR DESCRIPTION
Remove all addends with zero as coefficient in equations during preprocessing. 
If these addends are not removed, then the `processEquations()` and `processIdenticalVariables()` following would not catch all cases. 