### PR TITLE
Fix CI - clang compilation

### DIFF
--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -105,12 +105,8 @@ public:
     */
     virtual PiecewiseLinearCaseSplit getImpliedCaseSplit() const = 0;
 
-    /*
-      Check if the constraint's phase has been fixed.
-    */
-    virtual bool phaseFixed() const = 0;
 
-        /*
+    /*
       Register a bound manager. If a bound manager is registered,
       this piecewise linear constraint will inform the tightener whenever
       it discovers a tighter (entailed) bound.

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -82,8 +82,8 @@ public:
     /*
       Turn the constraint on/off.
     */
-    void setActiveConstraint( bool active );
-    bool isActive() const;
+    void setActiveConstraint( bool active ) override;
+    bool isActive() const override;
 
     /*
        Returns a list of all cases of this constraint and is used by the


### PR DESCRIPTION
Clang reports inconsistent override error in ContextDependentPiecewiseLinearConstraint.h during CI. This PR fixes the issue.