### PR TITLE
Bound Manager Class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ endif()
 # We build a static library that is the core of the project, the link it to the
 # API's (executable and python at the moment)
 add_library(${MARABOU_LIB} ${DEPS_CVC4_CONTEXT} ${DEPS_CVC4_BASE} ${SRCS_COMMON_REAL} ${SRCS_ENGINE_REAL})
+target_include_directories(${MARABOU_LIB} PRIVATE SYSTEM)
 
 add_executable(${MARABOU_EXE} "${ENGINE_DIR}/main.cpp")
 set(MARABOU_EXE_PATH "${BIN_DIR}/${MARABOU_EXE}")
@@ -306,7 +307,7 @@ if(CXXTEST_FOUND)
     enable_testing()
 endif()
 
-target_link_libraries(${MARABOU_TEST_LIB} ${LIBS})
+target_link_libraries(${MARABOU_TEST_LIB} ${MARABOU_LIB} ${LIBS})
 target_include_directories(${MARABOU_TEST_LIB} PRIVATE ${LIBS_INCLUDES} )
 target_compile_options(${MARABOU_TEST_LIB} PRIVATE ${CXXTEST_FLAGS})
 

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -43,20 +43,20 @@ BoundManager::~BoundManager()
 
 void BoundManager::initialize( unsigned numberOfVariables )
 {
-    ASSERT( 0 == _size );
+    ASSERT( _size == 0 );
 
     for ( unsigned i = 0; i < numberOfVariables; ++i )
         registerNewVariable();
 
-    ASSERT( numberOfVariables == _size );
+    ASSERT( _size == numberOfVariables );
 }
 
 unsigned BoundManager::registerNewVariable()
 {
-    ASSERT( _lowerBounds.size() == _size );
-    ASSERT( _upperBounds.size() == _size );
-    ASSERT( _tightenedLower.size() == _size );
-    ASSERT( _tightenedUpper.size() == _size );
+    ASSERT( _size == _lowerBounds.size() );
+    ASSERT( _size == _upperBounds.size() );
+    ASSERT( _size == _tightenedLower.size() );
+    ASSERT( _size == _tightenedUpper.size() );
 
     unsigned newVar = _size++;
 
@@ -81,7 +81,7 @@ unsigned BoundManager::getNumberOfVariables() const
 bool BoundManager::tightenLowerBound( unsigned variable, double value )
 {
     bool tightened = setLowerBound( variable, value );
-    if ( tightened && nullptr != _tableau )
+    if ( tightened && _tableau != nullptr )
         _tableau->ensureNonBasicVariableGTLB( variable, value );
     return tightened;
 }
@@ -89,7 +89,7 @@ bool BoundManager::tightenLowerBound( unsigned variable, double value )
 bool BoundManager::tightenUpperBound( unsigned variable, double value )
 {
     bool tightened = setUpperBound( variable, value );
-    if ( tightened && nullptr != _tableau )
+    if ( tightened && _tableau != nullptr )
         _tableau->ensureNonBasicVariableLTUB( variable, value );
     return tightened;
 }
@@ -160,6 +160,6 @@ bool BoundManager::consistentBounds( unsigned variable )
 
 void BoundManager::registerTableauReference( Tableau *ptrTableau )
 {
-    ASSERT( nullptr == _tableau );
+    ASSERT( _tableau == nullptr );
     _tableau = ptrTableau;
 }

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -18,16 +18,30 @@
 
 using namespace CVC4::context;
 
-BoundManager::BoundManager( unsigned numberOfVariables, Context &context )
-    : _size( numberOfVariables )
+BoundManager::BoundManager( Context &context)
+    : _context(context)
+    , _size(0)
 {
-    for ( unsigned i = 0; i < numberOfVariables; ++i)
+};
+
+BoundManager::~BoundManager()
+{
+    for ( unsigned i = 0; i < _size; ++i)
     {
-      //CDList<double> lb ( &context, false );
-      //CDList<double> ub ( &context, false );
-      //new (true) CDList<double>( &context )
-      _lowerBounds.append( new (true) CDList<double>( &context ) );
-      _upperBounds.append( new (true) CDList<double>( &context ) );
+        _lowerBounds[i]->deleteSelf();
+        _upperBounds[i]->deleteSelf();
+    }
+};
+
+void BoundManager::initialize( unsigned numberOfVariables)
+{
+    ASSERT( 0 == _size);
+
+    _size = numberOfVariables;
+    for ( unsigned i = 0; i < _size; ++i)
+    {
+        _lowerBounds.append( new (true) CDList<double>( &_context ) );
+        _upperBounds.append( new (true) CDList<double>( &_context ) );
     }
 }
 
@@ -70,7 +84,6 @@ unsigned BoundManager::getSize( )
 {
   return _size;
 }
-
 
 //
 // Local Variables:

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -101,7 +101,7 @@ bool BoundManager::setLowerBound( unsigned variable, double value )
     {
         *_lowerBounds[variable] = value;
         *_tightenedLower[variable] = true;
-        if ( !boundValid( variable ) )
+        if ( !consistentBounds( variable ) )
             throw InfeasibleQueryException();
         return true;
     }
@@ -115,7 +115,7 @@ bool BoundManager::setUpperBound( unsigned variable, double value )
     {
         *_upperBounds[variable] = value ;
         *_tightenedUpper[variable] = true;
-        if ( !boundValid( variable ) )
+        if ( !consistentBounds( variable ) )
             throw InfeasibleQueryException();
         return true;
     }
@@ -159,6 +159,11 @@ void BoundManager::getTightenings( List<Tightening> &tightenings )
     }
 }
 
+bool BoundManager::consistentBounds( unsigned variable )
+{
+    ASSERT( variable < _size );
+    return FloatUtils::gte( getUpperBound( variable ), getLowerBound( variable ) );
+}
 
 void BoundManager::registerTableauReference( Tableau *ptrTableau )
 {

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -73,7 +73,7 @@ unsigned BoundManager::registerNewVariable()
     return newVar;
 }
 
-unsigned BoundManager::getNumberOfVariables()
+unsigned BoundManager::getNumberOfVariables() const
 {
     return _size;
 }

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -34,22 +34,33 @@ BoundManager::~BoundManager()
     }
 };
 
-void BoundManager::initialize( unsigned numberOfVariables)
+unsigned BoundManager::registerNewVariable()
+{
+    ASSERT( _lowerBounds.size() == _size );
+    ASSERT( _upperBounds.size() == _size );
+
+    unsigned newVar = _size++; 
+
+    _lowerBounds.append( new (true) CDList<double>( &_context ) );
+    _upperBounds.append( new (true) CDList<double>( &_context ) );
+
+    _lowerBounds[newVar]->push_back( FloatUtils::negativeInfinity() );
+    _upperBounds[newVar]->push_back( FloatUtils::infinity() );
+
+    ASSERT( _lowerBounds.size() == _size );
+    ASSERT( _upperBounds.size() == _size );
+
+    return newVar;
+}
+
+void BoundManager::initialize( unsigned numberOfVariables )
 {
     ASSERT( 0 == _size);
 
-    _size = numberOfVariables;
-    for ( unsigned i = 0; i < _size; ++i)
-    {
-        _lowerBounds.append( new (true) CDList<double>( &_context ) );
-        _upperBounds.append( new (true) CDList<double>( &_context ) );
-    }
+    for ( unsigned i = 0; i < numberOfVariables; ++i)
+        registerNewVariable();
 
-    for ( unsigned i = 0; i < _size; ++i)
-    {
-        _lowerBounds[i]->push_back( FloatUtils::negativeInfinity() );
-        _upperBounds[i]->push_back( FloatUtils::infinity() );
-    }
+    ASSERT( numberOfVariables == _size );
 }
 
 bool BoundManager::updateLowerBound( unsigned variable, double value )

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -65,13 +65,6 @@ void BoundManager::initialize( unsigned numberOfVariables )
     ASSERT( numberOfVariables == _size );
 }
 
