### PR TITLE
Introduce CI using Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
            python3 -m pip install --upgrade setuptools
            python3 -m pip install wheel
            #python3 -m pip install -r maraboupy/test_requirements.txt --cache-dir $HOME/.pip-cache 
+           echo "/usr/lib/ccache" >> $GITHUB_PATH
 
       - name: Create Build Environment
         run: cmake -E make_directory build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ on: [push, pull_request]
 name: CI
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         # Note the current convention is to use the -S and -B options here to specify source 
         # and build directories, but this is only available with CMake 3.13 and higher.  
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_PYTHON=ON 
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_PYTHON=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build
         run: make -j2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,17 +78,18 @@ jobs:
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
         run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_PYTHON=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
-      # - name: Build
-      #   run: make -j2
-      #   working-directory: build
+      - name: Build
+        run: make -j2
+        working-directory: build
 
       - name: ccache statistics
         run: ccache -s
-      # - name: Run full CTest suite
-      #   run: ctest -j2 
-      #   working-directory: build
+        
+      - name: Run full CTest suite
+        run: ctest -j2 
+        working-directory: build
 
-      # - name: Python Bindings Install Check
-      #   run: |
-      #     export PYTHONPATH="$PYTHONPATH:$(dirname $(find $GITHUB_WORKSPACE -name "maraboupy" -type d))"
-      #     python3 -c "import maraboupy"
+      - name: Python Bindings Install Check
+        run: |
+          export PYTHONPATH="$PYTHONPATH:$(dirname $(find $GITHUB_WORKSPACE -name "maraboupy" -type d))"
+          python3 -c "import maraboupy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
         run: make -j2
         working-directory: build
 
-      - name: Run CTest
-        run: make -j2 check
+      - name: Run full CTest suite
+        run: ctest -j2 
         env:
           ARGS: --output-on-failure 
           working-directory: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,17 @@ jobs:
       - name: Create Build Environment
         run: cmake -E make_directory build
 
+      - name: List paths
+        run:  ls *
+              echo "----------------------------------"
+              ls tools
+
       - name: Restore Tools cache
         uses: actions/cache@v2 
         env:
           cache-name: cache-tools
         with: 
-          path: $GITHUB_WORKSPACE/tools
+          path: tools
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ env:
 
 jobs:
   build:
-    os: ubuntu-latest #TODO: macos-latest
+    runs-on: ubuntu-latest #TODO: macos-latest
     name: Production
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+on: [push, pull_request]
+name: CI
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    os: ubuntu-latest #TODO: macos-latest
+    name: Production
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Install Packages
+        if: 
+        run: |
+           sudo apt-get update
+           sudo apt-get install -y \
+             cxxtest
+           # python3 -m pip install --user --upgrade pip
+           # python3 -m pip install --user --upgrade setuptools
+           python3 -m pip install --user wheel
+           python3 -m pip install --user -r maraboupy/test_requirements.txt --cache-dir $HOME/.pip-cache --progress-bar off
+
+      - name: Create Build Environment
+        run: cmake -E make_directory build
+      
+      - name: Configure CMake
+        # Use a bash shell so we can use the same syntax for environment variable
+        # access regardless of the host operating system
+        shell: bash
+        working-directory: build
+        # Note the current convention is to use the -S and -B options here to specify source 
+        # and build directories, but this is only available with CMake 3.13 and higher.  
+        # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+        run: cmakeunsITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+      - name: Build
+        run: make -j2
+        working-directory: build
+
+      - name: Run CTest
+        run: make -j2 check
+        env:
+          ARGS: --output-on-failure 
+          working-directory: build
+
+      - name: Python Install Check
+        run: |
+          export PYTHONPATH="$PYTHONPATH:$(dirname $(find build/install/ -name "maraboupy" -type d))"
+          python3 -c "import maraboupy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,23 +19,23 @@ jobs:
            sudo apt-get update
            sudo apt-get install -y \
              cxxtest
