### PR TITLE
Context Dependent Piecewise Linear Constraint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Generate Python Code Coverage
         if: ${{ matrix.compiler == 'g++' }} 
-        run: python3 -m pytest --cov=maraboupy --cov-report=xml  $(find $GITHUB_WORKSPACE -name "maraboupy" -type d)/test
+        run: python3 -m pytest --cov=maraboupy --cov-report=xml  maraboupy/test
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.compiler == 'g++' }} 

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
@@ -162,7 +162,7 @@ PhaseStatus ContextDependentPiecewiseLinearConstraint::nextFeasibleCase()
     ASSERT( getPhaseStatus() == PHASE_NOT_FIXED );
 
     if ( !isFeasible() )
-        return PHASE_NOT_FIXED;
+        return CONSTRAINT_INFEASIBLE;
 
     List<PhaseStatus> allCases = getAllCases();
     for ( PhaseStatus thisCase : allCases )
@@ -170,14 +170,14 @@ PhaseStatus ContextDependentPiecewiseLinearConstraint::nextFeasibleCase()
         auto loc =
             std::find( _cdInfeasibleCases->begin(), _cdInfeasibleCases->end(), thisCase );
 
-        // Case not found, therefore it is feasible
+        // Case is not infeasible, return it as feasible
         if ( loc == _cdInfeasibleCases->end() )
             return thisCase;
     }
 
     // UNREACHABLE
     ASSERT( false );
-    return PHASE_NOT_FIXED;
+    return CONSTRAINT_INFEASIBLE;
 }
 
 //

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
@@ -71,26 +71,6 @@ void ContextDependentPiecewiseLinearConstraint::initializeCDOs(
     initializeCDInfeasibleCases();
 }
 