-
-void BoundManager::registerTableauReference( Tableau *tableau )
-{
-    if ( NULL == _tableau )
-        _tableau = tableau;
-}
-
 bool BoundManager::setLowerBound( unsigned variable, double value )
 {
     ASSERT( variable < _size );
@@ -109,6 +102,12 @@ double BoundManager::getUpperBound( unsigned variable )
 {
   ASSERT( variable < _size );
   return *_upperBounds[variable];
+}
+
+void BoundManager::registerTableauReference( Tableau *ptrTableau )
+{
+    ASSERT( nullptr == _tableau );
+    _tableau = ptrTableau;
 }
 
 unsigned BoundManager::getSize( )

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -13,9 +13,9 @@
 
 **/
 
-#include "FloatUtils.h"
 #include "BoundManager.h"
 #include "Debug.h"
+#include "FloatUtils.h"
 #include "InfeasibleQueryException.h"
 #include "Tableau.h"
 #include "Tightening.h"
@@ -59,10 +59,10 @@ unsigned BoundManager::registerNewVariable()
 
     unsigned newVar = _size++;
 
-    _lowerBounds.append( new (true) CDO<double>( &_context ) );
-    _upperBounds.append( new (true) CDO<double>( &_context ) );
-    _tightenedLower.append( new (true) CDO<bool>( &_context ) );
-    _tightenedUpper.append( new (true) CDO<bool>( &_context ) );
+    _lowerBounds.append( new ( true ) CDO<double>( &_context ) );
+    _upperBounds.append( new ( true ) CDO<double>( &_context ) );
+    _tightenedLower.append( new ( true ) CDO<bool>( &_context ) );
+    _tightenedUpper.append( new ( true ) CDO<bool>( &_context ) );
 
     *_lowerBounds[newVar] = FloatUtils::negativeInfinity();
     *_upperBounds[newVar] = FloatUtils::infinity();
@@ -123,14 +123,14 @@ bool BoundManager::setUpperBound( unsigned variable, double value )
 
 double BoundManager::getLowerBound( unsigned variable )
 {
-  ASSERT( variable < _size );
-  return *_lowerBounds[variable];
+    ASSERT( variable < _size );
+    return *_lowerBounds[variable];
 }
 
 double BoundManager::getUpperBound( unsigned variable )
 {
-  ASSERT( variable < _size );
-  return *_upperBounds[variable];
+    ASSERT( variable < _size );
+    return *_upperBounds[variable];
 }
 
 void BoundManager::getTightenings( List<Tightening> &tightenings )

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -55,7 +55,7 @@ void BoundManager::initialize( unsigned numberOfVariables)
 bool BoundManager::updateLowerBound( unsigned variable, double value )
 {
     ASSERT( variable < _size );
-    if ( value < getLowerBound( variable ) )
+    if ( value > getLowerBound( variable ) )
     {
         _lowerBounds[variable]->push_back( value );
         return true;
@@ -66,7 +66,7 @@ bool BoundManager::updateLowerBound( unsigned variable, double value )
 bool BoundManager::updateUpperBound( unsigned variable, double value )
 {
      ASSERT( variable < _size );
-    if ( value > getUpperBound( variable ) )
+    if ( value < getUpperBound( variable ) )
     {
         _upperBounds[variable]->push_back( value );
         return true;

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -14,6 +14,7 @@
 **/
 
 #include "BoundManager.h"
+
 #include "Debug.h"
 #include "FloatUtils.h"
 #include "InfeasibleQueryException.h"

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -32,7 +32,7 @@ BoundManager::BoundManager( Context &context )
 
 BoundManager::~BoundManager()
 {
-    for ( unsigned i = 0; i < _size; ++i)
+    for ( unsigned i = 0; i < _size; ++i )
     {
         _lowerBounds[i]->deleteSelf();
         _upperBounds[i]->deleteSelf();
@@ -81,7 +81,7 @@ unsigned BoundManager::getNumberOfVariables()
 bool BoundManager::tightenLowerBound( unsigned variable, double value )
 {
     bool tightened = setLowerBound( variable, value );
-    if ( tightened &&  nullptr != _tableau )
+    if ( tightened && nullptr != _tableau )
         _tableau->ensureNonBasicVariableGTLB( variable, value );
     return tightened;
 }
@@ -113,7 +113,7 @@ bool BoundManager::setUpperBound( unsigned variable, double value )
     ASSERT( variable < _size );
     if ( value < getUpperBound( variable ) )
     {
-        *_upperBounds[variable] = value ;
+        *_upperBounds[variable] = value;
         *_tightenedUpper[variable] = true;
         if ( !consistentBounds( variable ) )
             throw InfeasibleQueryException();

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -24,8 +24,8 @@ using namespace CVC4::context;
 
 BoundManager::BoundManager( Context &context )
     : _context( context )
-    , _tableau( nullptr )
     , _size( 0 )
+    , _tableau( nullptr )
 {
 };
 

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -41,11 +41,11 @@ unsigned BoundManager::registerNewVariable()
 
     unsigned newVar = _size++; 
 
-    _lowerBounds.append( new (true) CDList<double>( &_context ) );
-    _upperBounds.append( new (true) CDList<double>( &_context ) );
+    _lowerBounds.append( new (true) CDO<double>( &_context ) );
+    _upperBounds.append( new (true) CDO<double>( &_context ) );
 
-    _lowerBounds[newVar]->push_back( FloatUtils::negativeInfinity() );
-    _upperBounds[newVar]->push_back( FloatUtils::infinity() );
+    *_lowerBounds[newVar] = FloatUtils::negativeInfinity();
+    *_upperBounds[newVar] = FloatUtils::infinity();
 
     ASSERT( _lowerBounds.size() == _size );
     ASSERT( _upperBounds.size() == _size );
@@ -68,7 +68,7 @@ bool BoundManager::setLowerBound( unsigned variable, double value )
     ASSERT( variable < _size );
     if ( value > getLowerBound( variable ) )
     {
-        _lowerBounds[variable]->push_back( value );
+        *_lowerBounds[variable] = value;
         return true;
     }
     return false;
@@ -79,7 +79,7 @@ bool BoundManager::setUpperBound( unsigned variable, double value )
      ASSERT( variable < _size );
     if ( value < getUpperBound( variable ) )
     {
-        _upperBounds[variable]->push_back( value );
+        *_upperBounds[variable] = value ;
         return true;
     }
     return false;
@@ -88,14 +88,14 @@ bool BoundManager::setUpperBound( unsigned variable, double value )
 double BoundManager::getLowerBound( unsigned variable )
 {
   ASSERT( variable < _size );
-  return _lowerBounds[variable]->back();
+  return *_lowerBounds[variable];
 }
 
 
 double BoundManager::getUpperBound( unsigned variable )
 {
   ASSERT( variable < _size );
-  return _upperBounds[variable]->back();
+  return *_upperBounds[variable];
 }
 
 unsigned BoundManager::getSize( )

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -152,7 +152,7 @@ void BoundManager::getTightenings( List<Tightening> &tightenings )
     }
 }
 
-bool BoundManager::consistentBounds( unsigned variable )
+bool BoundManager::consistentBounds( unsigned variable ) const
 {
     ASSERT( variable < _size );
     return FloatUtils::gte( getUpperBound( variable ), getLowerBound( variable ) );

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -13,6 +13,7 @@
 
 **/
 
+#include "FloatUtils.h"
 #include "BoundManager.h"
 #include "Debug.h"
 
@@ -42,6 +43,12 @@ void BoundManager::initialize( unsigned numberOfVariables)
     {
         _lowerBounds.append( new (true) CDList<double>( &_context ) );
         _upperBounds.append( new (true) CDList<double>( &_context ) );
+    }
+
+    for ( unsigned i = 0; i < _size; ++i)
+    {
+        _lowerBounds[i]->push_back( FloatUtils::negativeInfinity() );
+        _upperBounds[i]->push_back( FloatUtils::infinity() );
     }
 }
 

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -63,7 +63,7 @@ void BoundManager::initialize( unsigned numberOfVariables )
     ASSERT( numberOfVariables == _size );
 }
 
-bool BoundManager::updateLowerBound( unsigned variable, double value )
+bool BoundManager::setLowerBound( unsigned variable, double value )
 {
     ASSERT( variable < _size );
     if ( value > getLowerBound( variable ) )
@@ -74,7 +74,7 @@ bool BoundManager::updateLowerBound( unsigned variable, double value )
     return false;
 }
 
-bool BoundManager::updateUpperBound( unsigned variable, double value )
+bool BoundManager::setUpperBound( unsigned variable, double value )
 {
      ASSERT( variable < _size );
     if ( value < getUpperBound( variable ) )

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -163,11 +163,3 @@ void BoundManager::registerTableauReference( Tableau *ptrTableau )
     ASSERT( nullptr == _tableau );
     _tableau = ptrTableau;
 }
-
-//
-// Local Variables:
-// compile-command: "make -C ../.. "
-// tags-file-name: "../../TAGS"
-// c-basic-offset: 4
-// End:
-//

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -40,6 +40,16 @@ BoundManager::~BoundManager()
     }
 };
 
+void BoundManager::initialize( unsigned numberOfVariables )
+{
+    ASSERT( 0 == _size );
+
+    for ( unsigned i = 0; i < numberOfVariables; ++i )
+        registerNewVariable();
+
+    ASSERT( numberOfVariables == _size );
+}
+
 unsigned BoundManager::registerNewVariable()
 {
     ASSERT( _lowerBounds.size() == _size );
@@ -56,26 +66,15 @@ unsigned BoundManager::registerNewVariable()
 
     *_lowerBounds[newVar] = FloatUtils::negativeInfinity();
     *_upperBounds[newVar] = FloatUtils::infinity();
-
     *_tightenedLower[newVar] = false;
     *_tightenedUpper[newVar] = false;
-
-    ASSERT( _lowerBounds.size() == _size );
-    ASSERT( _upperBounds.size() == _size );
-    ASSERT( _tightenedLower.size() == _size );
-    ASSERT( _tightenedUpper.size() == _size );
 
     return newVar;
 }
 
-void BoundManager::initialize( unsigned numberOfVariables )
+unsigned BoundManager::getNumberOfVariables()
 {
-    ASSERT( 0 == _size);
-
-    for ( unsigned i = 0; i < numberOfVariables; ++i)
-        registerNewVariable();
-
-    ASSERT( numberOfVariables == _size );
+    return _size;
 }
 
 bool BoundManager::tightenLowerBound( unsigned variable, double value )
@@ -122,18 +121,11 @@ bool BoundManager::setUpperBound( unsigned variable, double value )
     return false;
 }
 
-bool BoundManager::boundValid( unsigned variable )
-{
-    ASSERT( variable < _size );
-    return FloatUtils::gte( getUpperBound( variable ), getLowerBound( variable ) );
-}
-
 double BoundManager::getLowerBound( unsigned variable )
 {
   ASSERT( variable < _size );
   return *_lowerBounds[variable];
 }
-
 
 double BoundManager::getUpperBound( unsigned variable )
 {
@@ -169,11 +161,6 @@ void BoundManager::registerTableauReference( Tableau *ptrTableau )
 {
     ASSERT( nullptr == _tableau );
     _tableau = ptrTableau;
-}
-
-unsigned BoundManager::getSize( )
-{
-  return _size;
 }
 
 //

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -1,0 +1,81 @@
+/*********************                                                        */
+/*! \file BoundManager.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Haoze Wu, Aleksandar Zeljic
+ ** This file is part of the Marabou project.
+ ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved. See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** [[ Add lengthier description here ]]
+
+**/
+
+#include "BoundManager.h"
+#include "Debug.h"
+
+using namespace CVC4::context;
+
+BoundManager::BoundManager( unsigned numberOfVariables, Context &context )
+    : _size( numberOfVariables )
+{
+    for ( unsigned i = 0; i < numberOfVariables; ++i)
+    {
+      //CDList<double> lb ( &context, false );
+      //CDList<double> ub ( &context, false );
+      //new (true) CDList<double>( &context )
+      _lowerBounds.append( new (true) CDList<double>( &context ) );
+      _upperBounds.append( new (true) CDList<double>( &context ) );
+    }
+}
+
+bool BoundManager::updateLowerBound( unsigned variable, double value )
+{
+    ASSERT( variable < _size );
+    if ( value < getLowerBound( variable ) )
+    {
+        _lowerBounds[variable]->push_back( value );
+        return true;
+    }
+    return false;
+}
+
+bool BoundManager::updateUpperBound( unsigned variable, double value )
+{
+     ASSERT( variable < _size );
+    if ( value > getUpperBound( variable ) )
+    {
+        _upperBounds[variable]->push_back( value );
+        return true;
+    }
+    return false;
+}
+
+double BoundManager::getLowerBound( unsigned variable )
+{
+  ASSERT( variable < _size );
+  return _lowerBounds[variable]->back();
+}
+
+
+double BoundManager::getUpperBound( unsigned variable )
+{
+  ASSERT( variable < _size );
+  return _upperBounds[variable]->back();
+}
+
+unsigned BoundManager::getSize( )
+{
+  return _size;
+}
+
+
+//
+// Local Variables:
+// compile-command: "make -C ../.. "
+// tags-file-name: "../../TAGS"
+// c-basic-offset: 4
+// End:
+//

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -122,16 +122,16 @@ bool BoundManager::setUpperBound( unsigned variable, double value )
     return false;
 }
 
-double BoundManager::getLowerBound( unsigned variable )
+double BoundManager::getLowerBound( unsigned variable ) const
 {
     ASSERT( variable < _size );
-    return *_lowerBounds[variable];
+    return *_lowerBounds.get(variable);
 }
 
-double BoundManager::getUpperBound( unsigned variable )
+double BoundManager::getUpperBound( unsigned variable ) const
 {
     ASSERT( variable < _size );
-    return *_upperBounds[variable];
+    return *_upperBounds.get(variable);
 }
 
 void BoundManager::getTightenings( List<Tightening> &tightenings )

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -65,27 +65,39 @@ void BoundManager::initialize( unsigned numberOfVariables )
     ASSERT( numberOfVariables == _size );
 }
 
+bool BoundManager::tightenLowerBound( unsigned variable, double value )
+{
+    bool tightened = setLowerBound( variable, value );
+    if ( tightened &&  nullptr != _tableau )
+        _tableau->ensureNonBasicVariableGTLB( variable, value );
+    return tightened;
+}
+
 bool BoundManager::setLowerBound( unsigned variable, double value )
 {
     ASSERT( variable < _size );
     if ( value > getLowerBound( variable ) )
     {
         *_lowerBounds[variable] = value;
-        if ( nullptr != _tableau )
-            _tableau->ensureNonBasicVariableGTLB( variable, value );
         return true;
     }
     return false;
 }
 
+bool BoundManager::tightenUpperBound( unsigned variable, double value )
+{
+    bool tightened = setUpperBound( variable, value );
+    if ( tightened && nullptr != _tableau )
+        _tableau->ensureNonBasicVariableLTUB( variable, value );
+    return tightened;
+}
+
 bool BoundManager::setUpperBound( unsigned variable, double value )
 {
-     ASSERT( variable < _size );
+    ASSERT( variable < _size );
     if ( value < getUpperBound( variable ) )
     {
         *_upperBounds[variable] = value ;
-        if ( nullptr != _tableau )
-            _tableau->ensureNonBasicVariableLTUB( variable, value );
         return true;
     }
     return false;

--- a/src/engine/BoundManager.cpp
+++ b/src/engine/BoundManager.cpp
@@ -82,7 +82,7 @@ bool BoundManager::tightenLowerBound( unsigned variable, double value )
 {
     bool tightened = setLowerBound( variable, value );
     if ( tightened && _tableau != nullptr )
-        _tableau->ensureNonBasicVariableGTLB( variable, value );
+        _tableau->updateVariableToComplyWithLowerBoundUpdate( variable, value );
     return tightened;
 }
 
@@ -90,7 +90,7 @@ bool BoundManager::tightenUpperBound( unsigned variable, double value )
 {
     bool tightened = setUpperBound( variable, value );
     if ( tightened && _tableau != nullptr )
-        _tableau->ensureNonBasicVariableLTUB( variable, value );
+        _tableau->updateVariableToComplyWithUpperBoundUpdate( variable, value );
     return tightened;
 }
 

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -44,10 +44,15 @@ public:
     bool setLowerBound( unsigned variable, double value );
     bool setUpperBound( unsigned variable, double value );
 
+    /*
+      Returns true if the bounds for the variable is valid
+    */
+    bool boundValid( unsigned variable );
+
     double getLowerBound( unsigned variable );
     double getUpperBound( unsigned variable );
 
-    void getConstraintTightenings( List<Tightening> &tightenings );
+    void getTightenings( List<Tightening> &tightenings );
 
     unsigned getSize(); //TODO: Rename to getNumberOfVariables
 

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -54,7 +54,10 @@ public:
 
     void getTightenings( List<Tightening> &tightenings );
 
-    unsigned getSize(); //TODO: Rename to getNumberOfVariables
+    /*
+          Returns true if the bounds for the variable is valid, used to detectConflict state.
+    */
+    bool consistentBounds( unsigned variable );
 
     void registerTableauReference( Tableau *tableau );
 

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -1,0 +1,56 @@
+/*********************                                                        */
+/*! \file BoundManager.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Haoze Wu, Aleksandar Zeljic
+ ** This file is part of the Marabou project.
+ ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved. See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** [[ Add lengthier description here ]]
+
+**/
+
+#ifndef __BoundManager_h__
+#define __BoundManager_h__
+
+#include "context/cdlist.h"
+#include "context/context.h"
+
+#include "Vector.h"
+
+class BoundManager
+{
+public:
+    BoundManager( unsigned numberOfVariables, CVC4::context::Context &ctx );
+
+    bool updateLowerBound( unsigned variable, double value );
+    bool updateUpperBound( unsigned variable, double value );
+
+    double getLowerBound( unsigned variable );
+    double getUpperBound( unsigned variable );
+
+    unsigned getSize();
+
+private:
+
+    unsigned _size;
+
+    // For now, assume variable number is the vector index
+    Vector<CVC4::context::CDList<double> *> _lowerBounds;
+    Vector<CVC4::context::CDList<double> *> _upperBounds;
+
+};
+
+
+#endif // __BoundManager_h__
+
+//
+// Local Variables:
+// compile-command: "make -C ../.. "
+// tags-file-name: "../../TAGS"
+// c-basic-offset: 4
+// End:
+//

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -16,7 +16,7 @@
 #ifndef __BoundManager_h__
 #define __BoundManager_h__
 
-#include "context/cdlist.h"
+#include "context/cdo.h"
 #include "context/context.h"
 
 #include "Vector.h"
@@ -49,8 +49,8 @@ private:
     CVC4::context::Context &_context;
     unsigned _size; // TODO: Make context sensitive, to account for growing 
     // For now, assume variable number is the vector index
-    Vector<CVC4::context::CDList<double> *> _lowerBounds;
-    Vector<CVC4::context::CDList<double> *> _upperBounds;
+    Vector<CVC4::context::CDO<double> *> _lowerBounds;
+    Vector<CVC4::context::CDO<double> *> _upperBounds;
 
 };
 

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -36,8 +36,8 @@ public:
 
     void initialize( unsigned numberOfVariables );
 
-    bool updateLowerBound( unsigned variable, double value );
-    bool updateUpperBound( unsigned variable, double value );
+    bool setLowerBound( unsigned variable, double value );
+    bool setUpperBound( unsigned variable, double value );
 
     double getLowerBound( unsigned variable );
     double getUpperBound( unsigned variable );

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -2,24 +2,37 @@
 /*! \file BoundManager.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Haoze Wu, Aleksandar Zeljic
+ **  Aleksandar Zeljic, Haoze Wu,
  ** This file is part of the Marabou project.
  ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
  ** All rights reserved. See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** BoundManager class is a context-dependent implementation of a centralized set
- ** of bounds. It is intended to be a single centralized object used between multiple
- ** bound tightener classes, which enables those classes to care only about bounds
- ** and forget about book-keeping.
+ ** BoundManager class is a context-dependent implementation of a centralized
+ ** variable registry and their bounds. The intent it so use a single
+ ** BoundManager object between multiple bound tightener classes, which enables
+ ** those classes to care only about bounds and forget about book-keeping.
  **
- ** BoundManager serves as a central variable registry and provides a method to obtain
- ** a new variable id: registerNewVariable().
+ ** BoundManager provides a method to obtain a new variable with:
+ ** registerNewVariable().
  **
  ** The bound values and tighten flags are stored using context-dependent objects,
- ** which backtrack automatically with a centralized _context object.
-**/
+ ** which backtrack automatically with the central _context object.
+ **
+ ** There are two sets of methods to set bounds:
+ **   * set*Bounds     - private method used to update bounds
+ **   * tighten*Bounds - public method to update bounds, propagates the new bounds
+ **                        to the _tableau (if registered) to keep the assignment and
+ **                      basic/non-basic variables updated accordingly.
+ **
+ ** As soon as bounds become inconsistent, i.e. lowerBound > upperBound, an
+ ** InfeasableQueryException is thrown. In the long run, we want the exception
+ ** replaced by a flag, and switch to the conflict analysis mode instead.
+ **
+ ** It is assumed that variables are not introduced on the fly, and as such
+ ** interaction with context-dependent features is not implemented.  
+ **/
 
 #ifndef __BoundManager_h__
 #define __BoundManager_h__
@@ -38,62 +51,67 @@ public:
     ~BoundManager();
 
     /*
-     * Initialize BoundManager to numberOfVariables
+       Initialize BoundManager and register numberOfVariables of variables
      */
     void initialize( unsigned numberOfVariables );
 
     /*
-     * Registers a new variable, grows the BoundManager size and bound vectors,
-     * initializes bounds to +/-inf, and returns the new index as the new variable.
+       Registers a new variable, grows the BoundManager size and bound vectors,
+       initializes new bounds to +/-inf, and returns the index of the new
+       variable.
      */
-    unsigned registerNewVariable( );
+    unsigned registerNewVariable();
 
     /*
-     * Returns number of registered variables
+       Returns number of registered variables
      */
     unsigned getNumberOfVariables();
 
     /*
-     * Communicates bounds to the bound Manager and informs _tableau of the changes,
-     * so that any necessary updates can be performed.
+       Communicates bounds to the bound Manager and informs _tableau of the
+       changes, so that any necessary updates can be performed.
      */
     bool tightenLowerBound( unsigned variable, double value );
     bool tightenUpperBound( unsigned variable, double value );
 
     /*
-     * Silently sets bounds to the assigned value, if consistent.
+       Silently sets bounds to the assigned value, checks bound consistency.
      */
     bool setLowerBound( unsigned variable, double value );
     bool setUpperBound( unsigned variable, double value );
 
     /*
-     * Return current bound value.
+       Return current bound value.
      */
     double getLowerBound( unsigned variable );
     double getUpperBound( unsigned variable );
 
     /*
-     * Obtain a list of all the bound updates since the last call to getTightenings.
+       Obtain a list of all the bound updates since the last call to
+       getTightenings.
      */
     void getTightenings( List<Tightening> &tightenings );
 
     /*
-          Returns true if the bounds for the variable is valid, used to detectConflict state.
+          Returns true if the bounds for the variable is valid, used to
+          detect a conflict state.
     */
     bool consistentBounds( unsigned variable );
 
 
     /*
-       Register Tableau reference for callbacks from tighten*Bound methods.
+       Register Tableau reference for callbacks from tighten*Bound methods. 
      */
     void registerTableauReference( Tableau *tableau );
 
 private:
     CVC4::context::Context &_context;
-    Tableau *_tableau;
     unsigned _size;
+    Tableau *_tableau; // Used only by callbacks
+
     Vector<CVC4::context::CDO<double> *> _lowerBounds;
     Vector<CVC4::context::CDO<double> *> _upperBounds;
+
     Vector<CVC4::context::CDO<bool> *> _tightenedLower;
     Vector<CVC4::context::CDO<bool> *> _tightenedUpper;
 };

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -27,19 +27,27 @@ public:
     BoundManager( CVC4::context::Context &ctx );
     ~BoundManager();
 