-           # python3 -m pip install --user --upgrade pip
-           # python3 -m pip install --user --upgrade setuptools
-           python3 -m pip install --user wheel
-           python3 -m pip install --user -r maraboupy/test_requirements.txt --cache-dir $HOME/.pip-cache --progress-bar off
+           #python3 -m pip install --user --upgrade pip
+           #python3 -m pip install --user --upgrade setuptools
+           #python3 -m pip install --user wheel
+           #python3 -m pip install --user -r maraboupy/test_requirements.txt --cache-dir $HOME/.pip-cache 
 
       - name: Create Build Environment
         run: cmake -E make_directory build
       
       - name: Configure CMake
-        # Use a bash shell so we can use the same syntax for environment variable
+        # Use a bash shell so we can use the same syntax for environment variable bb
         # access regardless of the host operating system
         shell: bash
         working-directory: build
         # Note the current convention is to use the -S and -B options here to specify source 
         # and build directories, but this is only available with CMake 3.13 and higher.  
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmakeunsITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_PYTHON=OFF 
 
       - name: Build
         run: make -j2
@@ -47,7 +47,7 @@ jobs:
           ARGS: --output-on-failure 
           working-directory: build
 
-      - name: Python Install Check
-        run: |
-          export PYTHONPATH="$PYTHONPATH:$(dirname $(find build/install/ -name "maraboupy" -type d))"
-          python3 -c "import maraboupy"
+      #- name: Python Install Check
+      #  run: |
+      #    export PYTHONPATH="$PYTHONPATH:$(dirname $(find build/install/ -name "maraboupy" -type d))"
+      #    python3 -c "import maraboupy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,6 @@ jobs:
       - name: Create Build Environment
         run: cmake -E make_directory build
 
-      # - name: List paths
-      #   run: |
-      #     ls *
-      #     echo "----------------------------------"
-      #     ls tools
-
       - name: Restore Tools cache
         uses: actions/cache@v2 
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Create Build Environment
         run: cmake -E make_directory build
 
-      - name: List paths
-        run: |
-          ls *
-          echo "----------------------------------"
-          ls tools
+      # - name: List paths
+      #   run: |
+      #     ls *
+      #     echo "----------------------------------"
+      #     ls tools
 
       - name: Restore Tools cache
         uses: actions/cache@v2 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         # Note the current convention is to use the -S and -B options here to specify source 
         # and build directories, but this is only available with CMake 3.13 and higher.  
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_PYTHON=OFF 
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_PYTHON=ON 
 
       - name: Build
         run: make -j2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
            sudo apt-get update
            sudo apt-get install -y \
              cxxtest
-           #python3 -m pip install --user --upgrade pip
-           #python3 -m pip install --user --upgrade setuptools
-           #python3 -m pip install --user wheel
-           #python3 -m pip install --user -r maraboupy/test_requirements.txt --cache-dir $HOME/.pip-cache 
+           python3 -m pip install --upgrade pip
+           python3 -m pip install --upgrade setuptools
+           python3 -m pip install wheel
+           #python3 -m pip install -r maraboupy/test_requirements.txt --cache-dir $HOME/.pip-cache 
 
       - name: Create Build Environment
         run: cmake -E make_directory build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
            sudo apt-get install -y \
              ccache \
              cxxtest
-           python3 -m pip install --upgrade pip
-           python3 -m pip install --upgrade setuptools
-           python3 -m pip install wheel
-           #python3 -m pip install -r maraboupy/test_requirements.txt --cache-dir $HOME/.pip-cache 
+           python3 -m pip install --user --upgrade pip
+           python3 -m pip install --user --upgrade setuptools
+           python3 -m pip install --user wheel
+           python3 -m pip install --user -r maraboupy/test_requirements.txt --cache-dir $HOME/.pip-cache 
            echo "/usr/lib/ccache" >> $GITHUB_PATH
 
       - name: Create Build Environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,16 @@ jobs:
 
       - name: Create Build Environment
         run: cmake -E make_directory build
+
+      - name: Restore Tools cache
+        uses: actions/cache@v2 
+        env:
+          cache-name: cache-tools
+        with: 
+          path: $GITHUB_WORKSPACE/tools
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
+
         
       # GitHub actions currently does not support modifying an already existing
       # cache. Hence, we create a new cache for each commit with key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,18 +72,17 @@ jobs:
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
         run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_PYTHON=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
-      - name: Build
-        run: make -j2
-        working-directory: build
+      # - name: Build
+      #   run: make -j2
+      #   working-directory: build
 
       - name: ccache statistics
         run: ccache -s