-void ContextDependentPiecewiseLinearConstraint::cdoCleanup()
-{
-    if ( nullptr != _cdConstraintActive )
-        _cdConstraintActive->deleteSelf();
-
-    _cdConstraintActive = nullptr;
-
-    if ( nullptr != _cdPhaseStatus )
-        _cdPhaseStatus->deleteSelf();
-
-    _cdPhaseStatus = nullptr;
-
-    if ( nullptr != _cdInfeasibleCases )
-        _cdInfeasibleCases->deleteSelf();
-
-    _cdInfeasibleCases = nullptr;
-
-    _context = nullptr;
-}
-
 void ContextDependentPiecewiseLinearConstraint::initializeCDInfeasibleCases()
 {
     ASSERT( nullptr != _context );
@@ -111,6 +91,26 @@ void ContextDependentPiecewiseLinearConstraint::initializeCDPhaseStatus()
     ASSERT( nullptr == _cdPhaseStatus );
     _cdPhaseStatus =
         new ( true ) CVC4::context::CDO<PhaseStatus>( _context, PHASE_NOT_FIXED );
+}
+
+void ContextDependentPiecewiseLinearConstraint::cdoCleanup()
+{
+    if ( nullptr != _cdConstraintActive )
+        _cdConstraintActive->deleteSelf();
+
+    _cdConstraintActive = nullptr;
+
+    if ( nullptr != _cdPhaseStatus )
+        _cdPhaseStatus->deleteSelf();
+
+    _cdPhaseStatus = nullptr;
+
+    if ( nullptr != _cdInfeasibleCases )
+        _cdInfeasibleCases->deleteSelf();
+
+    _cdInfeasibleCases = nullptr;
+
+    _context = nullptr;
 }
 
 PhaseStatus ContextDependentPiecewiseLinearConstraint::getPhaseStatus() const

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
@@ -159,11 +159,10 @@ void ContextDependentPiecewiseLinearConstraint::markInfeasible(
 
 PhaseStatus ContextDependentPiecewiseLinearConstraint::nextFeasibleCase()
 {
+    ASSERT( getPhaseStatus() == PHASE_NOT_FIXED );
+
     if ( !isFeasible() )
         return PHASE_NOT_FIXED;
-
-    if ( phaseFixed() )
-        return getPhaseStatus();
 
     List<PhaseStatus> allCases = getAllCases();
     for ( PhaseStatus thisCase : allCases )

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
@@ -82,7 +82,7 @@ void ContextDependentPiecewiseLinearConstraint::initializeCDActiveStatus()
 {
     ASSERT( _context != nullptr );
     ASSERT( _cdConstraintActive == nullptr );
-    _cdConstraintActive = new ( true ) CVC4::context::CDO<bool>( _context, true );
+    _cdConstraintActive = new ( true ) CVC4::context::CDO<bool>( _context, _constraintActive );
 }
 
 void ContextDependentPiecewiseLinearConstraint::initializeCDPhaseStatus()

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
@@ -1,0 +1,190 @@
+/*********************                                                        */
+/*! \file ContextDependentPiecewiseLinearConstraint.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Aleksandar Zeljic
+ ** This file is part of the Marabou project.
+ ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved. See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** A context dependent implementation of ContextDependentPiecewiseLinearConstraint class
+ **/
+
+include "ContextDependentPiecewiseLinearConstraint.h"
+#include "Statistics.h"
+
+    ContextDependentPiecewiseLinearConstraint::ContextDependentPiecewiseLinearConstraint()
+   : _context( nullptr )
+   , _cdConstraintActive( nullptr )
+   , _cdPhaseStatus( nullptr )
+   , _cdInfeasibleCases( nullptr )
+   , _numCases( 0 )
+   , _boundManager( nullptr )
+{
+}
+
+ContextDependentPiecewiseLinearConstraint::ContextDependentPiecewiseLinearConstraint(
+    unsigned numCases )
+   : _context( nullptr )
+   , _cdConstraintActive( nullptr )
+   , _cdPhaseStatus( nullptr )
+   , _cdInfeasibleCases( nullptr )
+   , _numCases( numCases )
+   , _boundManager( nullptr )
+{
+}
+
+void ContextDependentPiecewiseLinearConstraint::registerBoundManager(
+    BoundManager *boundManager )
+{
+    ASSERT( nullptr == _boundManager );
+    _boundManager = boundManager;
+}
+
+void ContextDependentPiecewiseLinearConstraint::initializeCDOs(
+    CVC4::context::Context *context )
+{
+    ASSERT( nullptr == _context );
+    _context = context;
+
+    initializeCDActiveStatus();
+    initializeCDPhaseStatus();
+    initializeCDInfeasibleCases();
+}
+
+void ContextDependentPiecewiseLinearConstraint::cdoCleanup()
+{
+    if ( nullptr != _cdConstraintActive )
+        _cdConstraintActive->deleteSelf();
+
+    _cdConstraintActive = nullptr;
+
+    if ( nullptr != _cdPhaseStatus )
+        _cdPhaseStatus->deleteSelf();
+
+    _cdPhaseStatus = nullptr;
+
+    if ( nullptr != _cdInfeasibleCases )
+        _cdInfeasibleCases->deleteSelf();
+
+    _cdInfeasibleCases = nullptr;
+
+    _context = nullptr;
+}
+
+void ContextDependentPiecewiseLinearConstraint::initializeCDInfeasibleCases()
+{
+    ASSERT( nullptr != _context );
+    ASSERT( nullptr == _cdInfeasibleCases );
+    _cdInfeasibleCases = new ( true ) CVC4::context::CDList<PhaseStatus>( _context );
+}
+
+void ContextDependentPiecewiseLinearConstraint::initializeCDActiveStatus()
+{
+    ASSERT( nullptr != _context );
+    ASSERT( nullptr == _cdConstraintActive );
+    _cdConstraintActive = new ( true ) CVC4::context::CDO<bool>( _context, true );
+}
+
+void ContextDependentPiecewiseLinearConstraint::initializeCDPhaseStatus()
+{
+    ASSERT( nullptr != _context );
+    ASSERT( nullptr == _cdPhaseStatus );
+    _cdPhaseStatus =
+        new ( true ) CVC4::context::CDO<PhaseStatus>( _context, PHASE_NOT_FIXED );
+}
+
+PhaseStatus ContextDependentPiecewiseLinearConstraint::getPhaseStatus() const
+{
+    if ( nullptr != _cdPhaseStatus )
+        return *_cdPhaseStatus;
+    else
+        return static_cast<PhaseStatus>(
+            _phaseStatus ); // TODO: Remove cast at integration.
+}
+
+void ContextDependentPiecewiseLinearConstraint::setPhaseStatus( PhaseStatus phaseStatus )
+{
+    if ( nullptr != _cdPhaseStatus )
+        *_cdPhaseStatus = phaseStatus;
+    else
+        _phaseStatus =
+            static_cast<unsigned>( phaseStatus ); // TODO: Remove cast at integration.
+}
+
+void ContextDependentPiecewiseLinearConstraint::initializeDuplicatesCDOs(
+    ContextDependentPiecewiseLinearConstraint *clone ) const
+{
+    if ( nullptr != clone->_context )
+    {
+        ASSERT( nullptr != clone->_cdConstraintActive );
+        clone->_cdConstraintActive = nullptr;
+        clone->initializeCDActiveStatus();
+        clone->setActiveConstraint( this->isActive() );
+
+        ASSERT( nullptr != clone->_cdPhaseStatus );
+        clone->_cdPhaseStatus = nullptr;
+        clone->initializeCDPhaseStatus();
+        clone->setPhaseStatus( this->getPhaseStatus() );
+
+        ASSERT( nullptr != clone->_cdInfeasibleCases );
+        clone->_cdInfeasibleCases = nullptr;
+        clone->initializeCDInfeasibleCases();
+        // Does not copy contents
+    }
+}
+
+void ContextDependentPiecewiseLinearConstraint::markInfeasible(
+    PhaseStatus infeasibleCase )
+{
+    _cdInfeasibleCases->push_back( infeasibleCase );
+}
+
+PhaseStatus ContextDependentPiecewiseLinearConstraint::nextFeasibleCase()
+{
+    if ( !isFeasible() )
+        return PHASE_NOT_FIXED;
+
+    if ( phaseFixed() )
+        return getPhaseStatus();
+
+    List<PhaseStatus> allCases = getAllCases();
+    for ( PhaseStatus thisCase : allCases )
+    {
+        auto loc =
+            std::find( _cdInfeasibleCases->begin(), _cdInfeasibleCases->end(), thisCase );
+
+        // Case not found, therefore it is feasible
+        if ( _cdInfeasibleCases->end() == loc )
+            return thisCase;
+    }
+
+    // UNREACHABLE
+    ASSERT( false );
+    return PHASE_NOT_FIXED;
+}
+
+unsigned ContextDependentPiecewiseLinearConstraint::numFeasibleCases()
+{
+    return _numCases - _cdInfeasibleCases->size();
+}
+
+bool ContextDependentPiecewiseLinearConstraint::isFeasible()
+{
+    return numFeasibleCases() > 0u;
+}
+
+bool ContextDependentPiecewiseLinearConstraint::isImplication()
+{
+    return 1u == numFeasibleCases();
+}
+
+//
+// Local Variables:
+// compile-command: "make -C ../.. "
+// tags-file-name: "../../TAGS"
+// c-basic-offset: 4
+// End:
+//

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
@@ -181,21 +181,6 @@ PhaseStatus ContextDependentPiecewiseLinearConstraint::nextFeasibleCase()
     return PHASE_NOT_FIXED;
 }
 
-unsigned ContextDependentPiecewiseLinearConstraint::numFeasibleCases()
-{
-    return _numCases - _cdInfeasibleCases->size();
-}
-
-bool ContextDependentPiecewiseLinearConstraint::isFeasible()
-{
-    return numFeasibleCases() > 0u;
-}
-
-bool ContextDependentPiecewiseLinearConstraint::isImplication()
-{
-    return 1u == numFeasibleCases();
-}
-
 //
 // Local Variables:
 // compile-command: "make -C ../.. "

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
@@ -171,7 +171,7 @@ PhaseStatus ContextDependentPiecewiseLinearConstraint::nextFeasibleCase()
             std::find( _cdInfeasibleCases->begin(), _cdInfeasibleCases->end(), thisCase );
 
         // Case not found, therefore it is feasible
-        if ( _cdInfeasibleCases->end() == loc )
+        if ( loc == _cdInfeasibleCases->end() )
             return thisCase;
     }
 

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
@@ -12,28 +12,45 @@
  ** A context dependent implementation of ContextDependentPiecewiseLinearConstraint class
  **/
 