+
+    /*
+     * Registers a new variable, grows the BoundManager size and bound vectors,
+     * initializes bounds to +/-inf, and returns the new index as the new variable.
+     */
+    unsigned registerNewVariable( );
+
     void initialize( unsigned numberOfVariables );
+
     bool updateLowerBound( unsigned variable, double value );
     bool updateUpperBound( unsigned variable, double value );
 
     double getLowerBound( unsigned variable );
     double getUpperBound( unsigned variable );
 
-    unsigned getSize();
+    unsigned getSize(); //TODO: Rename to getNumberOfVariables
 
 private:
 
     CVC4::context::Context &_context;
-    unsigned _size;
+    unsigned _size; // TODO: Make context sensitive, to account for growing 
     // For now, assume variable number is the vector index
     Vector<CVC4::context::CDList<double> *> _lowerBounds;
     Vector<CVC4::context::CDList<double> *> _upperBounds;

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -116,13 +116,4 @@ private:
     Vector<CVC4::context::CDO<bool> *> _tightenedUpper;
 };
 
-
 #endif // __BoundManager_h__
-
-//
-// Local Variables:
-// compile-command: "make -C ../.. "
-// tags-file-name: "../../TAGS"
-// c-basic-offset: 4
-// End:
-//

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -96,7 +96,7 @@ public:
       Returns true if the bounds for the variable is valid, used to
       detect a conflict state.
     */
