### PR TITLE
support user defined preprocessor bound tolerance in marabou/py api

### DIFF
--- a/maraboupy/Marabou.py
+++ b/maraboupy/Marabou.py
@@ -120,7 +120,8 @@ def solve_query(ipq, filename="", verbose=True, options=None):
 def createOptions(numWorkers=1, initialTimeout=5, initialDivides=0, onlineDivides=2,
                   timeoutInSeconds=0, timeoutFactor=1.5, verbosity=2, snc=False,
                   splittingStrategy="auto", sncSplittingStrategy="auto",
-                  restoreTreeStates=False, splitThreshold=20, solveWithMILP=False ):
+                  restoreTreeStates=False, splitThreshold=20, solveWithMILP=False,
+                  preprocessorBoundTolerance=0.0000000001):
     """Create an options object for how Marabou should solve the query
 
     Args:
@@ -138,6 +139,7 @@ def createOptions(numWorkers=1, initialTimeout=5, initialDivides=0, onlineDivide
         sncSplittingStrategy (string, optional): Specifies which partitioning strategy to use in the DNC mode (auto/largest-interval/polarity).
         restoreTreeStates (bool, optional): Whether to restore tree states in dnc mode, defaults to False
         solveWithMILP ( bool, optional): Whther to solve the input query with a MILP encoding. Currently only works when Gurobi is installed. Defaults to False.
+        preprocessorBoundTolerance ( float, optional): epsilon value for preprocess bound tightening . Defaults to 10^-10.
     Returns:
         :class:`~maraboupy.MarabouCore.Options`
     """