+      # - name: Run full CTest suite
+      #   run: ctest -j2 
+      #   working-directory: build
 
-      - name: Run full CTest suite
-        run: ctest -j2 
-        working-directory: build
-
-      - name: Python Bindings Install Check
-        run: |
-          export PYTHONPATH="$PYTHONPATH:$(dirname $(find $GITHUB_WORKSPACE -name "maraboupy" -type d))"
-          python3 -c "import maraboupy"
+      # - name: Python Bindings Install Check
+      #   run: |
+      #     export PYTHONPATH="$PYTHONPATH:$(dirname $(find $GITHUB_WORKSPACE -name "maraboupy" -type d))"
+      #     python3 -c "import maraboupy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,17 +42,6 @@ jobs:
       # ${{ env.cache-name }}-${{ matrix.compiler }}-, and if found uses it as
       # a base for the new cache.
       # Add ${{ matrix.cache-key }}- to the key pattern if matrix grows
-      - name: Restore Tools cache
-        id: cache
-        uses: actions/cache@v2 
-        env:
-          cache-name: cache-tools
-        with: 
-          path: tools
-          key: ${{ env.cache-name }}-${{ matrix.compiler }}-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: ${{ env.cache-name }}-${{ matrix.compiler }}-
-
-      
       - name: Restore ccache
         id: ccache
         uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: ctest -j2 
         working-directory: build
 
-      #- name: Python Install Check
-      #  run: |
-      #    export PYTHONPATH="$PYTHONPATH:$(dirname $(find build/install/ -name "maraboupy" -type d))"
-      #    python3 -c "import maraboupy"
+      - name: Python Install Check
+        run: |
+          export PYTHONPATH="$PYTHONPATH:$(dirname $(find build/install/ -name "maraboupy" -type d))"
+          python3 -c "import maraboupy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,14 @@ jobs:
       - name: ccache statistics
         run: ccache -s
         
-      - name: Run full CTest suite
-        run: ctest -j2 
+      - name: Run system tests
+        run: ctest -L system -j 2 
         working-directory: build
+ 
+      - name: Run regression tests
+        run: ctest -L regress[0-1] -j 2 
+        working-directory: build
+
 
       - name: Python Bindings Install Check
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: ctest -j2 
         working-directory: build
 
-      - name: Python Install Check
+      - name: Python Bindings Install Check
         run: |
-          export PYTHONPATH="$PYTHONPATH:$(dirname $(find build/install/ -name "maraboupy" -type d))"
+          export PYTHONPATH="$PYTHONPATH:$(dirname $(find $GITHUB_WORKSPACE -name "maraboupy" -type d))"
           python3 -c "import maraboupy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,7 @@ jobs:
 
       - name: Run full CTest suite
         run: ctest -j2 
-        env:
-          ARGS: --output-on-failure 
-          working-directory: build
+        working-directory: build
 
       #- name: Python Install Check
       #  run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,10 @@ jobs:
         run: cmake -E make_directory build
 
       - name: List paths
-        run:  ls *
-              echo "----------------------------------"
-              ls tools
+        run: |
+          ls *
+          echo "----------------------------------"
+          ls tools
 
       - name: Restore Tools cache
         uses: actions/cache@v2 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
            sudo apt-get update
            sudo apt-get install -y \
+             ccache \
              cxxtest
            python3 -m pip install --upgrade pip
            python3 -m pip install --upgrade setuptools
@@ -26,7 +27,30 @@ jobs:
 
       - name: Create Build Environment
         run: cmake -E make_directory build
-      
+        
+      # GitHub actions currently does not support modifying an already existing
+      # cache. Hence, we create a new cache for each commit with key
+      # cache-${{ runner.os }}-${{ matrix.cache-key }}-${{ github.sha }}. This
+      # will result in an initial cache miss. However, restore-keys will search
+      # for the most recent cache with prefix
+      # cache-${{ runner.os }}-${{ matrix.cache-key }}-, and if found uses it as
+      # a base for the new cache.
+      - name: Restore ccache
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: ccache-dir
+          key: cache-${{ runner.os }}-${{ github.sha }} # TODO: Add when switching to matrix ${{ matrix.cache-key }}-
+          restore-keys: cache-${{ runner.os }}- # ${{ matrix.cache-key }}-
+
+      - name: Configure ccache
+        run: |
+          ccache --set-config=cache_dir=${{ github.workspace }}/ccache-dir
+          ccache --set-config=compression=true
+          ccache --set-config=compression_level=6
+          ccache -M 500M
+          ccache -z
+
       - name: Configure CMake
         # Use a bash shell so we can use the same syntax for environment variable bb
         # access regardless of the host operating system