-    bool consistentBounds( unsigned variable );
+    bool consistentBounds( unsigned variable ) const;
 
     /*
        Register Tableau reference for callbacks from tighten*Bound methods.

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -83,8 +83,8 @@ public:
     /*
        Return current bound value.
      */
-    double getLowerBound( unsigned variable );
-    double getUpperBound( unsigned variable );
+    double getLowerBound( unsigned variable ) const;
+    double getUpperBound( unsigned variable ) const;
 
     /*
        Obtain a list of all the bound updates since the last call to

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -24,8 +24,10 @@
 class BoundManager
 {
 public:
-    BoundManager( unsigned numberOfVariables, CVC4::context::Context &ctx );
+    BoundManager( CVC4::context::Context &ctx );
+    ~BoundManager();
 
+    void initialize( unsigned numberOfVariables );
     bool updateLowerBound( unsigned variable, double value );
     bool updateUpperBound( unsigned variable, double value );
 
@@ -36,8 +38,8 @@ public:
 
 private:
 
+    CVC4::context::Context &_context;
     unsigned _size;
-
     // For now, assume variable number is the vector index
     Vector<CVC4::context::CDList<double> *> _lowerBounds;
     Vector<CVC4::context::CDList<double> *> _upperBounds;

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -37,6 +37,9 @@ public:
 
     void initialize( unsigned numberOfVariables );
 
+    bool tightenLowerBound( unsigned variable, double value );
+    bool tightenUpperBound( unsigned variable, double value );
+
     bool setLowerBound( unsigned variable, double value );
     bool setUpperBound( unsigned variable, double value );
 

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -37,10 +37,10 @@
 #ifndef __BoundManager_h__
 #define __BoundManager_h__
 
-#include "context/cdo.h"
-#include "context/context.h"
 #include "List.h"
 #include "Vector.h"
+#include "context/cdo.h"
+#include "context/context.h"
 
 class Tableau;
 class Tightening;

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -93,14 +93,13 @@ public:
     void getTightenings( List<Tightening> &tightenings );
 
     /*
-          Returns true if the bounds for the variable is valid, used to
-          detect a conflict state.
+      Returns true if the bounds for the variable is valid, used to
+      detect a conflict state.
     */
     bool consistentBounds( unsigned variable );
 
-
     /*
-       Register Tableau reference for callbacks from tighten*Bound methods. 
+       Register Tableau reference for callbacks from tighten*Bound methods.
      */
     void registerTableauReference( Tableau *tableau );
 

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -65,7 +65,7 @@ public:
     /*
        Returns number of registered variables
      */