-include "ContextDependentPiecewiseLinearConstraint.h"
+#include "ContextDependentPiecewiseLinearConstraint.h"
+
 #include "Statistics.h"
 
-    ContextDependentPiecewiseLinearConstraint::ContextDependentPiecewiseLinearConstraint()
-   : _context( nullptr )
+ContextDependentPiecewiseLinearConstraint::ContextDependentPiecewiseLinearConstraint()
+   : _numCases( 0 )
+   , _boundManager( nullptr )
+   , _context( nullptr )
    , _cdConstraintActive( nullptr )
    , _cdPhaseStatus( nullptr )
    , _cdInfeasibleCases( nullptr )
-   , _numCases( 0 )
-   , _boundManager( nullptr )
 {
 }
 
 ContextDependentPiecewiseLinearConstraint::ContextDependentPiecewiseLinearConstraint(
     unsigned numCases )
-   : _context( nullptr )
+   : _numCases( numCases )
+   , _boundManager( nullptr )
+   , _context( nullptr )
    , _cdConstraintActive( nullptr )
    , _cdPhaseStatus( nullptr )
    , _cdInfeasibleCases( nullptr )
-   , _numCases( numCases )
-   , _boundManager( nullptr )
 {
+}
+
+void ContextDependentPiecewiseLinearConstraint::setActiveConstraint( bool active )
+{
+    if ( nullptr != _cdConstraintActive )
+        *_cdConstraintActive = active;
+    else
+        _constraintActive = active;
+}
+
+bool ContextDependentPiecewiseLinearConstraint::isActive() const
+{
+    if ( nullptr != _cdConstraintActive )
+        return *_cdConstraintActive;
+    else
+        return _constraintActive;
 }
 
 void ContextDependentPiecewiseLinearConstraint::registerBoundManager(
@@ -101,8 +118,7 @@ PhaseStatus ContextDependentPiecewiseLinearConstraint::getPhaseStatus() const
     if ( nullptr != _cdPhaseStatus )
         return *_cdPhaseStatus;
     else
-        return static_cast<PhaseStatus>(
-            _phaseStatus ); // TODO: Remove cast at integration.
+        return _phaseStatus;
 }
 
 void ContextDependentPiecewiseLinearConstraint::setPhaseStatus( PhaseStatus phaseStatus )