@@ -40,6 +64,9 @@ jobs:
       - name: Build
         run: make -j2
         working-directory: build
+
+      - name: ccache statistics
+        run: ccache -s
 
       - name: Run full CTest suite
         run: ctest -j2 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,12 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        compiler: [g++, clang++]
+
     runs-on: ubuntu-latest #TODO: macos-latest
-    name: Production
+    name: Debug build 
 
     steps:
 
@@ -29,30 +33,36 @@ jobs:
       - name: Create Build Environment
         run: cmake -E make_directory build
 
-      - name: Restore Tools cache
-        uses: actions/cache@v2 
-        env:
-          cache-name: cache-tools
-        with: 
-          path: tools
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
-
-        
+      # ---------------------------- CACHING ----------------------------------
       # GitHub actions currently does not support modifying an already existing
       # cache. Hence, we create a new cache for each commit with key
       # cache-${{ runner.os }}-${{ matrix.cache-key }}-${{ github.sha }}. This
       # will result in an initial cache miss. However, restore-keys will search
       # for the most recent cache with prefix
-      # cache-${{ runner.os }}-${{ matrix.cache-key }}-, and if found uses it as
+      # ${{ env.cache-name }}-${{ matrix.compiler }}-, and if found uses it as
       # a base for the new cache.
-      - name: Restore ccache
+      # Add ${{ matrix.cache-key }}- to the key pattern if matrix grows
+      - name: Restore Tools cache
         id: cache
+        uses: actions/cache@v2 
+        env:
+          cache-name: cache-tools
+        with: 
+          path: tools
+          key: ${{ env.cache-name }}-${{ matrix.compiler }}-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: ${{ env.cache-name }}-${{ matrix.compiler }}-
+
+      
+      - name: Restore ccache
+        id: ccache
         uses: actions/cache@v1
+        env:
+          cache-name: ccache-
         with:
           path: ccache-dir
-          key: cache-${{ runner.os }}-${{ github.sha }} # TODO: Add when switching to matrix ${{ matrix.cache-key }}-
-          restore-keys: cache-${{ runner.os }}- # ${{ matrix.cache-key }}-
+          key: ${{ env.cache-name }}-${{ matrix.compiler }}-${{ github.sha }} 
+          restore-keys: ${{ env.cache-name }}-${{ matrix.compiler }}-         
+      # ---------------------------- END CACHE RESTORE -------------------------
 
       - name: Configure ccache
         run: |
@@ -70,7 +80,7 @@ jobs:
         # Note the current convention is to use the -S and -B options here to specify source 
         # and build directories, but this is only available with CMake 3.13 and higher.  
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_PYTHON=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_PYTHON=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
 
       - name: Build
         run: make -j2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,13 @@ jobs:
         run: |
           export PYTHONPATH="$PYTHONPATH:$(dirname $(find $GITHUB_WORKSPACE -name "maraboupy" -type d))"
           python3 -c "import maraboupy"
+
+      - name: Generate Python Code Coverage
+        if: ${{ matrix.compiler == 'g++' }} 
+        run: python3 -m pytest --cov=maraboupy --cov-report=xml  $(find $GITHUB_WORKSPACE -name "maraboupy" -type d)/test
+
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.compiler == 'g++' }} 
+        uses: codecov/codecov-action@v1
+        with:
+          files: ./coverage.xml


### PR DESCRIPTION
Adds a basic Github Actions workflow for CI which runs a matrix strategy over compilers - [gcc, clang]. For each it does the following:

- Prepares build folder
- Caches tools folder and compilation artifacts between runs 
- Sets up CMake
- Runs make
- Runs system and regression tests
- Checks Python bindings
- Runs code coverage for Python API