-    unsigned getNumberOfVariables();
+    unsigned getNumberOfVariables() const;
 
     /*
        Communicates bounds to the bound Manager and informs _tableau of the

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -18,8 +18,9 @@
 
 #include "context/cdo.h"
 #include "context/context.h"
-
 #include "Vector.h"
+
+class Tableau;
 
 class BoundManager
 {
@@ -44,9 +45,12 @@ public:
 
     unsigned getSize(); //TODO: Rename to getNumberOfVariables
 
+    void registerTableauReference( Tableau *tableau );
+
 private:
 
     CVC4::context::Context &_context;
+    Tableau *_tableau;
     unsigned _size; // TODO: Make context sensitive, to account for growing 
     // For now, assume variable number is the vector index
     Vector<CVC4::context::CDO<double> *> _lowerBounds;

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -18,10 +18,11 @@
 
 #include "context/cdo.h"
 #include "context/context.h"
+#include "List.h"
 #include "Vector.h"
 
 class Tableau;
-
+class Tightening;
 class BoundManager
 {
 public:
@@ -46,6 +47,8 @@ public:
     double getLowerBound( unsigned variable );
     double getUpperBound( unsigned variable );
 
+    void getConstraintTightenings( List<Tightening> &tightenings );
+
     unsigned getSize(); //TODO: Rename to getNumberOfVariables
 
     void registerTableauReference( Tableau *tableau );
@@ -58,6 +61,10 @@ private:
     // For now, assume variable number is the vector index
     Vector<CVC4::context::CDO<double> *> _lowerBounds;
     Vector<CVC4::context::CDO<double> *> _upperBounds;
+    Vector<CVC4::context::CDO<bool> *> _tightenedLower;
+    Vector<CVC4::context::CDO<bool> *> _tightenedUpper;
+
+
 
 };
 

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -9,8 +9,16 @@
  ** All rights reserved. See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** [[ Add lengthier description here ]]
-
+ ** BoundManager class is a context-dependent implementation of a centralized set
+ ** of bounds. It is intended to be a single centralized object used between multiple
+ ** bound tightener classes, which enables those classes to care only about bounds
+ ** and forget about book-keeping.
+ **
+ ** BoundManager serves as a central variable registry and provides a method to obtain
+ ** a new variable id: registerNewVariable().
+ **
+ ** The bound values and tighten flags are stored using context-dependent objects,
+ ** which backtrack automatically with a centralized _context object.
 **/
 
 #ifndef __BoundManager_h__
@@ -29,6 +37,10 @@ public:
     BoundManager( CVC4::context::Context &ctx );
     ~BoundManager();
 
+    /*
+     * Initialize BoundManager to numberOfVariables
+     */
+    void initialize( unsigned numberOfVariables );
 
     /*
      * Registers a new variable, grows the BoundManager size and bound vectors,
@@ -36,22 +48,33 @@ public:
      */
     unsigned registerNewVariable( );
 
-    void initialize( unsigned numberOfVariables );
+    /*
+     * Returns number of registered variables
+     */
+    unsigned getNumberOfVariables();
 
+    /*
+     * Communicates bounds to the bound Manager and informs _tableau of the changes,
+     * so that any necessary updates can be performed.
+     */
     bool tightenLowerBound( unsigned variable, double value );
     bool tightenUpperBound( unsigned variable, double value );
 
+    /*
+     * Silently sets bounds to the assigned value, if consistent.
+     */
     bool setLowerBound( unsigned variable, double value );
     bool setUpperBound( unsigned variable, double value );
 
     /*
-      Returns true if the bounds for the variable is valid
-    */
-    bool boundValid( unsigned variable );
-
+     * Return current bound value.
+     */
     double getLowerBound( unsigned variable );
     double getUpperBound( unsigned variable );
 
+    /*
+     * Obtain a list of all the bound updates since the last call to getTightenings.
+     */
     void getTightenings( List<Tightening> &tightenings );
 
     /*
@@ -59,21 +82,20 @@ public:
     */
     bool consistentBounds( unsigned variable );
 
+
+    /*
+       Register Tableau reference for callbacks from tighten*Bound methods.
+     */
     void registerTableauReference( Tableau *tableau );
 
 private:
-
     CVC4::context::Context &_context;
     Tableau *_tableau;
-    unsigned _size; // TODO: Make context sensitive, to account for growing 
-    // For now, assume variable number is the vector index
+    unsigned _size;
     Vector<CVC4::context::CDO<double> *> _lowerBounds;
     Vector<CVC4::context::CDO<double> *> _upperBounds;
     Vector<CVC4::context::CDO<bool> *> _tightenedLower;
     Vector<CVC4::context::CDO<bool> *> _tightenedUpper;
-
-
-
 };
 
 

--- a/src/engine/BoundManager.h
+++ b/src/engine/BoundManager.h
@@ -21,8 +21,8 @@
  ** which backtrack automatically with the central _context object.
  **
  ** There are two sets of methods to set bounds:
- **   * set*Bounds     - private method used to update bounds
- **   * tighten*Bounds - public method to update bounds, propagates the new bounds
+ **   * set*Bounds     - local method used to update bounds
+ **   * tighten*Bounds - shared method to update bounds, propagates the new bounds
  **                        to the _tableau (if registered) to keep the assignment and
  **                      basic/non-basic variables updated accordingly.
  **
@@ -31,7 +31,7 @@
  ** replaced by a flag, and switch to the conflict analysis mode instead.
  **
  ** It is assumed that variables are not introduced on the fly, and as such
- ** interaction with context-dependent features is not implemented.  
+ ** interaction with context-dependent features is not implemented.
  **/
 
 #ifndef __BoundManager_h__

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -18,6 +18,7 @@ endmacro()
 
 engine_add_unit_test(AbsoluteValueConstraint)
 engine_add_unit_test(BlandsRule)
+engine_add_unit_test(BoundManager)
 engine_add_unit_test(ConstraintBoundTightener)
 engine_add_unit_test(ConstraintMatrixAnalyzer)
 engine_add_unit_test(CostFunctionManager)

--- a/src/engine/Tableau.cpp
+++ b/src/engine/Tableau.cpp
@@ -1731,18 +1731,18 @@ void Tableau::ensureNonBasicVariableLTUB( unsigned variable, double value )
 {
     unsigned index = _variableToIndex[variable];
     if ( !_basicVariables.exists( variable ) )
-        {
-            if ( FloatUtils::lt( value, _nonBasicAssignment[index] ) )
-                setNonBasicAssignment( variable, value, true );
-        }
+    {
+        if ( FloatUtils::lt( value, _nonBasicAssignment[index] ) )
+            setNonBasicAssignment( variable, value, true );
+    }
     else
-        {
-            // Recompute the status of an affected basic variable
-            // If the status changes, invalidate the cost function
-            unsigned oldStatus = _basicStatus[index];
-            computeBasicStatus( index );
-            if ( _basicStatus[index] != oldStatus )
-                _costFunctionManager->invalidateCostFunction();
+    {
+        // Recompute the status of an affected basic variable
+        // If the status changes, invalidate the cost function
+        unsigned oldStatus = _basicStatus[index];
+        computeBasicStatus( index );
+        if ( _basicStatus[index] != oldStatus )
+            _costFunctionManager->invalidateCostFunction();
     }
 }
 

--- a/src/engine/Tableau.cpp
+++ b/src/engine/Tableau.cpp
@@ -1705,8 +1705,8 @@ bool Tableau::allBoundsValid() const
     return _boundsValid;
 }
 
-// Ensure that non-basic variables are within bounds
-void Tableau::ensureNonBasicVariableGTLB( unsigned variable, double value )
+
+void Tableau::updateVariableAfterLowerBoundUpdate( unsigned variable, double value )
 {
     unsigned index = _variableToIndex[variable];
     if ( !_basicVariables.exists( variable ) )
@@ -1725,9 +1725,7 @@ void Tableau::ensureNonBasicVariableGTLB( unsigned variable, double value )
     }
 }
 
-
-// Ensure that non-basic variables are within bounds
-void Tableau::ensureNonBasicVariableLTUB( unsigned variable, double value )
+void Tableau::updateVariableAfterUpperBoundUpdate( unsigned variable, double value )
 {
     unsigned index = _variableToIndex[variable];
     if ( !_basicVariables.exists( variable ) )
@@ -1758,7 +1756,7 @@ void Tableau::tightenLowerBound( unsigned variable, double value )
 
     setLowerBound( variable, value );
 
-    ensureNonBasicVariableGTLB( variable, value );
+    updateVariableAfterLowerBoundUpdate( variable, value );
 }
 
 void Tableau::tightenUpperBound( unsigned variable, double value )
@@ -1773,7 +1771,7 @@ void Tableau::tightenUpperBound( unsigned variable, double value )
 
     setUpperBound( variable, value );
 
-    ensureNonBasicVariableLTUB( variable, value );
+    updateVariableAfterUpperBoundUpdate( variable, value );
 }
 
 unsigned Tableau::addEquation( const Equation &equation )

--- a/src/engine/Tableau.cpp
+++ b/src/engine/Tableau.cpp
@@ -1706,7 +1706,7 @@ bool Tableau::allBoundsValid() const
 }
 
 
-void Tableau::updateVariableAfterLowerBoundUpdate( unsigned variable, double value )
+void Tableau::updateVariableToComplyWithLowerBoundUpdate( unsigned variable, double value )
 {
     unsigned index = _variableToIndex[variable];
     if ( !_basicVariables.exists( variable ) )
@@ -1725,7 +1725,7 @@ void Tableau::updateVariableAfterLowerBoundUpdate( unsigned variable, double val
     }
 }
 
-void Tableau::updateVariableAfterUpperBoundUpdate( unsigned variable, double value )
+void Tableau::updateVariableToComplyWithUpperBoundUpdate( unsigned variable, double value )
 {
     unsigned index = _variableToIndex[variable];
     if ( !_basicVariables.exists( variable ) )
@@ -1756,7 +1756,7 @@ void Tableau::tightenLowerBound( unsigned variable, double value )
 
     setLowerBound( variable, value );
 
-    updateVariableAfterLowerBoundUpdate( variable, value );
+    updateVariableToComplyWithLowerBoundUpdate( variable, value );
 }
 
 void Tableau::tightenUpperBound( unsigned variable, double value )
@@ -1771,7 +1771,7 @@ void Tableau::tightenUpperBound( unsigned variable, double value )
 
     setUpperBound( variable, value );
 