@@ -155,4 +157,5 @@ def createOptions(numWorkers=1, initialTimeout=5, initialDivides=0, onlineDivide
     options._restoreTreeStates = restoreTreeStates
     options._splitThreshold = splitThreshold
     options._solveWithMILP = solveWithMILP
+    options._preprocessorBoundTolerance = preprocessorBoundTolerance
     return options

--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -190,6 +190,7 @@ struct MarabouOptions {
         , _timeoutInSeconds( Options::get()->getInt( Options::TIMEOUT ) )
         , _splitThreshold( Options::get()->getInt( Options::CONSTRAINT_VIOLATION_THRESHOLD ) )
         , _timeoutFactor( Options::get()->getFloat( Options::TIMEOUT_FACTOR ) )
+        , _preprocessorBoundTolerance( Options::get()->getFloat( Options::PREPROCESSOR_BOUND_TOLERANCE ) )
         , _splittingStrategyString( Options::get()->getString( Options::SPLITTING_STRATEGY ).ascii() )
         , _sncSplittingStrategyString( Options::get()->getString( Options::SNC_SPLITTING_STRATEGY ).ascii() )
     {};
@@ -212,6 +213,7 @@ struct MarabouOptions {
 
     // float options
     Options::get()->setFloat( Options::TIMEOUT_FACTOR, _timeoutFactor );
+    Options::get()->setFloat( Options::PREPROCESSOR_BOUND_TOLERANCE, _preprocessorBoundTolerance );
 
     // string options
     Options::get()->setString( Options::SPLITTING_STRATEGY, _splittingStrategyString );
@@ -229,6 +231,7 @@ struct MarabouOptions {
     unsigned _timeoutInSeconds;
     unsigned _splitThreshold;
     float _timeoutFactor;
+    float _preprocessorBoundTolerance;
     std::string _splittingStrategyString;
     std::string _sncSplittingStrategyString;
 };
@@ -410,6 +413,7 @@ PYBIND11_MODULE(MarabouCore, m) {
         .def_readwrite("_onlineDivides", &MarabouOptions::_onlineDivides)
         .def_readwrite("_timeoutInSeconds", &MarabouOptions::_timeoutInSeconds)
         .def_readwrite("_timeoutFactor", &MarabouOptions::_timeoutFactor)
+        .def_readwrite("_preprocessorBoundTolerance", &MarabouOptions::_preprocessorBoundTolerance)
         .def_readwrite("_verbosity", &MarabouOptions::_verbosity)
         .def_readwrite("_splitThreshold", &MarabouOptions::_splitThreshold)
         .def_readwrite("_snc", &MarabouOptions::_snc)

--- a/src/configuration/OptionParser.cpp
+++ b/src/configuration/OptionParser.cpp
@@ -97,6 +97,9 @@ void OptionParser::initialize()
         ( "version",
           boost::program_options::bool_switch( &((*_boolOptions)[Options::VERSION]) ),
           "Prints the version number")
+         ( "preprocessor-bound-tolerance",
+          boost::program_options::value<float>( &((*_floatOptions)[Options::PREPROCESSOR_BOUND_TOLERANCE]) ),
+          "epsilon for preprocessor bound tightening comparisons" )
 #ifdef ENABLE_GUROBI
         ( "milp",
           boost::program_options::bool_switch( &((*_boolOptions)[Options::SOLVE_WITH_MILP]) ),

--- a/src/configuration/Options.cpp
+++ b/src/configuration/Options.cpp
@@ -15,6 +15,7 @@
 
 #include "ConfigurationError.h"
 #include "Debug.h"
+#include "GlobalConfiguration.h"
 #include "Options.h"
 
 Options *Options::get()
@@ -63,6 +64,8 @@ void Options::initializeDefaultValues()
     */
     _floatOptions[TIMEOUT_FACTOR] = 1.5;
     _floatOptions[MILP_SOLVER_TIMEOUT] = 1.0;
+    _floatOptions[PREPROCESSOR_BOUND_TOLERANCE] = \
+        GlobalConfiguration::DEFAULT_EPSILON_FOR_COMPARISONS;
 
     /*
       String options

--- a/src/configuration/Options.h
+++ b/src/configuration/Options.h
@@ -73,6 +73,9 @@ public:
 
         // Gurobi options
         MILP_SOLVER_TIMEOUT,
+
+        // Engine's Preprocessor options
+        PREPROCESSOR_BOUND_TOLERANCE,
     };
 
     enum StringOptions {

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -266,6 +266,7 @@ bool Engine::solve( unsigned timeoutInSeconds )
                 continue;
             }
 
+
             // We have out-of-bounds variables.
             performSimplexStep();
             continue;

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -266,7 +266,6 @@ bool Engine::solve( unsigned timeoutInSeconds )
                 continue;
             }
 
-
             // We have out-of-bounds variables.
             performSimplexStep();
             continue;

--- a/src/engine/Preprocessor.cpp
+++ b/src/engine/Preprocessor.cpp
@@ -339,8 +339,11 @@ bool Preprocessor::processEquations()
 
                 lowerBound /= -ci;
 
-                double diff = lowerBound - _preprocessed.getLowerBound( xi );
-                if ( FloatUtils::isPositive( diff, epsilon ) )
+                if (
+                    FloatUtils::gt(
+                        lowerBound, _preprocessed.getLowerBound( xi ), epsilon
+                    )
+                )
                 {
                     tighterBoundFound = true;
                     _preprocessed.setLowerBound( xi, lowerBound );
@@ -364,8 +367,11 @@ bool Preprocessor::processEquations()
 
                 upperBound /= -ci;
 
-                double diff = upperBound - _preprocessed.getUpperBound( xi );
-                if ( FloatUtils::isNegative( diff, epsilon ) )
+                if (
+                    FloatUtils::lt(
+                        upperBound, _preprocessed.getUpperBound( xi ), epsilon
+                    )
+                )
                 {
                     tighterBoundFound = true;
                     _preprocessed.setUpperBound( xi, upperBound );

--- a/src/engine/Preprocessor.cpp
+++ b/src/engine/Preprocessor.cpp
@@ -14,6 +14,7 @@
  **/
 
 #include "Debug.h"
+#include "Options.h"
 #include "FloatUtils.h"
 #include "InfeasibleQueryException.h"
 #include "InputQuery.h"
@@ -319,6 +320,8 @@ bool Preprocessor::processEquations()
             }
 
             // Now compute the actual bounds and see if they are tighter
+            double epsilon = Options::get()->getFloat( Options::PREPROCESSOR_BOUND_TOLERANCE );
+
             if ( validLb )
             {
                 if ( ciSign[xi] == NEGATIVE )
@@ -336,7 +339,8 @@ bool Preprocessor::processEquations()
 
                 lowerBound /= -ci;
 
-                if ( FloatUtils::gt( lowerBound, _preprocessed.getLowerBound( xi ) ) )
+                double diff = lowerBound - _preprocessed.getLowerBound( xi );
+                if ( FloatUtils::isPositive( diff, epsilon ) )
                 {
                     tighterBoundFound = true;
                     _preprocessed.setLowerBound( xi, lowerBound );
@@ -360,7 +364,8 @@ bool Preprocessor::processEquations()
 
                 upperBound /= -ci;
 
-                if ( FloatUtils::lt( upperBound, _preprocessed.getUpperBound( xi ) ) )
+                double diff = upperBound - _preprocessed.getUpperBound( xi );
+                if ( FloatUtils::isNegative( diff, epsilon ) )
                 {
                     tighterBoundFound = true;
                     _preprocessed.setUpperBound( xi, upperBound );


### PR DESCRIPTION
Currently, Preprocessor uses a default value of epsilon from GlobalConfiguration for bound tightening.
The code of this PR enables to define this epsilon's value from command line and while using maraboupy API.