@@ -110,8 +126,7 @@ void ContextDependentPiecewiseLinearConstraint::setPhaseStatus( PhaseStatus phas
     if ( nullptr != _cdPhaseStatus )
         *_cdPhaseStatus = phaseStatus;
     else
-        _phaseStatus =
-            static_cast<unsigned>( phaseStatus ); // TODO: Remove cast at integration.
+        _phaseStatus = phaseStatus;
 }
 
 void ContextDependentPiecewiseLinearConstraint::initializeDuplicatesCDOs(

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
@@ -90,7 +90,7 @@ void ContextDependentPiecewiseLinearConstraint::initializeCDPhaseStatus()
     ASSERT( _context != nullptr );
     ASSERT( _cdPhaseStatus == nullptr );
     _cdPhaseStatus =
-        new ( true ) CVC4::context::CDO<PhaseStatus>( _context, _phaseStatus );
+        new ( true ) CVC4::context::CDO<PhaseStatus>( _context, PHASE_NOT_FIXED );
 }
 
 void ContextDependentPiecewiseLinearConstraint::cdoCleanup()

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
@@ -39,7 +39,7 @@ ContextDependentPiecewiseLinearConstraint::ContextDependentPiecewiseLinearConstr
 
 void ContextDependentPiecewiseLinearConstraint::setActiveConstraint( bool active )
 {
-    if ( nullptr != _cdConstraintActive )
+    if ( _cdConstraintActive != nullptr )
         *_cdConstraintActive = active;
     else
         _constraintActive = active;
@@ -47,7 +47,7 @@ void ContextDependentPiecewiseLinearConstraint::setActiveConstraint( bool active
 
 bool ContextDependentPiecewiseLinearConstraint::isActive() const
 {
-    if ( nullptr != _cdConstraintActive )
+    if ( _cdConstraintActive != nullptr )
         return *_cdConstraintActive;
     else
         return _constraintActive;
@@ -56,14 +56,14 @@ bool ContextDependentPiecewiseLinearConstraint::isActive() const
 void ContextDependentPiecewiseLinearConstraint::registerBoundManager(
     BoundManager *boundManager )
 {
-    ASSERT( nullptr == _boundManager );
+    ASSERT( _boundManager == nullptr );
     _boundManager = boundManager;
 }
 
 void ContextDependentPiecewiseLinearConstraint::initializeCDOs(
     CVC4::context::Context *context )
 {
-    ASSERT( nullptr == _context );
+    ASSERT( _context == nullptr );
     _context = context;
 
     initializeCDActiveStatus();
@@ -73,39 +73,39 @@ void ContextDependentPiecewiseLinearConstraint::initializeCDOs(
 
 void ContextDependentPiecewiseLinearConstraint::initializeCDInfeasibleCases()
 {
-    ASSERT( nullptr != _context );
-    ASSERT( nullptr == _cdInfeasibleCases );
+    ASSERT( _context != nullptr );
+    ASSERT( _cdInfeasibleCases == nullptr );
     _cdInfeasibleCases = new ( true ) CVC4::context::CDList<PhaseStatus>( _context );
 }
 
 void ContextDependentPiecewiseLinearConstraint::initializeCDActiveStatus()
 {
-    ASSERT( nullptr != _context );
-    ASSERT( nullptr == _cdConstraintActive );
+    ASSERT( _context != nullptr );
+    ASSERT( _cdConstraintActive == nullptr );
     _cdConstraintActive = new ( true ) CVC4::context::CDO<bool>( _context, true );
 }
 
 void ContextDependentPiecewiseLinearConstraint::initializeCDPhaseStatus()
 {
-    ASSERT( nullptr != _context );
-    ASSERT( nullptr == _cdPhaseStatus );
+    ASSERT( _context != nullptr );
+    ASSERT( _cdPhaseStatus == nullptr );
     _cdPhaseStatus =
         new ( true ) CVC4::context::CDO<PhaseStatus>( _context, PHASE_NOT_FIXED );
 }
 
 void ContextDependentPiecewiseLinearConstraint::cdoCleanup()
 {
-    if ( nullptr != _cdConstraintActive )
+    if ( _cdConstraintActive != nullptr )
         _cdConstraintActive->deleteSelf();
 
     _cdConstraintActive = nullptr;
 
-    if ( nullptr != _cdPhaseStatus )
+    if ( _cdPhaseStatus != nullptr )
         _cdPhaseStatus->deleteSelf();
 
     _cdPhaseStatus = nullptr;
 
-    if ( nullptr != _cdInfeasibleCases )
+    if ( _cdInfeasibleCases != nullptr )
         _cdInfeasibleCases->deleteSelf();
 
     _cdInfeasibleCases = nullptr;
@@ -115,7 +115,7 @@ void ContextDependentPiecewiseLinearConstraint::cdoCleanup()
 
 PhaseStatus ContextDependentPiecewiseLinearConstraint::getPhaseStatus() const
 {
-    if ( nullptr != _cdPhaseStatus )
+    if ( _cdPhaseStatus != nullptr )
         return *_cdPhaseStatus;
     else
         return _phaseStatus;
@@ -123,7 +123,7 @@ PhaseStatus ContextDependentPiecewiseLinearConstraint::getPhaseStatus() const
 
 void ContextDependentPiecewiseLinearConstraint::setPhaseStatus( PhaseStatus phaseStatus )
 {
-    if ( nullptr != _cdPhaseStatus )
+    if ( _cdPhaseStatus != nullptr )
         *_cdPhaseStatus = phaseStatus;
     else
         _phaseStatus = phaseStatus;
@@ -132,19 +132,19 @@ void ContextDependentPiecewiseLinearConstraint::setPhaseStatus( PhaseStatus phas
 void ContextDependentPiecewiseLinearConstraint::initializeDuplicatesCDOs(
     ContextDependentPiecewiseLinearConstraint *clone ) const
 {
-    if ( nullptr != clone->_context )
+    if ( clone->_context != nullptr )
     {
-        ASSERT( nullptr != clone->_cdConstraintActive );
+        ASSERT( clone->_cdConstraintActive != nullptr );
         clone->_cdConstraintActive = nullptr;
         clone->initializeCDActiveStatus();
         clone->setActiveConstraint( this->isActive() );
 
-        ASSERT( nullptr != clone->_cdPhaseStatus );
+        ASSERT( clone->_cdPhaseStatus != nullptr );
         clone->_cdPhaseStatus = nullptr;
         clone->initializeCDPhaseStatus();
         clone->setPhaseStatus( this->getPhaseStatus() );
 
-        ASSERT( nullptr != clone->_cdInfeasibleCases );
+        ASSERT( clone->_cdInfeasibleCases != nullptr );
         clone->_cdInfeasibleCases = nullptr;
         clone->initializeCDInfeasibleCases();
         // Does not copy contents

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
@@ -90,7 +90,7 @@ void ContextDependentPiecewiseLinearConstraint::initializeCDPhaseStatus()
     ASSERT( _context != nullptr );
     ASSERT( _cdPhaseStatus == nullptr );
     _cdPhaseStatus =
-        new ( true ) CVC4::context::CDO<PhaseStatus>( _context, PHASE_NOT_FIXED );
+        new ( true ) CVC4::context::CDO<PhaseStatus>( _context, _phaseStatus );
 }
 
 void ContextDependentPiecewiseLinearConstraint::cdoCleanup()

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -166,10 +166,10 @@ public:
 
     /*
       Returns phaseStatus representing next feasible case.
-      Returns PHASE_NOT_FIXED if no feasible case exists.
+      Returns CONSTRAINT_INFEASIBLE if no feasible case exists.
       Assumes the contraint phase is PHASE_NOT_FIXED.
       Worst case complexity O(n^2)
-      This method should be overloaded for MAX and DISJUNCTION constraints.
+      This method is overloaded in MAX and DISJUNCTION constraints.
      */
     virtual PhaseStatus nextFeasibleCase();
 

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -9,7 +9,31 @@
  ** All rights reserved. See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** A context dependent implementation of PiecewiseLinearConstraint class
+ ** This class is an implementation of PiecewiseLinearConstraint using
+ ** context-dependent data structures from CVC4, which lazily and automatically
+ ** back-track in sync with the central context object. These data structures
+ ** are delicate and require that data stored is safe to memcopy around, but
+ ** provide built-in backtracking which is cheap in terms of computational overhead.
+ **
+ ** The basic members of PiecewiseLinearConstraint class use context-dependent
+ ** objects (CDOs), which need to be initialized for the backtracking search in
+ ** Marabou and are not needed for pre-processing purposes. The initialization
+ ** is performed using the initializeCDOs( Context context ) method. Descendant
+ ** classes need to call initializeDuplicatesCDOs() method in
+ ** duplicateConstraint method to avoid sharing context-dependent members. The
+ ** duplication functionality might be unnecessary (and perhaps even prohibited)
+ ** after CDOs are initialized.
+ **
+ ** The methods used by the Marabou search:
+ **  * markInfeasible( PhaseStatus caseId ) - which denotes explored search space
+ **  * nextFeasibleCase() - which obtains next unexplored case if one exists
+ **
+ ** These methods rely on:
+ **  * _numCases field, which denotes the number of piecewise linear
+ **     segments the constraint has, passed through the constructor.
+ **  * getAllCases() virtual method returns all possible cases represented using
+ **    PhaseStatus enumeration. The order of returned cases will determine the
+ **    search order, so it should implement any search heuristics.
  **/
 
 #ifndef __ContextDependentPiecewiseLinearConstraint_h__

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -152,25 +152,48 @@ public:
     }
 
     /*
-       Mark that exploredCase is infeasible.
+       Mark that an exploredCase is infeasible, reducing the remaining search space.
      */
     void markInfeasible( PhaseStatus exploredCase );
 
     /*
-      Retrieve next feasible case; Worst case O(n^2)
-      Returns PhaseStatus representing next feasible case.
+      Returns haseStatus representing next feasible case.
       Returns PHASE_NOT_FIXED if no feasible case exists.
+      Assumes the contraint phase is PHASE_NOT_FIXED.
+      Worst case complexity O(n^2)
+      This method should be overloaded for MAX and DISJUNCTION constraints.
      */
     PhaseStatus nextFeasibleCase();
 
-    bool isFeasible();
-    bool isImplication();
-    unsigned numFeasibleCases();
+    /*
+       Returns number of cases not yet marked as infeasible.
+     */
+    unsigned numFeasibleCases()
+    {
+        return _numCases - _cdInfeasibleCases->size();
+    }
+
+    /*
+        Returns true if there are feasible cases remaining.
+     */
+    bool isFeasible()
+    {
+        return numFeasibleCases() > 0u;
+    }
+
+    /*
+       Returns true if there is only one feasible case remaining.
+     */
+    bool isImplication()
+    {
+        return 1u == numFeasibleCases();
+    }
 
 protected:
-    unsigned _numCases;
-    PhaseStatus _phaseStatus; //TODO: Move to PiecewiseLinearConstraint, before integration.
-    BoundManager *_boundManager;
+    unsigned _numCases; // Number of possible cases/phases for this constraint
+                        // (e.g. 2 for ReLU, ABS, SIGN; >=2 for Max and Disjunction )
+
+    BoundManager *_boundManager; // Pointer to a centralized object to store bounds.
     CVC4::context::Context *_context;
     CVC4::context::CDO<bool> *_cdConstraintActive;
 

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -171,7 +171,7 @@ public:
       Worst case complexity O(n^2)
       This method should be overloaded for MAX and DISJUNCTION constraints.
      */
-    PhaseStatus nextFeasibleCase();
+    virtual PhaseStatus nextFeasibleCase();
 
     /*
        Returns number of cases not yet marked as infeasible.

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -59,14 +59,6 @@ class ITableau;
 class InputQuery;
 class String;
 
-enum PhaseStatus : unsigned {
-    PHASE_NOT_FIXED = 0,
-    RELU_PHASE_ACTIVE = 1,
-    RELU_PHASE_INACTIVE = 2,
-    ABS_PHASE_POSITIVE = 3,
-    ABS_PHASE_NEGATIVE = 4,
-};
-
 class ContextDependentPiecewiseLinearConstraint
    : public virtual PiecewiseLinearConstraint
 {

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -78,14 +78,20 @@ public:
     bool isActive() const;
 
     /*
-     * Returns a list of all cases of this constraint
+       Returns a list of all cases of this constraint and is used by the
+       nextFeasibleCase during search. The order of returned cases affects the
+       search, and this method is where related heuristics should be
+       implemented.
      */
     virtual List<PhaseStatus> getAllCases() const = 0;
 
     /*
      * Returns case split corresponding to the given phase/id
+       TODO: Update the signature in PiecewiseLinearConstraint, once the new
+       search is integrated.
      */
-    virtual PiecewiseLinearCaseSplit getCaseSplit( unsigned caseId ) const = 0;
+    virtual PiecewiseLinearCaseSplit getCaseSplit( PhaseStatus caseId ) const = 0;
+
 
     /*
       Check if the constraint's phase has been fixed.
@@ -211,8 +217,11 @@ protected:
     void initializeCDActiveStatus();
     void initializeCDPhaseStatus();
     void initializeCDInfeasibleCases();
-    void
-    initializeDuplicatesCDOs( ContextDependentPiecewiseLinearConstraint *clone ) const;
+
+    /*
+       Method provided to allow safe copying of the context-dependent members, which will be freshly initialized in a copy and with the same values.
+     */
+    void initializeDuplicatesCDOs( ContextDependentPiecewiseLinearConstraint *clone ) const;
 
     void setPhaseStatus( PhaseStatus phaseStatus );
     PhaseStatus getPhaseStatus() const;

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -176,7 +176,7 @@ public:
     /*
        Returns number of cases not yet marked as infeasible.
      */
-    unsigned numFeasibleCases()
+    unsigned numFeasibleCases() const
     {
         return _numCases - _cdInfeasibleCases->size();
     }
@@ -184,7 +184,7 @@ public:
     /*
         Returns true if there are feasible cases remaining.
      */
-    bool isFeasible()
+    bool isFeasible() const
     {
         return numFeasibleCases() > 0u;
     }
@@ -192,7 +192,7 @@ public:
     /*
        Returns true if there is only one feasible case remaining.
      */
-    bool isImplication()
+    bool isImplication() const
     {
         return 1u == numFeasibleCases();
     }

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -98,7 +98,6 @@ public:
      */
     virtual PiecewiseLinearCaseSplit getCaseSplit( PhaseStatus caseId ) const = 0;
 
-
     /*
       Check if the constraint's phase has been fixed.
     */

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -65,7 +65,11 @@ class ContextDependentPiecewiseLinearConstraint
 public:
     ContextDependentPiecewiseLinearConstraint();
     ContextDependentPiecewiseLinearConstraint( unsigned numCases );
-    virtual ~ContextDependentPiecewiseLinearConstraint() { cdoCleanup(); }
+
+    virtual ~ContextDependentPiecewiseLinearConstraint()
+    {
+        cdoCleanup();
+    }
 
     /*
       Turn the constraint on/off.
@@ -131,17 +135,29 @@ public:
      */
     void cdoCleanup();
 
-    CVC4::context::Context *getContext() const { return _context; }
+    /*
+      Get the context object - debugging purposes only
+    */
+    CVC4::context::Context *getContext() const
+    {
+        return _context;
+    }
 
     /*
       Get the active status object - debugging purposes only
     */
-    CVC4::context::CDO<bool> *getActiveStatusCDO() const { return _cdConstraintActive; };
+    CVC4::context::CDO<bool> *getActiveStatusCDO() const
+    {
+        return _cdConstraintActive;
+    };
 
     /*
       Get the current phase status object - debugging purposes only
     */
-    CVC4::context::CDO<PhaseStatus> *getPhaseStatusCDO() const { return _cdPhaseStatus; }
+    CVC4::context::CDO<PhaseStatus> *getPhaseStatusCDO() const
+    {
+        return _cdPhaseStatus;
+    }
 
     /*
       Get the infeasable cases object - debugging purposes only

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -98,25 +98,6 @@ public:
     virtual PiecewiseLinearCaseSplit getImpliedCaseSplit() const = 0;
 
     /*
-      Dump the current state of the constraint.
-    */
-    void dump() const;
-
-    /*
-      Dump the current state of the constraint.
-    */
-    virtual void dump( String & ) const {}
-
-    /*
-      Produce string representation of the piecewise linear constraint.
-      This representation contains only the information necessary to reproduce it
-      but does not account for state or change in state during execution. Additionally
-      the first string before a comma has the contraint type identifier
-      (ie. "relu", "max", etc)
-    */
-    virtual String serializeToString() const = 0;
-
-    /*
       Register a bound manager. If a bound manager is registered,
       this piecewise linear constraint will inform the tightener whenever
       it discovers a tighter (entailed) bound.

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -17,12 +17,12 @@
  **
  ** The basic members of PiecewiseLinearConstraint class use context-dependent
  ** objects (CDOs), which need to be initialized for the backtracking search in
- ** Marabou and are not needed for pre-processing purposes. The initialization
- ** is performed using the initializeCDOs( Context context ) method. Descendant
- ** classes need to call initializeDuplicatesCDOs() method in
- ** duplicateConstraint method to avoid sharing context-dependent members. The
- ** duplication functionality might be unnecessary (and perhaps even prohibited)
- ** after CDOs are initialized.
+ ** Marabou and are not needed for pre-processing purposes. Initialization is
+ ** performed using the initializeCDOs( Context context ) method. Subclasses
+ ** need to call initializeDuplicatesCDOs() method in the duplicateConstraint()
+ ** method to avoid sharing context-dependent members. The duplication
+ ** functionality might be unnecessary (and perhaps even prohibited) after CDOs
+ ** are initialized.
  **
  ** The methods used by the Marabou search:
  **  * markInfeasible( PhaseStatus caseId ) - which denotes explored search space

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -66,8 +66,7 @@ class ITableau;
 class InputQuery;
 class String;
 
-class ContextDependentPiecewiseLinearConstraint
-   : public virtual PiecewiseLinearConstraint
+class ContextDependentPiecewiseLinearConstraint : public PiecewiseLinearConstraint
 {
 public:
     ContextDependentPiecewiseLinearConstraint();

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -1,0 +1,346 @@
+/*********************                                                        */
+/*! \file ContextDependentPiecewiseLinearConstraint.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Aleksandar Zeljic
+ ** This file is part of the Marabou project.
+ ** Copyright (c) 2017-2020 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved. See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** A context dependent implementation of PiecewiseLinearConstraint class
+**/
+
+#ifndef __ContextDependentPiecewiseLinearConstraint_h__
+#define __ContextDependentPiecewiseLinearConstraint_h__
+
+#include "context/context.h"
+#include "context/cdo.h"
+#include "context/cdlist.h"
+#include "FloatUtils.h"
+#include "ITableau.h"
+#include "List.h"
+#include "Map.h"
+#include "MarabouError.h"
+#include "PiecewiseLinearCaseSplit.h"
+#include "PiecewiseLinearFunctionType.h"
+#include "Queue.h"
+#include "Tightening.h"
+
+class Equation;
+class BoundManager;
+class ITableau;
+class InputQuery;
+class String;
+
+enum PhaseStatus : unsigned {
+        PHASE_NOT_FIXED = 0,
+        RELU_PHASE_ACTIVE = 1,
+        RELU_PHASE_INACTIVE = 2,
+        ABS_PHASE_POSITIVE = 3,
+        ABS_PHASE_NEGATIVE = 4,
+        };
+
+virtual class ContextDependentPiecewiseLinearConstraint : public virtual PiecewiseLinearConstraint, public ITableau::VariableWatcher
+{
+public:
+
+    ContextDependentPiecewiseLinearConstraint();
+    ContextDependentPiecewiseLinearConstraint( unsigned numCases );
+    virtual ~ContextDependentPiecewiseLinearConstraint()
+    {
+        cdoCleanup();
+    }
+
+    bool operator<( const ContextDependentPiecewiseLinearConstraint &other ) const
+    {
+        return _score < other._score;
+    }
+
+    /*
+      Get the type of this constraint.
+    */
+    virtual PiecewiseLinearFunctionType getType() const = 0;
+
+    /*
+      Return a clone of the constraint. Allocates CDOs for the copy.
+    */
+    virtual ContextDependentPiecewiseLinearConstraint *duplicateConstraint() const = 0;
+
+    /*
+      Restore the state of this constraint from the given one.
+      We have this function in order to take advantage of the polymorphically
+      correct assignment operator.
+    */
+    virtual void restoreState( const ContextDependentPiecewiseLinearConstraint *state ) = 0;
+
+    /*
+      Register/unregister the constraint with a tableau.
+    */
+    virtual void registerAsWatcher( ITableau *tableau ) = 0;
+    virtual void unregisterAsWatcher( ITableau *tableau ) = 0;
+
+    /*
+      The variable watcher notifcation callbacks, about a change in a variable's value or bounds.
+    */
+    virtual void notifyVariableValue( unsigned /* variable */, double /* value */ ) {}
+    virtual void notifyLowerBound( unsigned /* variable */, double /* bound */ ) {}
+    virtual void notifyUpperBound( unsigned /* variable */, double /* bound */ ) {}
+
+    /*
+      Turn the constraint on/off.
+    */
+    void setActiveConstraint( bool active )
+    {
+        if ( nullptr != _cdConstraintActive )
+            *_cdConstraintActive = active;
+        else
+          _constraintActive = active;
+    }
+
+    bool isActive() const
+    {
+        if ( nullptr != _cdConstraintActive )
+            return *_cdConstraintActive;
+        else
+          return _constraintActive;
+    }
+
+    /*
+      Returns true iff the variable participates in this piecewise
+      linear constraint.
+    */
+    virtual bool participatingVariable( unsigned variable ) const = 0;
+
+    /*
+      Get the list of variables participating in this constraint.
+    */
+    virtual List<unsigned> getParticipatingVariables() const = 0;
+
+    /*
+      Returns true iff the assignment satisfies the constraint.
+    */
+    virtual bool satisfied() const = 0;
+
+    /*
+      Returns a list of possible fixes for the violated constraint.
+    */
+    virtual List<ContextDependentPiecewiseLinearConstraint::Fix> getPossibleFixes() const = 0;
+
+    /*
+      Return a list of smart fixes for violated constraint.
+    */
+    virtual List<ContextDependentPiecewiseLinearConstraint::Fix> getSmartFixes( ITableau *tableau ) const = 0;
+
+    /*
+      Returns the list of case splits that this piecewise linear
+      constraint breaks into. These splits need to complementary,
+      i.e. if the list is {l1, l2, ..., ln-1, ln},
+      then ~l1 /\ ~l2 /\ ... /\ ~ln-1 --> ln.
+    */
+    virtual List<PiecewiseLinearCaseSplit> getCaseSplits() const = 0;
+
+    /*
+     * Returns a list of all cases of this constraint
+     */
+    virtual List<PhaseStatus> getAllCases() const = 0;
+
+    /*
+     * Returns case split corresponding to the given phase/id
+     */
+    virtual PiecewiseLinearCaseSplit getCaseSplit( unsigned caseId ) const = 0;
+
+    /*
+      Check if the constraint's phase has been fixed.
+    */
+    virtual bool phaseFixed() const = 0;
+
+    /*
+      If the constraint's phase has been fixed, get the (valid) case split.
+    */
+    virtual PiecewiseLinearCaseSplit getImpliedCaseSplit() const = 0;
+
+    /*
+      Dump the current state of the constraint.
+    */
+    void dump() const;
+
+    /*
+      Dump the current state of the constraint.
+    */
+    virtual void dump( String & ) const {}
+
+    /*
+      Preprocessing related functions, to inform that a variable has been eliminated completely
+      because it was fixed to some value, or that a variable's index has changed (e.g., x4 is now
+      called x2). constraintObsolete() returns true iff and the constraint has become obsolote
+      as a result of variable eliminations.
+    */
+    virtual void eliminateVariable( unsigned variable, double fixedValue ) = 0;
+    virtual void updateVariableIndex( unsigned oldIndex, unsigned newIndex ) = 0;
+    virtual bool constraintObsolete() const = 0;
+
+    /*
+      Get the tightenings entailed by the constraint.
+    */
+    virtual void getEntailedTightenings( List<Tightening> &tightenings ) const = 0;
+
+    void setStatistics( Statistics *statistics );
+
+    /*
+      For preprocessing: get any auxiliary equations that this constraint would
+      like to add to the equation pool.
+    */
+    virtual void addAuxiliaryEquations( InputQuery &/* inputQuery */ ) {}
+
+    /*
+      Ask the piecewise linear constraint to contribute a component to the cost
+      function. If implemented, this component should be empty when the constraint is
+      satisfied or inactive, and should be non-empty otherwise. Minimizing the returned
+      equation should then lead to the constraint being "closer to satisfied".
+    */
+    virtual void getCostFunctionComponent( Map<unsigned, double> &/* cost */ ) const {}
+
+    /*
+      Produce string representation of the piecewise linear constraint.
+      This representation contains only the information necessary to reproduce it
+      but does not account for state or change in state during execution. Additionally
+      the first string before a comma has the contraint type identifier
+      (ie. "relu", "max", etc)
+    */
+    virtual String serializeToString() const = 0;
+
+    /*
+      Register a bound manager. If a bound manager is registered,
+      this piecewise linear constraint will inform the tightener whenever
+      it discovers a tighter (entailed) bound.
+    */
+    void registerBoundManager( BoundManager *boundManager );
+
+    /*
+      Return true if and only if this piecewise linear constraint supports
+      symbolic bound tightening.
+    */
+    virtual bool supportsSymbolicBoundTightening() const
+    {
+        return false;
+    }
+
+    /*
+      Return true if and only if this piecewise linear constraint supports
+      the polarity metric
+    */
+    virtual bool supportPolarity() const
+    {
+        return false;
+    }
+
+    /*
+      Update the preferred direction to take first when splitting on this PLConstraint
+    */
+    virtual void updateDirection()
+    {
+    }
+
+    virtual void updateScore()
+    {
+    }
+
+    /*
+       Register context object. Necessary for lazy backtracking features - such
+       as _cdPhaseStatus and _activeStatus. Does not require initialization until
+       after pre-processing.
+     */
+    void initializeCDOs( CVC4::context::Context *context );
+
+    /*
+       Politely clean up allocated CDOs.
+     */
+    void cdoCleanup();
+
+    CVC4::context::Context *getContext() const
+    {
+        return _context;
+    }
+
+    /*
+      Get the active status object - debugging purposes only
+    */
+    CVC4::context::CDO<bool> *getActiveStatusCDO() const
+    {
+        return _cdConstraintActive;
+    };
+
+    /*
+      Get the current phase status object - debugging purposes only
+    */
+    CVC4::context::CDO<PhaseStatus> *getPhaseStatusCDO() const
+    {
+            return _cdPhaseStatus;
+    }
+
+    /*
+      Get the infeasable cases object - debugging purposes only
+    */
+    CVC4::context::CDList<PhaseStatus> *getInfeasibleCasesCDList() const
+    {
+        return _cdInfeasibleCases;
+    }
+
+    /*
+       Mark that exploredCase is infeasible.
+     */
+    void markInfeasible( PhaseStatus exploredCase );
+
+    /*
+      Retrieve next feasible case; Worst case O(n^2)
+      Returns PhaseStatus representing next feasible case.
+      Returns PHASE_NOT_FIXED if no feasible case exists.
+     */
+    PhaseStatus nextFeasibleCase();
+
+    bool isFeasible();
+    bool isImplication();
+    unsigned numFeasibleCases();
+
+protected:
+    BoundManager *_boundManager;
+    CVC4::context::Context *_context;
+    CVC4::context::CDO<bool> *_cdConstraintActive;
+
+    /* ReluConstraint and AbsoluteValueConstraint use PhaseStatus enumeration.
+       MaxConstraint and Disjunction interpret the PhaseStatus value as the case
+       number (counts from 1, value 0 is reserved and used as PHASE_NOT_FIXED).
+    */
+    CVC4::context::CDO<PhaseStatus> *_cdPhaseStatus;
+
+    /*
+      Store infeasible cases under the current trail. Backtracks with context.
+    */
+    CVC4::context::CDList<PhaseStatus> *_cdInfeasibleCases;
+
+    unsigned _numCases;
+
+    /*
+      Initialize CDOs.
+    */
+    void initializeCDActiveStatus();
+    void initializeCDPhaseStatus();
+    void initializeDuplicatesCDOs( ContextDependentPiecewiseLinearConstraint *clone ) const;
+    void initializeCDInfeasibleCases();
+
+    void setPhaseStatus( PhaseStatus phaseStatus );
+    PhaseStatus getPhaseStatus() const;
+
+};
+
+#endif // __ContextDependentPiecewiseLinearConstraint_h__
+
+//
+// Local Variables:
+// compile-command: "make -C ../.. "
+// tags-file-name: "../../TAGS"
+// c-basic-offset: 4
+// End:
+//

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -131,7 +131,7 @@ public:
     /*
       Get the context object - debugging purposes only
     */
-    CVC4::context::Context *getContext() const
+    const CVC4::context::Context *getContext() const
     {
         return _context;
     }
@@ -139,7 +139,7 @@ public:
     /*
       Get the active status object - debugging purposes only
     */
-    CVC4::context::CDO<bool> *getActiveStatusCDO() const
+    const CVC4::context::CDO<bool> *getActiveStatusCDO() const
     {
         return _cdConstraintActive;
     };
@@ -147,7 +147,7 @@ public:
     /*
       Get the current phase status object - debugging purposes only
     */
-    CVC4::context::CDO<PhaseStatus> *getPhaseStatusCDO() const
+    const CVC4::context::CDO<PhaseStatus> *getPhaseStatusCDO() const
     {
         return _cdPhaseStatus;
     }
@@ -155,7 +155,7 @@ public:
     /*
       Get the infeasible cases object - debugging purposes only
     */
-    CVC4::context::CDList<PhaseStatus> *getInfeasibleCasesCDList() const
+    const CVC4::context::CDList<PhaseStatus> *getInfeasibleCasesCDList() const
     {
         return _cdInfeasibleCases;
     }

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -194,7 +194,7 @@ public:
      */
     bool isImplication() const
     {
-        return 1u == numFeasibleCases();
+        return numFeasibleCases() == 1u;
     }
 
 protected:

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -154,7 +154,7 @@ public:
     }
 
     /*
-      Get the infeasable cases object - debugging purposes only
+      Get the infeasible cases object - debugging purposes only
     */
     CVC4::context::CDList<PhaseStatus> *getInfeasibleCasesCDList() const
     {
@@ -226,7 +226,8 @@ protected:
     void initializeCDInfeasibleCases();
 
     /*
-       Method provided to allow safe copying of the context-dependent members, which will be freshly initialized in a copy and with the same values.
+       Method provided to allow safe copying of the context-dependent members,
+       which will be freshly initialized in a copy and with the same values.
      */
     void initializeDuplicatesCDOs( ContextDependentPiecewiseLinearConstraint *clone ) const;
 

--- a/src/engine/PiecewiseLinearConstraint.h
+++ b/src/engine/PiecewiseLinearConstraint.h
@@ -38,7 +38,10 @@ enum PhaseStatus : unsigned {
     ABS_PHASE_POSITIVE = 3,
     ABS_PHASE_NEGATIVE = 4,
     SIGN_PHASE_POSITIVE = 5,
-    SIGN_PHASE_NEGATIVE = 6
+    SIGN_PHASE_NEGATIVE = 6,
+
+    // SENTINEL VALUE
+    CONSTRAINT_INFEASIBLE = 65535
 };
 
 class PiecewiseLinearConstraint : public ITableau::VariableWatcher


### PR DESCRIPTION
This PR introduces an implementation of PiecewiseLinearConstraint using
context-dependent (CD) data structures from CVC4, which lazily and automatically
backtrack in sync with the central context object. These data structures
are delicate and require that data stored is safe to memcopy around. 
 
Members are initialized using the initializeCDOs( Context context ) method.
Subclasses need to call initializeDuplicatesCDOs() method in the
duplicateConstraint() method to avoid sharing context-dependent members.
CDOs need not be initialized for pre-processing purposes.

The class uses CDOs to record:
   * _cdConstraintActive
   * _cdPhaseStatus
   * _cdInfeasibleCases
 
PhaseStatus enumeration is used to keep track of current phase of the
object, as well as to record previously explored phases. This replaces
moving PiecewiseLinearCaseSplits around.
 
ContextDependentPiecewiseLinearConstraint stores locally which phases have
been explored so far using _cdInfeasibleCases. To communicate with the
search it implements two methods:
   * markInfeasible( PhaseStatus caseId ) - marks explored phase
   * nextFeasibleCase() - obtains next unexplored case if one exists
 
These methods rely on subclass properly handling:
   * _numCases field, which denotes the number of piecewise linear
      segments the constraint has, initialized by the constructor.
   * getAllCases() virtual method returns all possible phases represented using
     PhaseStatus enumeration. The order of returned cases will determine the
     search order, so this method should implement any search heuristics.