-    updateVariableAfterUpperBoundUpdate( variable, value );
+    updateVariableToComplyWithUpperBoundUpdate( variable, value );
 }
 
 unsigned Tableau::addEquation( const Equation &equation )

--- a/src/engine/Tableau.cpp
+++ b/src/engine/Tableau.cpp
@@ -1710,18 +1710,18 @@ void Tableau::updateVariableAfterLowerBoundUpdate( unsigned variable, double val
 {
     unsigned index = _variableToIndex[variable];
     if ( !_basicVariables.exists( variable ) )
-        {
-            if ( FloatUtils::gt( value, _nonBasicAssignment[index] ) )
-                setNonBasicAssignment( variable, value, true );
-        }
+    {
+        if ( FloatUtils::gt( value, _nonBasicAssignment[index] ) )
+            setNonBasicAssignment( variable, value, true );
+    }
     else
-        {
-            // Recompute the status of an affected basic variable
-            // If the status changes, invalidate the cost function
-            unsigned oldStatus = _basicStatus[index];
-            computeBasicStatus( index );
-            if ( _basicStatus[index] != oldStatus )
-                _costFunctionManager->invalidateCostFunction();
+    {
+        // Recompute the status of an affected basic variable
+        // If the status changes, invalidate the cost function
+        unsigned oldStatus = _basicStatus[index];
+        computeBasicStatus( index );
+        if ( _basicStatus[index] != oldStatus )
+            _costFunctionManager->invalidateCostFunction();
     }
 }
 

--- a/src/engine/Tableau.cpp
+++ b/src/engine/Tableau.cpp
@@ -33,8 +33,8 @@
 #include <string.h>
 
 Tableau::Tableau()
-    : _n ( 0 )
-    , _m ( 0 )
+    : _n( 0 )
+    , _m( 0 )
     , _A( NULL )
     , _sparseColumnsOfA( NULL )
     , _sparseRowsOfA( NULL )
@@ -348,7 +348,7 @@ void Tableau::initializeTableau( const List<unsigned> &initialBasicVariables )
 
     // Assign the basic indices
     unsigned basicIndex = 0;
-    for( unsigned basicVar : initialBasicVariables )
+    for ( unsigned basicVar : initialBasicVariables )
     {
         markAsBasic( basicVar );
         assignIndexToBasicVariable( basicVar, basicIndex );

--- a/src/engine/Tableau.cpp
+++ b/src/engine/Tableau.cpp
@@ -13,6 +13,8 @@
 
  **/
 
+#include "Tableau.h"
+
 #include "BasisFactorizationFactory.h"
 #include "CSRMatrix.h"
 #include "ConstraintMatrixAnalyzer.h"
@@ -25,7 +27,6 @@
 #include "MalformedBasisException.h"
 #include "MarabouError.h"
 #include "PiecewiseLinearCaseSplit.h"
-#include "Tableau.h"
 #include "TableauRow.h"
 #include "TableauState.h"
 

--- a/src/engine/Tableau.h
+++ b/src/engine/Tableau.h
@@ -390,6 +390,13 @@ public:
     void setBasicAssignmentStatus( ITableau::BasicAssignmentStatus status );
 
     /*
+      Callback from the BoundManager to ensure that non-basic variable
+      assignment is consistent with the new bounds.
+     */
+    void ensureNonBasicVariableGTLB( unsigned variable, double value );
+    void ensureNonBasicVariableLTUB( unsigned variable, double value );
+
+    /*
       True if the basic variable is out of bounds
     */
     bool basicOutOfBounds( unsigned basic ) const;

--- a/src/engine/Tableau.h
+++ b/src/engine/Tableau.h
@@ -390,11 +390,12 @@ public:
     void setBasicAssignmentStatus( ITableau::BasicAssignmentStatus status );
 
     /*
-      Callback from the BoundManager to ensure that non-basic variable
-      assignment is consistent with the new bounds.
-     */
-    void ensureNonBasicVariableGTLB( unsigned variable, double value );
-    void ensureNonBasicVariableLTUB( unsigned variable, double value );
+      Callbacks for the BoundManager to update assignment of a non-basic
+      variable or status of a basic variable after a lower/upper bound is
+      updated.
+    */
+    void updateVariableToComplyWithLowerBoundUpdate( unsigned variable, double value );
+    void updateVariableToComplyWithUpperBoundUpdate( unsigned variable, double value );
 
     /*
       True if the basic variable is out of bounds

--- a/src/engine/tests/Test_BoundManager.h
+++ b/src/engine/tests/Test_BoundManager.h
@@ -46,10 +46,42 @@ public:
 
         for ( unsigned i = 0; i < numberOfVariables; ++i)
         {
-          TS_ASSERT( boundManager.getLowerBound( i ) >= FloatUtils::negativeInfinity() ) ;
-          TS_ASSERT( boundManager.getUpperBound( i ) <= FloatUtils::infinity() ) ;
+            TS_ASSERT( FloatUtils::areEqual( boundManager.getLowerBound( i ),
+                                             FloatUtils::negativeInfinity() ) );
+            TS_ASSERT( FloatUtils::areEqual( boundManager.getUpperBound( i ),
+                                             FloatUtils::infinity() ) );
         }
 
+    }
+
+    /*
+     * BoundManager correctly updates the number of variables with advancement
+     * and backtracking of context
+     *
+     */
+    void test_register_variable()
+    {
+        CVC4::context::Context context;
+
+        BoundManager boundManager(context);
+
+        unsigned numberOfVariables = 5u;
+
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( numberOfVariables ) );
+
+        TS_ASSERT_EQUALS( boundManager.getSize(), 5u );
+        TS_ASSERT( FloatUtils::areEqual( boundManager.getLowerBound( 4 ),
+                                         FloatUtils::negativeInfinity() ) );
+        TS_ASSERT( FloatUtils::areEqual( boundManager.getUpperBound( 4 ),
+                                         FloatUtils::infinity() ) );
+
+        TS_ASSERT_THROWS_NOTHING( boundManager.registerNewVariable() );
+        TS_ASSERT_THROWS_NOTHING( boundManager.registerNewVariable() );
+        TS_ASSERT_EQUALS( boundManager.getSize(), 7u );
+        TS_ASSERT( FloatUtils::areEqual( boundManager.getLowerBound( 6 ),
+                                         FloatUtils::negativeInfinity() ) );
+        TS_ASSERT( FloatUtils::areEqual( boundManager.getUpperBound( 6 ),
+                                         FloatUtils::infinity() ) );
     }
 
     /*
@@ -64,7 +96,7 @@ public:
 
       unsigned numberOfVariables = 5u;
 
-      TS_ASSERT_THROWS_NOTHING( boundManager.initialize( numberOfVariables) );
+      TS_ASSERT_THROWS_NOTHING( boundManager.initialize( numberOfVariables ) );
 
       double level0Lower[] = { -12.357682,  0.230001234, -333.78091231, 100.00,    -9.000002354 };
       double level0Upper[] = {  15.387692, 20.301878234,   45.79159213, 120.03559, 89.53402 };

--- a/src/engine/tests/Test_BoundManager.h
+++ b/src/engine/tests/Test_BoundManager.h
@@ -78,8 +78,8 @@ public:
 
       for ( unsigned v = 0; v < numberOfVariables; ++v )
       {
-        TS_ASSERT_THROWS_NOTHING( boundManager.updateLowerBound( v, level0Lower[v] ) );
-        TS_ASSERT_THROWS_NOTHING( boundManager.updateUpperBound( v, level0Upper[v] ) );
+        TS_ASSERT_THROWS_NOTHING( boundManager.setLowerBound( v, level0Lower[v] ) );
+        TS_ASSERT_THROWS_NOTHING( boundManager.setUpperBound( v, level0Upper[v] ) );
 
         TS_ASSERT_EQUALS( boundManager.getLowerBound( v ), level0Lower[v] );
         TS_ASSERT_EQUALS( boundManager.getUpperBound( v ), level0Upper[v] );
@@ -89,8 +89,8 @@ public:
 
       for ( unsigned v = 0; v < numberOfVariables; ++v )
       {
-          TS_ASSERT_THROWS_NOTHING( boundManager.updateLowerBound( v, level1Lower[v] ) );
-          TS_ASSERT_THROWS_NOTHING( boundManager.updateUpperBound( v, level1Upper[v] ) );
+          TS_ASSERT_THROWS_NOTHING( boundManager.setLowerBound( v, level1Lower[v] ) );
+          TS_ASSERT_THROWS_NOTHING( boundManager.setUpperBound( v, level1Upper[v] ) );
 
           TS_ASSERT_EQUALS( boundManager.getLowerBound( v ), level1Lower[v] );
           TS_ASSERT_EQUALS( boundManager.getUpperBound( v ), level1Upper[v] );
@@ -101,8 +101,8 @@ public:
 
       for ( unsigned v = 0; v < numberOfVariables; ++v )
       {
-          TS_ASSERT_THROWS_NOTHING( boundManager.updateLowerBound( v, level2Lower[v] ) );
-          TS_ASSERT_THROWS_NOTHING( boundManager.updateUpperBound( v, level2Upper[v] ) );
+          TS_ASSERT_THROWS_NOTHING( boundManager.setLowerBound( v, level2Lower[v] ) );
+          TS_ASSERT_THROWS_NOTHING( boundManager.setUpperBound( v, level2Upper[v] ) );
 
           TS_ASSERT_EQUALS( boundManager.getLowerBound( v ), level2Lower[v] );
           TS_ASSERT_EQUALS( boundManager.getUpperBound( v ), level2Upper[v] );
@@ -128,8 +128,8 @@ public:
 
       for ( unsigned v = 0; v < numberOfVariables; ++v )
       {
-          TS_ASSERT_THROWS_NOTHING( boundManager.updateLowerBound( v, level1Lower[v] ) );
-          TS_ASSERT_THROWS_NOTHING( boundManager.updateUpperBound( v, level1Upper[v] ) );
+          TS_ASSERT_THROWS_NOTHING( boundManager.setLowerBound( v, level1Lower[v] ) );
+          TS_ASSERT_THROWS_NOTHING( boundManager.setUpperBound( v, level1Upper[v] ) );
 
           TS_ASSERT_EQUALS( boundManager.getLowerBound( v ), level1Lower[v] );
           TS_ASSERT_EQUALS( boundManager.getUpperBound( v ), level1Upper[v] );
@@ -137,8 +137,8 @@ public:
 
       for ( unsigned v = 0; v < numberOfVariables; ++v )
         {
-          TS_ASSERT_THROWS_NOTHING( boundManager.updateLowerBound( v, level2Lower[v] ) );
-          TS_ASSERT_THROWS_NOTHING( boundManager.updateUpperBound( v, level2Upper[v] ) );
+          TS_ASSERT_THROWS_NOTHING( boundManager.setLowerBound( v, level2Lower[v] ) );
+          TS_ASSERT_THROWS_NOTHING( boundManager.setUpperBound( v, level2Upper[v] ) );
 
           TS_ASSERT_EQUALS( boundManager.getLowerBound( v ), level2Lower[v] );
           TS_ASSERT_EQUALS( boundManager.getUpperBound( v ), level2Upper[v] );

--- a/src/engine/tests/Test_BoundManager.h
+++ b/src/engine/tests/Test_BoundManager.h
@@ -1,0 +1,118 @@
+/*********************                                                        */
+/*! \file Test_BoundManager.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Haoze (Andrew) Wu, Aleksandar Zeljic
+ ** This file is part of the Marabou project.
+ ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved. See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** [[ Add lengthier description here ]]
+
+**/
+
+#include <cxxtest/TestSuite.h>
+
+#include "BoundManager.h"
+#include "context/cdlist.h"
+#include "context/context.h"
+#include "FloatUtils.h"
+
+class BoundManagerTestSuite : public CxxTest::TestSuite
+{
+public:
+
+    void setUp()
+    {
+    }
+
+    void tearDown()
+    {
+    }
+
+    void test_bound_manager_initialize()
+    {
+        CVC4::context::Context context;
+        BoundManager boundManager(context);
+
+        unsigned numberOfVariables = 5u;
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( numberOfVariables) );
+
+        for ( unsigned i = 0; i < numberOfVariables; ++i)
+        {
+          TS_ASSERT( boundManager.getLowerBound( i ) >= FloatUtils::negativeInfinity() ) ;
+          TS_ASSERT( boundManager.getUpperBound( i ) <= FloatUtils::infinity() ) ;
+        }
+
+
+        /* RowBoundTightener tightener( *tableau, boundManager ); */
+
+        /* tableau->setDimensions( 2, 5 ); */
+
+        /* // Current bounds: */
+        /* //  0 <= x0 <= 0 */
+        /* //    5  <= x1 <= 10 */
+        /* //    -2 <= x2 <= 3 */
+        /* //  -100 <= x4 <= 100 */
+        /* tableau->setLowerBound( 0, -200 ); */
+        /* tableau->setUpperBound( 0, 200 ); */
+        /* tableau->setLowerBound( 1, 5 ); */
+        /* tableau->setUpperBound( 1, 10 ); */
+        /* tableau->setLowerBound( 2, -2 ); */
+        /* tableau->setUpperBound( 2, 3 ); */
+        /* tableau->setLowerBound( 3, -5 ); */
+        /* tableau->setUpperBound( 3, 5 ); */
+        /* tableau->setLowerBound( 4, -100 ); */
+        /* tableau->setUpperBound( 4, 100 ); */
+
+        /* tightener.setDimensions(); */
+
+        /* TableauRow row( 3 ); */
+        /* // 1 - x0 - x1 + 2x2 */
+        /* row._row[0] = TableauRow::Entry( 0, -1 ); */
+        /* row._row[1] = TableauRow::Entry( 1, -1 ); */
+        /* row._row[2] = TableauRow::Entry( 2, 2 ); */
+        /* row._scalar = 1; */
+        /* row._lhs = 4; */
+
+        /* tableau->nextPivotRow = &row; */
+
+        /* // 1 - x0 - x1 + 2x2 = x4 (pre pivot) */
+        /* // x0 entering, x4 leaving */
+        /* // x0 = 1 - x1 + 2 x2 - x4 */
+
+        /* TS_ASSERT_THROWS_NOTHING( tightener.examinePivotRow() ); */
+
+        /* List<Tightening> tightenings; */
+        /* TS_ASSERT_THROWS_NOTHING( tightener.getRowTightenings( tightenings ) ); */
+
+        /* // Lower and upper bounds should have been tightened */
+        /* TS_ASSERT_EQUALS( tightenings.size(), 2U ); */
+
+        /* auto lower = tightenings.begin(); */
+        /* while ( ( lower != tightenings.end() ) && !( ( lower->_variable == 0 ) && ( lower->_type == Tightening::LB ) ) ) */
+        /*     ++lower; */
+        /* TS_ASSERT( lower != tightenings.end() ); */
+
+        /* auto upper = tightenings.begin(); */
+        /* while ( ( upper != tightenings.end() ) && !( ( upper->_variable == 0 ) && ( upper->_type == Tightening::UB ) ) ) */
+        /*     ++upper; */
+        /* TS_ASSERT( upper != tightenings.end() ); */
+
+        /* // LB -> 1 - 10 - 4 -100 */
+        /* // UB -> 1 - 5 + 6 + 100 */
+        /* TS_ASSERT_EQUALS( lower->_value, -113 ); */
+        /* TS_ASSERT_EQUALS( upper->_value, 102 ); */
+    }
+
+};
+
+//
+// Local Variables:
+// compile-command: "make -C ../../.. "
+// tags-file-name: "../../../TAGS"
+// c-basic-offset: 4
+// End:
+//

--- a/src/engine/tests/Test_BoundManager.h
+++ b/src/engine/tests/Test_BoundManager.h
@@ -49,21 +49,19 @@ public:
         BoundManager boundManager( *context );
 
         unsigned numberOfVariables = 5u;
-        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( numberOfVariables) );
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( numberOfVariables ) );
 
-        for ( unsigned i = 0; i < numberOfVariables; ++i)
+        for ( unsigned i = 0; i < numberOfVariables; ++i )
         {
             TS_ASSERT( FloatUtils::areEqual( boundManager.getLowerBound( i ),
                                              FloatUtils::negativeInfinity() ) );
             TS_ASSERT( FloatUtils::areEqual( boundManager.getUpperBound( i ),
                                              FloatUtils::infinity() ) );
         }
-
     }
 
     /*
-     * BoundManager correctly updates the number of variables with advancement
-     * and backtracking of context
+     * BoundManager correctly registers new variables after intialization.
      *
      */
     void test_register_variable()
@@ -94,7 +92,7 @@ public:
      * become invalid
      *
      */
-    void test_bound_valid()
+    void test_consistent_bounds()
     {
         BoundManager boundManager( *context );
 
@@ -148,7 +146,7 @@ public:
 
     /*
      * BoundManager correctly updates bounds with advancement and backtracking of context
-     * 
+     *
      */
     void test_bound_manager_context_interaction()
     {

--- a/src/engine/tests/Test_BoundManager.h
+++ b/src/engine/tests/Test_BoundManager.h
@@ -19,6 +19,7 @@
 #include "context/cdlist.h"
 #include "context/context.h"
 #include "FloatUtils.h"
+#include "InfeasibleQueryException.h"
 
 class BoundManagerTestSuite : public CxxTest::TestSuite
 {
@@ -82,6 +83,29 @@ public:
                                          FloatUtils::negativeInfinity() ) );
         TS_ASSERT( FloatUtils::areEqual( boundManager.getUpperBound( 6 ),
                                          FloatUtils::infinity() ) );
+    }
+
+    /*
+     * BoundManager throws infeasible query exception when some variable bounds
+     * become invalid
+     *
+     */
+    void test_bound_valid()
+    {
+        CVC4::context::Context context;
+
+        BoundManager boundManager(context);
+
+        unsigned numberOfVariables = 1u;
+
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( numberOfVariables ) );
+
+        TS_ASSERT_THROWS_NOTHING( boundManager.setLowerBound( 0, 1 ) );
+        TS_ASSERT_THROWS_NOTHING( boundManager.setUpperBound( 0, 2 ) );
+        TS_ASSERT( boundManager.boundValid( 0 ) );
+
+        TS_ASSERT_THROWS_NOTHING( boundManager.setUpperBound( 0, 1 ) );
+        TS_ASSERT_THROWS( boundManager.setUpperBound( 0, 0 ), InfeasibleQueryException );
     }
 
     /*

--- a/src/engine/tests/Test_BoundManager.h
+++ b/src/engine/tests/Test_BoundManager.h
@@ -102,7 +102,7 @@ public:
 
         TS_ASSERT_THROWS_NOTHING( boundManager.setLowerBound( 0, 1 ) );
         TS_ASSERT_THROWS_NOTHING( boundManager.setUpperBound( 0, 2 ) );
-        TS_ASSERT( boundManager.boundValid( 0 ) );
+        TS_ASSERT( boundManager.consistentBounds( 0 ) );
 
         TS_ASSERT_THROWS_NOTHING( boundManager.setUpperBound( 0, 1 ) );
         TS_ASSERT_THROWS( boundManager.setUpperBound( 0, 0 ), InfeasibleQueryException );

--- a/src/engine/tests/Test_BoundManager.h
+++ b/src/engine/tests/Test_BoundManager.h
@@ -20,17 +20,24 @@
 #include "context/context.h"
 #include "FloatUtils.h"
 #include "InfeasibleQueryException.h"
+#include "Tightening.h"
+
+using CVC4::context::Context;
 
 class BoundManagerTestSuite : public CxxTest::TestSuite
 {
 public:
 
+    Context * context;
+
     void setUp()
     {
+        TS_ASSERT_THROWS_NOTHING( context = new Context );
     }
 
     void tearDown()
     {
+        TS_ASSERT_THROWS_NOTHING( delete context; );
     }
 
     /*
@@ -39,8 +46,7 @@ public:
      */
     void test_bound_manager_initialize()
     {
-        CVC4::context::Context context;
-        BoundManager boundManager(context);
+        BoundManager boundManager( *context );
 
         unsigned numberOfVariables = 5u;
         TS_ASSERT_THROWS_NOTHING( boundManager.initialize( numberOfVariables) );
@@ -62,9 +68,7 @@ public:
      */
     void test_register_variable()
     {
-        CVC4::context::Context context;
-
-        BoundManager boundManager(context);
+        BoundManager boundManager( *context );
 
         unsigned numberOfVariables = 5u;
 
@@ -92,9 +96,7 @@ public:
      */
     void test_bound_valid()
     {
-        CVC4::context::Context context;
-
-        BoundManager boundManager(context);
+        BoundManager boundManager( *context );
 
         unsigned numberOfVariables = 1u;
 
@@ -114,9 +116,7 @@ public:
      */
     void test_bound_manager_context_interaction()
     {
-      CVC4::context::Context context;
-
-      BoundManager boundManager(context);
+      BoundManager boundManager( *context );
 
       unsigned numberOfVariables = 5u;
 
@@ -130,7 +130,7 @@ public:
       double level2Upper[] = {  3.738962,   8.308432000,   16.79211593, 115.9003,  57.5459822 };
 
 
-      TS_ASSERT_THROWS_NOTHING( context.push() );
+      TS_ASSERT_THROWS_NOTHING( context->push() )
 
       for ( unsigned v = 0; v < numberOfVariables; ++v )
       {
@@ -141,7 +141,7 @@ public:
         TS_ASSERT_EQUALS( boundManager.getUpperBound( v ), level0Upper[v] );
       }
 
-      TS_ASSERT_THROWS_NOTHING( context.push() );
+      TS_ASSERT_THROWS_NOTHING( context->push() );
 
       for ( unsigned v = 0; v < numberOfVariables; ++v )
       {
@@ -153,7 +153,7 @@ public:
       }
 
 
-      TS_ASSERT_THROWS_NOTHING( context.push() );
+      TS_ASSERT_THROWS_NOTHING( context->push() );
 
       for ( unsigned v = 0; v < numberOfVariables; ++v )
       {
@@ -165,7 +165,7 @@ public:
        }
 
 
-      TS_ASSERT_THROWS_NOTHING( context.pop() );
+      TS_ASSERT_THROWS_NOTHING( context->pop() );
 
       for ( unsigned v = 0; v < numberOfVariables; ++v )
       {
@@ -174,7 +174,7 @@ public:
       }
 
 
-      TS_ASSERT_THROWS_NOTHING( context.pop() );
+      TS_ASSERT_THROWS_NOTHING( context->pop() );
 
       for ( unsigned v = 0; v < numberOfVariables; ++v )
       {
@@ -200,7 +200,7 @@ public:
           TS_ASSERT_EQUALS( boundManager.getUpperBound( v ), level2Upper[v] );
         }
 
-      TS_ASSERT_THROWS_NOTHING( context.pop() );
+      TS_ASSERT_THROWS_NOTHING( context->pop() );
 
       for ( unsigned v = 0; v < numberOfVariables; ++v )
         {

--- a/src/engine/tests/Test_BoundManager.h
+++ b/src/engine/tests/Test_BoundManager.h
@@ -70,7 +70,7 @@ public:
 
         TS_ASSERT_THROWS_NOTHING( boundManager.initialize( numberOfVariables ) );
 
-        TS_ASSERT_EQUALS( boundManager.getSize(), 5u );
+        TS_ASSERT_EQUALS( boundManager.getNumberOfVariables(), 5u );
         TS_ASSERT( FloatUtils::areEqual( boundManager.getLowerBound( 4 ),
                                          FloatUtils::negativeInfinity() ) );
         TS_ASSERT( FloatUtils::areEqual( boundManager.getUpperBound( 4 ),
@@ -78,7 +78,7 @@ public:
 
         TS_ASSERT_THROWS_NOTHING( boundManager.registerNewVariable() );
         TS_ASSERT_THROWS_NOTHING( boundManager.registerNewVariable() );
-        TS_ASSERT_EQUALS( boundManager.getSize(), 7u );
+        TS_ASSERT_EQUALS( boundManager.getNumberOfVariables(), 7u );
         TS_ASSERT( FloatUtils::areEqual( boundManager.getLowerBound( 6 ),
                                          FloatUtils::negativeInfinity() ) );
         TS_ASSERT( FloatUtils::areEqual( boundManager.getUpperBound( 6 ),

--- a/src/engine/tests/Test_BoundManager.h
+++ b/src/engine/tests/Test_BoundManager.h
@@ -111,6 +111,42 @@ public:
     }
 
     /*
+     * Test tightened bound book-keeping
+     */
+    void test_get_tightenings()
+    {
+        BoundManager boundManager( *context );
+
+        unsigned numberOfVariables = 3u;
+
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( numberOfVariables ) );
+
+        List<Tightening> tightenings;
+        TS_ASSERT_THROWS_NOTHING( boundManager.getTightenings( tightenings ));
+        TS_ASSERT( tightenings.empty() );
+
+        TS_ASSERT_THROWS_NOTHING( boundManager.setLowerBound( 0, 1 ) );
+        TS_ASSERT_THROWS_NOTHING( boundManager.setUpperBound( 1, 2 ) );
+        TS_ASSERT_THROWS_NOTHING( boundManager.getTightenings( tightenings ) );
+        TS_ASSERT( tightenings.size() == 2u );
+        Tightening lb = Tightening( 0, 1, Tightening::LB );
+        Tightening ub = Tightening( 1, 2, Tightening::UB );
+        TS_ASSERT( std::find( tightenings.begin(), tightenings.end(), lb ) != tightenings.end() );
+        TS_ASSERT( std::find( tightenings.begin(), tightenings.end(), ub ) != tightenings.end() );
+        tightenings.clear();
+
+        TS_ASSERT_THROWS_NOTHING( boundManager.setUpperBound( 0, 1 ) );
+        TS_ASSERT_THROWS_NOTHING( boundManager.getTightenings( tightenings ) );
+        TS_ASSERT( tightenings.size() == 1u );
+        Tightening ub2 = Tightening( 0, 1, Tightening::UB );
+        TS_ASSERT( std::find( tightenings.begin(), tightenings.end(), ub2 ) != tightenings.end() );
+        tightenings.clear();
+
+        TS_ASSERT_THROWS_NOTHING( boundManager.getTightenings( tightenings ) );
+        TS_ASSERT( tightenings.size() == 0u );
+    }
+
+    /*
      * BoundManager correctly updates bounds with advancement and backtracking of context
      * 
      */


### PR DESCRIPTION
BoundManager class is a context-dependent implementation of a centralized
variable registry and their bounds. The intent it so use a single BoundManager
object between multiple bound tightener classes, which enables
those classes to care only about bounds and forget about book-keeping. 
Furthermore, the context-dependent implementation eliminates the need for 
eager memory book-keeping.

BoundManager provides a method to obtain a new variable with:
 - registerNewVariable().

The bound values and tighten flags are stored using context-dependent objects,
which backtrack automatically with the central _context object.

There are two sets of methods to set bounds:
-  setLower/UpperBounds - local methods used to update bounds
-  tightenLower/Upper Bounds - shared method to update bounds, 
   propagates the new bounds to the _tableau (if registered) to keep the 
   assignment and basic/non-basic variables updated accordingly.
 
As soon as bounds become inconsistent, i.e. lowerBound > upperBound, an
InfeasableQueryException is thrown. In the long run, we want the exception
replaced by a flag, and switch to the conflict analysis mode instead.

It is assumed that variables are not introduced on the fly, and as such
interaction with context-dependent features is not implemented.

Another thing we may want to consider in the long run, is to make the 
BoundManager a VariableWatcher, and move those features from Tableau.

Integration into the master can be gradual, first allowing each class storing 
bounds a private copy of the object, before switching to a centralized object,
instant bound visibility and elimination of tightening propagation.