### PR TITLE
Add BoundManager support to CDPWLC

### DIFF
--- a/src/engine/AbsoluteValueConstraint.cpp
+++ b/src/engine/AbsoluteValueConstraint.cpp
@@ -341,7 +341,7 @@ List<PiecewiseLinearCaseSplit> AbsoluteValueConstraint::getCaseSplits() const
 
 List<PhaseStatus> AbsoluteValueConstraint::getAllCases() const
 {
-    return { ABS_PHASE_NEGATIVE, ABS_PHASE_POSITIVE};
+    return { ABS_PHASE_NEGATIVE, ABS_PHASE_POSITIVE };
 }
 
 PiecewiseLinearCaseSplit AbsoluteValueConstraint::getCaseSplit( PhaseStatus phase ) const
@@ -557,9 +557,9 @@ void AbsoluteValueConstraint::getEntailedTightenings( List<Tightening> &tighteni
     else if ( bLowerBound < 0 && bUpperBound >= 0 && FloatUtils::isZero( fLowerBound ) )
     {
         // Phase undetermined, b can be either positive or negative, f can be 0
-        tightenings.append( Tightening( _b, -fUpperBound , Tightening::LB ) );
+        tightenings.append( Tightening( _b, -fUpperBound, Tightening::LB ) );
         tightenings.append( Tightening( _b, fUpperBound, Tightening::UB ) );
-        tightenings.append( Tightening( _f, FloatUtils::max( -bLowerBound , bUpperBound ), Tightening::UB ) );
+        tightenings.append( Tightening( _f, FloatUtils::max( -bLowerBound, bUpperBound ), Tightening::UB ) );
 
         if ( _auxVarsInUse )
         {
@@ -753,4 +753,3 @@ String AbsoluteValueConstraint::phaseToString( PhaseStatus phase )
         return "UNKNOWN";
     }
 };
-

--- a/src/engine/AbsoluteValueConstraint.cpp
+++ b/src/engine/AbsoluteValueConstraint.cpp
@@ -9,7 +9,7 @@
  ** All rights reserved. See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** [[ Add lengthier description here ]]
+ ** See the description of the class in AbsoluteValueConstraint.h.
  **/
 
 #include "AbsoluteValueConstraint.h"

--- a/src/engine/AbsoluteValueConstraint.h
+++ b/src/engine/AbsoluteValueConstraint.h
@@ -192,39 +192,6 @@ private:
     */
     PiecewiseLinearCaseSplit getPositiveSplit() const;
     PiecewiseLinearCaseSplit getNegativeSplit() const;
-
-    /*
-       Bounds get/set wrappers
-     */
-    inline bool existsLowerBound( unsigned var ) const
-    {
-      return _boundManager != nullptr || _lowerBounds.exists( var );
-    }
-
-    inline bool existsUpperBound( unsigned var ) const
-    {
-      return _boundManager != nullptr || _upperBounds.exists( var );
-    }
-
-    inline double getLowerBound( unsigned var ) const
-    {
-      return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( var ) : _lowerBounds[var];
-    }
-
-    inline double getUpperBound( unsigned var ) const
-    {
-      return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( var ) : _upperBounds[var];
-    }
-
-    inline void setLowerBound( unsigned var, double value )
-    {
-      ( _boundManager != nullptr ) ? _boundManager->setLowerBound( var, value ) : _lowerBounds[var] = value;
-    }
-
-    inline void setUpperBound( unsigned var, double value )
-    {
-      ( _boundManager != nullptr ) ? _boundManager->setUpperBound( var, value ) : _upperBounds[var] = value;
-    }
 };
 
 #endif // __AbsoluteValueConstraint_h__

--- a/src/engine/AbsoluteValueConstraint.h
+++ b/src/engine/AbsoluteValueConstraint.h
@@ -192,6 +192,39 @@ private:
     */
     PiecewiseLinearCaseSplit getPositiveSplit() const;
     PiecewiseLinearCaseSplit getNegativeSplit() const;
+
+    /*
+       Bounds get/set wrappers
+     */
+    inline bool existsLowerBound( unsigned var ) const
+    {
+      return _boundManager != nullptr || _lowerBounds.exists( var );
+    }
+
+    inline bool existsUpperBound( unsigned var ) const
+    {
+      return _boundManager != nullptr || _upperBounds.exists( var );
+    }
+
+    inline double getLowerBound( unsigned var ) const
+    {
+      return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( var ) : _lowerBounds[var];
+    }
+
+    inline double getUpperBound( unsigned var ) const
+    {
+      return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( var ) : _upperBounds[var];
+    }
+
+    inline void setLowerBound( unsigned var, double value )
+    {
+      ( _boundManager != nullptr ) ? _boundManager->setLowerBound( var, value ) : _lowerBounds[var] = value;
+    }
+
+    inline void setUpperBound( unsigned var, double value )
+    {
+      ( _boundManager != nullptr ) ? _boundManager->setUpperBound( var, value ) : _upperBounds[var] = value;
+    }
 };
 
 #endif // __AbsoluteValueConstraint_h__

--- a/src/engine/AbsoluteValueConstraint.h
+++ b/src/engine/AbsoluteValueConstraint.h
@@ -10,17 +10,21 @@
  ** directory for licensing information.\endverbatim
  **
  ** AbsoluteValueConstraint implements the following constraint:
- ** f = Abs( b )
+ ** f = Abs( b ) =     ( b > 0 -> f =  b )
+ **                 /\ ( b <=0 -> f = -b )
  **
  ** It distinguishes two relevant phases for search:
  ** ABS_PHASE_POSITIVE: b > 0
  ** ABS_PHASE_NEGATIVE: b <=0
  **
- ** The constraint operates in two modes: pre-processing mode, which stores
- ** bounds locally, and context dependent mode, used during the search.
- ** Invoking initializeCDOs meth activates the context dependent mode, and the
- ** constraint object synchronizes its state automatically with the central context
- ** object.
+ ** The constraint is implemented as ContextDependentPiecewiseLinearConstraint
+ ** and operates in two modes:
+ **   * pre-processing mode, which stores bounds locally, and
+ **   * context dependent mode, used during the search.
+ **
+ ** Invoking initializeCDOs method activates the context dependent mode, and the
+ ** AbsoluteValueConstraint object synchronizes its state automatically with the central
+ ** Context object.
  **/
 
 #ifndef __AbsoluteValueConstraint_h__

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.cpp
@@ -9,7 +9,7 @@
  ** All rights reserved. See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** A context dependent implementation of ContextDependentPiecewiseLinearConstraint class
+ ** See the description of the class in ContextDependentPiecewiseLinearConstraint.h.
  **/
 
 #include "ContextDependentPiecewiseLinearConstraint.h"

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -247,7 +247,7 @@ protected:
     /*
        Bounds get/set wrappers
      */
-    inline bool existsLowerBound( unsigned var ) const 
+    inline bool existsLowerBound( unsigned var ) const
     {
       return _boundManager != nullptr || _lowerBounds.exists( var );
     }

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -243,6 +243,39 @@ protected:
        dependent and context-less behavior.
      */
     PhaseStatus getPhaseStatus() const;
+
+    /*
+       Bounds get/set wrappers
+     */
+    inline bool existsLowerBound( unsigned var ) const 
+    {
+      return _boundManager != nullptr || _lowerBounds.exists( var );
+    }
+
+    inline bool existsUpperBound( unsigned var ) const
+    {
+      return _boundManager != nullptr || _upperBounds.exists( var );
+    }
+
+    inline double getLowerBound( unsigned var ) const override
+    {
+      return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( var ) : _lowerBounds[var];
+    }
+
+    inline double getUpperBound( unsigned var ) const override
+    {
+      return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( var ) : _upperBounds[var];
+    }
+
+    inline void setLowerBound( unsigned var, double value )
+    {
+      ( _boundManager != nullptr ) ? _boundManager->setLowerBound( var, value ) : _lowerBounds[var] = value;
+    }
+
+    inline void setUpperBound( unsigned var, double value )
+    {
+      ( _boundManager != nullptr ) ? _boundManager->setUpperBound( var, value ) : _upperBounds[var] = value;
+    }
 };
 
 #endif // __ContextDependentPiecewiseLinearConstraint_h__

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -46,6 +46,7 @@
 #ifndef __ContextDependentPiecewiseLinearConstraint_h__
 #define __ContextDependentPiecewiseLinearConstraint_h__
 
+#include "BoundManager.h"
 #include "FloatUtils.h"
 #include "ITableau.h"
 #include "List.h"
@@ -61,7 +62,6 @@
 #include "context/context.h"
 
 class Equation;
-class BoundManager;
 class ITableau;
 class InputQuery;
 class String;

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -249,34 +249,37 @@ protected:
      */
     inline bool existsLowerBound( unsigned var ) const
     {
-      return _boundManager != nullptr || _lowerBounds.exists( var );
+        return _boundManager != nullptr || _lowerBounds.exists( var );
     }
 
     inline bool existsUpperBound( unsigned var ) const
     {
-      return _boundManager != nullptr || _upperBounds.exists( var );
+        return _boundManager != nullptr || _upperBounds.exists( var );
     }
 
     inline double getLowerBound( unsigned var ) const override
     {
-      return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( var ) : _lowerBounds[var];
+        return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( var )
+                                            : _lowerBounds[var];
     }
 
     inline double getUpperBound( unsigned var ) const override
     {
-      return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( var ) : _upperBounds[var];
+        return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( var )
+                                            : _upperBounds[var];
     }
 
     inline void setLowerBound( unsigned var, double value )
     {
-      ( _boundManager != nullptr ) ? _boundManager->setLowerBound( var, value ) : _lowerBounds[var] = value;
+        ( _boundManager != nullptr ) ? _boundManager->setLowerBound( var, value )
+                                     : _lowerBounds[var] = value;
     }
 
     inline void setUpperBound( unsigned var, double value )
     {
-      ( _boundManager != nullptr ) ? _boundManager->setUpperBound( var, value ) : _upperBounds[var] = value;
+        ( _boundManager != nullptr ) ? _boundManager->setUpperBound( var, value )
+                                     : _upperBounds[var] = value;
     }
 };
 
 #endif // __ContextDependentPiecewiseLinearConstraint_h__
-

--- a/src/engine/ContextDependentPiecewiseLinearConstraint.h
+++ b/src/engine/ContextDependentPiecewiseLinearConstraint.h
@@ -245,36 +245,62 @@ protected:
     PhaseStatus getPhaseStatus() const;
 
     /*
-       Bounds get/set wrappers
+       BOUND WRAPPER METHODS
+
+       All wrapper methods use the following semantics:
+       If BoundManager is initialized use BoundManager, otherwise use local bound arrays.
      */
+
+    /*
+       Checks whether lower bound value exists.
+
+       If BoundManager is in use, returns true since it initializes bounds for all variables.
+    */
     inline bool existsLowerBound( unsigned var ) const
     {
         return _boundManager != nullptr || _lowerBounds.exists( var );
     }
 
+    /*
+       Checks whether upper bound value exists.
+
+       If BoundManager is in use, returns true since it initializes bounds for all variables.
+    */
     inline bool existsUpperBound( unsigned var ) const
     {
         return _boundManager != nullptr || _upperBounds.exists( var );
     }
 
+    /*
+       Method obtains lower bound of *var*.
+     */
     inline double getLowerBound( unsigned var ) const override
     {
         return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( var )
                                             : _lowerBounds[var];
     }
 
+    /*
+       Method obtains upper bound of *var*.
+     */
     inline double getUpperBound( unsigned var ) const override
     {
         return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( var )
                                             : _upperBounds[var];
     }
 
+    /*
+       Method sets the lower bound of *var* to *value*.
+     */
     inline void setLowerBound( unsigned var, double value )
     {
         ( _boundManager != nullptr ) ? _boundManager->setLowerBound( var, value )
                                      : _lowerBounds[var] = value;
     }
 
+    /*
+       Method sets the upper bound of *var* to *value*.
+     */
     inline void setUpperBound( unsigned var, double value )
     {
         ( _boundManager != nullptr ) ? _boundManager->setUpperBound( var, value )

--- a/src/engine/DisjunctionConstraint.cpp
+++ b/src/engine/DisjunctionConstraint.cpp
@@ -94,10 +94,10 @@ void DisjunctionConstraint::notifyLowerBound( unsigned variable, double bound )
     if ( _statistics )
         _statistics->incNumBoundNotificationsPlConstraints();
 
-    if ( _lowerBounds.exists( variable ) && !FloatUtils::gt( bound, _lowerBounds[variable] ) )
+    if ( existsLowerBound(  variable  ) && !FloatUtils::gt( bound, getLowerBound( variable ) ) )
         return;
 
-    _lowerBounds[variable] = bound;
+    setLowerBound( variable, bound );
 
     updateFeasibleDisjuncts();
 }
@@ -107,10 +107,10 @@ void DisjunctionConstraint::notifyUpperBound( unsigned variable, double bound )
     if ( _statistics )
         _statistics->incNumBoundNotificationsPlConstraints();
 
-    if ( _upperBounds.exists( variable ) && !FloatUtils::lt( bound, _upperBounds[variable] ) )
+    if ( existsUpperBound(  variable  ) && !FloatUtils::lt( bound, getUpperBound( variable ) ) )
         return;
 
-    _upperBounds[variable] = bound;
+    setUpperBound( variable, bound );
 
     updateFeasibleDisjuncts();
 }
@@ -329,14 +329,14 @@ bool DisjunctionConstraint::caseSplitIsFeasible( const PiecewiseLinearCaseSplit 
     {
         if ( bound._type == Tightening::LB )
         {
-            if ( _upperBounds.exists( bound._variable ) &&
-                 _upperBounds[bound._variable] < bound._value )
+            if ( existsUpperBound(  bound._variable  ) &&
+                 getUpperBound( bound._variable ) < bound._value )
                 return false;
         }
         else
         {
-            if ( _lowerBounds.exists( bound._variable ) &&
-                 _lowerBounds[bound._variable] > bound._value )
+            if ( existsLowerBound(  bound._variable  ) &&
+                 getLowerBound( bound._variable ) > bound._value )
                 return false;
         }
     }

--- a/src/engine/DisjunctionConstraint.cpp
+++ b/src/engine/DisjunctionConstraint.cpp
@@ -12,8 +12,9 @@
  ** [[ Add lengthier description here ]]
  **/
 
-#include "Debug.h"
 #include "DisjunctionConstraint.h"
+
+#include "Debug.h"
 #include "MStringf.h"
 #include "MarabouError.h"
 #include "Statistics.h"
@@ -23,7 +24,7 @@ DisjunctionConstraint::DisjunctionConstraint( const List<PiecewiseLinearCaseSpli
     , _disjuncts( disjuncts.begin(), disjuncts.end() )
     , _feasibleDisjuncts( disjuncts.size(), 0 )
 {
-    for ( unsigned ind = 0;  ind < disjuncts.size();  ++ind )
+    for ( unsigned ind = 0; ind < disjuncts.size(); ++ind )
         _feasibleDisjuncts.append( ind );
 
     extractParticipatingVariables();
@@ -34,7 +35,7 @@ DisjunctionConstraint::DisjunctionConstraint( const Vector<PiecewiseLinearCaseSp
     , _disjuncts( disjuncts )
     , _feasibleDisjuncts( disjuncts.size(), 0 )
 {
-    for ( unsigned ind = 0;  ind < disjuncts.size();  ++ind )
+    for ( unsigned ind = 0; ind < disjuncts.size(); ++ind )
         _feasibleDisjuncts.append( ind );
 
     extractParticipatingVariables();
@@ -94,7 +95,7 @@ void DisjunctionConstraint::notifyLowerBound( unsigned variable, double bound )
     if ( _statistics )
         _statistics->incNumBoundNotificationsPlConstraints();
 
-    if ( existsLowerBound(  variable  ) && !FloatUtils::gt( bound, getLowerBound( variable ) ) )
+    if ( existsLowerBound( variable ) && !FloatUtils::gt( bound, getLowerBound( variable ) ) )
         return;
 
     setLowerBound( variable, bound );
@@ -107,7 +108,7 @@ void DisjunctionConstraint::notifyUpperBound( unsigned variable, double bound )
     if ( _statistics )
         _statistics->incNumBoundNotificationsPlConstraints();
 
-    if ( existsUpperBound(  variable  ) && !FloatUtils::lt( bound, getUpperBound( variable ) ) )
+    if ( existsUpperBound( variable ) && !FloatUtils::lt( bound, getUpperBound( variable ) ) )
         return;
 
     setUpperBound( variable, bound );
@@ -156,7 +157,7 @@ List<PiecewiseLinearCaseSplit> DisjunctionConstraint::getCaseSplits() const
 List<PhaseStatus> DisjunctionConstraint::getAllCases() const
 {
     List<PhaseStatus> cases;
-    for ( unsigned i = 0; i < _disjuncts.size(); ++i  )
+    for ( unsigned i = 0; i < _disjuncts.size(); ++i )
         cases.append( indToPhaseStatus( i ) );
     return cases;
 }
@@ -329,13 +330,13 @@ bool DisjunctionConstraint::caseSplitIsFeasible( const PiecewiseLinearCaseSplit 
     {
         if ( bound._type == Tightening::LB )
         {
-            if ( existsUpperBound(  bound._variable  ) &&
+            if ( existsUpperBound( bound._variable ) &&
                  getUpperBound( bound._variable ) < bound._value )
                 return false;
         }
         else
         {
-            if ( existsLowerBound(  bound._variable  ) &&
+            if ( existsLowerBound( bound._variable ) &&
                  getLowerBound( bound._variable ) > bound._value )
                 return false;
         }
@@ -343,4 +344,3 @@ bool DisjunctionConstraint::caseSplitIsFeasible( const PiecewiseLinearCaseSplit 
 
     return true;
 }
-

--- a/src/engine/DisjunctionConstraint.cpp
+++ b/src/engine/DisjunctionConstraint.cpp
@@ -9,7 +9,7 @@
  ** All rights reserved. See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** [[ Add lengthier description here ]]
+ ** See the description of the class in DisjunctionConstraint.h.
  **/
 
 #include "DisjunctionConstraint.h"

--- a/src/engine/DisjunctionConstraint.h
+++ b/src/engine/DisjunctionConstraint.h
@@ -15,11 +15,14 @@
  ** The constraint introduces identifiers for its PiecewiseLinearCaseSplit
  ** elements.
  **
- ** The constraint operates in two modes: pre-processing mode, which stores
- ** bounds locally, and context dependent mode, which is used during the search.
+ ** The constraint is implemented as ContextDependentPiecewiseLinearConstraint
+ ** and operates in two modes:
+ **   * pre-processing mode, which stores bounds locally, and
+ **   * context dependent mode, used during the search.
+ **
  ** Invoking initializeCDOs method activates the context dependent mode, and the
- ** constraint object synchronizes its state automatically with the central context
- ** object.
+ ** DisjunctionConstraint object synchronizes its state automatically with the central
+ ** Context object.
  **/
 
 #ifndef __DisjunctionConstraint_h__
@@ -198,7 +201,7 @@ private:
 
     /*
       Go over the list of disjuncts and find just the ones that are
-      still possible, given the current varibale bounds
+      still feasible, given the current variable bounds
     */
     void updateFeasibleDisjuncts();
     bool disjunctIsFeasible( unsigned ind ) const;

--- a/src/engine/MaxConstraint.cpp
+++ b/src/engine/MaxConstraint.cpp
@@ -160,7 +160,7 @@ void MaxConstraint::notifyLowerBound( unsigned variable, double value )
     if ( existsLowerBound( variable ) && !FloatUtils::gt( value, getLowerBound( variable ) ) )
         return;
 
-    _lowerBounds[variable] = value;
+    setLowerBound( variable, value );
 
     bool maxErased = false;
 
@@ -218,7 +218,7 @@ void MaxConstraint::notifyUpperBound( unsigned variable, double value )
     if ( existsUpperBound( variable ) && !FloatUtils::lt( value, getUpperBound( variable ) ) )
         return;
 
-    _upperBounds[variable] = value;
+    setUpperBound( variable, value );
 
     if ( _elements.exists( variable ) && _f != variable && FloatUtils::lt( value, _maxLowerBound ) )
     {

--- a/src/engine/MaxConstraint.cpp
+++ b/src/engine/MaxConstraint.cpp
@@ -304,9 +304,7 @@ void MaxConstraint::getEntailedTightenings( List<Tightening> &tightenings ) cons
     {
         // Special case: there is only one element. In that case, the tighter lower
         // bound (in this case, f's) wins.
-        if ( !_eliminatedVariables )
-            tightenings.append( Tightening( *_elements.begin(), fLB, Tightening::LB ) );
-        else if ( FloatUtils::gt( fLB, _maxValueOfEliminated ) )
+        if ( !_eliminatedVariables || FloatUtils::gt( fLB, _maxValueOfEliminated ) )
             tightenings.append( Tightening( *_elements.begin(), fLB, Tightening::LB ) );
     }
 

--- a/src/engine/MaxConstraint.cpp
+++ b/src/engine/MaxConstraint.cpp
@@ -294,7 +294,6 @@ void MaxConstraint::getEntailedTightenings( List<Tightening> &tightenings ) cons
                 for ( const auto &element : _elements )
                 {
                     if ( !existsUpperBound( element ) || FloatUtils::gt( getUpperBound( element ), fUB ) )
-                         FloatUtils::gt( getUpperBound( element ), fUB ) )
                         tightenings.append( Tightening( element, fUB, Tightening::UB ) );
                 }
             }

--- a/src/engine/MaxConstraint.cpp
+++ b/src/engine/MaxConstraint.cpp
@@ -157,7 +157,7 @@ void MaxConstraint::notifyLowerBound( unsigned variable, double value )
     if ( _statistics )
         _statistics->incNumBoundNotificationsPlConstraints();
 
-    if ( _lowerBounds.exists( variable ) && !FloatUtils::gt( value, _lowerBounds[variable] ) )
+    if ( existsLowerBound( variable ) && !FloatUtils::gt( value, getLowerBound( variable ) ) )
         return;
 
     _lowerBounds[variable] = value;
@@ -172,8 +172,8 @@ void MaxConstraint::notifyLowerBound( unsigned variable, double value )
         {
             if ( element == variable || element == _f )
                 continue;
-            if ( _upperBounds.exists( element ) &&
-                 FloatUtils::lt( _upperBounds[element], value ) )
+            if ( existsUpperBound( element ) &&
+                 FloatUtils::lt( getUpperBound( element ), value ) )
             {
                 toRemove.append( element );
             }
@@ -215,7 +215,7 @@ void MaxConstraint::notifyUpperBound( unsigned variable, double value )
     if ( _statistics )
         _statistics->incNumBoundNotificationsPlConstraints();
 
-    if ( _upperBounds.exists( variable ) && !FloatUtils::lt( value, _upperBounds[variable] ) )
+    if ( existsUpperBound( variable ) && !FloatUtils::lt( value, getUpperBound( variable ) ) )
         return;
 
     _upperBounds[variable] = value;
@@ -253,8 +253,8 @@ void MaxConstraint::notifyUpperBound( unsigned variable, double value )
 void MaxConstraint::getEntailedTightenings( List<Tightening> &tightenings ) const
 {
     // Lower and upper bounds for the f variable
-    double fLB = _lowerBounds.exists( _f ) ? _lowerBounds.get( _f ) : FloatUtils::negativeInfinity();
-    double fUB = _upperBounds.exists( _f ) ? _upperBounds.get( _f ) : FloatUtils::infinity();
+    double fLB = existsLowerBound( _f ) ? _lowerBounds.get( _f ) : FloatUtils::negativeInfinity();
+    double fUB = existsUpperBound( _f ) ? _upperBounds.get( _f ) : FloatUtils::infinity();
 
     // Compute the maximal bounds (lower and upper) for the elements
     double maxElementLB = FloatUtils::negativeInfinity();
@@ -262,13 +262,13 @@ void MaxConstraint::getEntailedTightenings( List<Tightening> &tightenings ) cons
 
     for ( const auto &element : _elements )
     {
-        if ( _lowerBounds.exists( element ) )
-            maxElementLB = FloatUtils::max( _lowerBounds[element], maxElementLB );
+        if ( existsLowerBound( element ) )
+            maxElementLB = FloatUtils::max( getLowerBound( element ), maxElementLB );
 
-        if ( !_upperBounds.exists( element ) )
+        if ( !existsUpperBound( element ) )
             maxElementUB = FloatUtils::infinity();
         else
-            maxElementUB = FloatUtils::max( _upperBounds[element], maxElementUB );
+            maxElementUB = FloatUtils::max( getUpperBound( element ), maxElementUB );
     }
 
     // Treat the maxValueEliminated as an element
@@ -290,7 +290,7 @@ void MaxConstraint::getEntailedTightenings( List<Tightening> &tightenings ) cons
 			// f_UB <= maxElementUB
             for ( const auto &element : _elements )
             {
-                if ( !_upperBounds.exists( element ) || FloatUtils::gt( _upperBounds[element], fUB ) )
+                if ( !existsUpperBound( element ) || FloatUtils::gt( getUpperBound( element ), fUB ) )
                     tightenings.append( Tightening( element, fUB, Tightening::UB ) );
             }
         }
@@ -537,10 +537,10 @@ bool MaxConstraint::phaseFixed() const
             return true;
 
         unsigned singleVarLeft = *_elements.begin();
-        if ( _lowerBounds.exists( singleVarLeft ) && FloatUtils::gte( _lowerBounds[singleVarLeft], _maxValueOfEliminated ) )
+        if ( existsLowerBound( singleVarLeft ) && FloatUtils::gte( getLowerBound( singleVarLeft ), _maxValueOfEliminated ) )
             return true;
 
-        if ( _upperBounds.exists( singleVarLeft ) && FloatUtils::lte( _upperBounds[singleVarLeft], _maxValueOfEliminated ) )
+        if ( existsUpperBound( singleVarLeft ) && FloatUtils::lte( getUpperBound( singleVarLeft ), _maxValueOfEliminated ) )
             return true;
     }
 
@@ -615,12 +615,12 @@ PiecewiseLinearCaseSplit MaxConstraint::getSplit( unsigned argMax ) const
         gtEquation.setScalar( 0 );
         maxPhase.addEquation( gtEquation );
 
-        if ( _upperBounds.exists( argMax ) )
+        if ( existsUpperBound( argMax ) )
         {
-            if ( !_upperBounds.exists( other ) ||
-                 FloatUtils::gt( _upperBounds[other], _upperBounds[argMax] ) )
+            if ( !existsUpperBound( other ) ||
+                 FloatUtils::gt( getUpperBound( other ), getUpperBound( argMax ) ) )
             {
-                maxPhase.storeBoundTightening( Tightening( other, _upperBounds[argMax], Tightening::UB ) );
+                maxPhase.storeBoundTightening( Tightening( other, getUpperBound( argMax ), Tightening::UB ) );
             }
         }
     }

--- a/src/engine/MaxConstraint.cpp
+++ b/src/engine/MaxConstraint.cpp
@@ -26,7 +26,7 @@
  ** Once in the context-dependent mode, MaxConstraint can be used for explicit
  ** exploration of the search space, using the markInfeasible/nextFeasibleCase
  ** methods.
-**/
+ **/
 
 #include "MaxConstraint.h"
 
@@ -40,6 +40,7 @@
 #include "MarabouError.h"
 #include "PiecewiseLinearCaseSplit.h"
 #include "Statistics.h"
+
 #include <algorithm>
 
 #ifdef _WIN32
@@ -48,14 +49,14 @@
 #endif
 
 MaxConstraint::MaxConstraint( unsigned f, const Set<unsigned> &elements )
-  : ContextDependentPiecewiseLinearConstraint( elements.size() )
-  , _f( f )
-	, _elements( elements )
-	, _initialElements( elements )
-	, _maxLowerBound( FloatUtils::negativeInfinity() )
-	, _obsolete( false )
-	, _eliminatedVariables( false )
-	, _maxValueOfEliminated( FloatUtils::negativeInfinity() )
+    : ContextDependentPiecewiseLinearConstraint( elements.size() )
+    , _f( f )
+    , _elements( elements )
+    , _initialElements( elements )
+    , _maxLowerBound( FloatUtils::negativeInfinity() )
+    , _obsolete( false )
+    , _eliminatedVariables( false )
+    , _maxValueOfEliminated( FloatUtils::negativeInfinity() )
 {
 }
 
@@ -73,7 +74,7 @@ MaxConstraint::MaxConstraint( const String &serializedMax )
     ++valuesIter;
 
     Set<unsigned> elements;
-    for ( ; *valuesIter != "e" ; ++valuesIter )
+    for ( ; *valuesIter != "e"; ++valuesIter )
         elements.insert( atoi( valuesIter->ascii() ) );
 
     // Save flag and values indicating eliminated variables
@@ -265,12 +266,12 @@ void MaxConstraint::getEntailedTightenings( List<Tightening> &tightenings ) cons
         for ( const auto &element : _elements )
         {
             if ( existsLowerBound( element ) )
-              maxElementLB = FloatUtils::max( getLowerBound( element ), maxElementLB );
+                maxElementLB = FloatUtils::max( getLowerBound( element ), maxElementLB );
 
             if ( !existsUpperBound( element ) )
-              maxElementUB = FloatUtils::infinity();
+                maxElementUB = FloatUtils::infinity();
             else
-              maxElementUB = FloatUtils::max( getUpperBound( element ), maxElementUB );
+                maxElementUB = FloatUtils::max( getUpperBound( element ), maxElementUB );
         }
 
         // Treat the maxValueEliminated as an element
@@ -288,26 +289,27 @@ void MaxConstraint::getEntailedTightenings( List<Tightening> &tightenings ) cons
                 tightenings.append( Tightening( _f, maxElementUB, Tightening::UB ) );
             }
             else
-             {
+            {
                 // f_UB <= maxElementUB
                 for ( const auto &element : _elements )
                 {
                     if ( !existsUpperBound( element ) || FloatUtils::gt( getUpperBound( element ), fUB ) )
-                      tightenings.append( Tightening( element, fUB, Tightening::UB ) );
+                         FloatUtils::gt( getUpperBound( element ), fUB ) )
+                        tightenings.append( Tightening( element, fUB, Tightening::UB ) );
                 }
             }
         }
 
         // fLB cannot be smaller than maxElementLB
         if ( FloatUtils::lt( fLB, maxElementLB ) )
-          tightenings.append( Tightening( _f, maxElementLB, Tightening::LB ) );
+            tightenings.append( Tightening( _f, maxElementLB, Tightening::LB ) );
         // f_LB >= maxElementLB & single input element
         else if ( _elements.size() == 1 )
         {
             // Special case: there is only one element. In that case, the tighter lower
             // bound (in this case, f's) wins.
             if ( !_eliminatedVariables || FloatUtils::gt( fLB, _maxValueOfEliminated ) )
-              tightenings.append( Tightening( *_elements.begin(), fLB, Tightening::LB ) );
+                tightenings.append( Tightening( *_elements.begin(), fLB, Tightening::LB ) );
         }
 
         // TODO: can we derive additional bounds?
@@ -323,8 +325,8 @@ void MaxConstraint::getEntailedTightenings( List<Tightening> &tightenings ) cons
 
         for ( const auto &element : _elements )
         {
-              maxElementLB = FloatUtils::max( getLowerBound( element ), maxElementLB );
-              maxElementUB = FloatUtils::max( getUpperBound( element ), maxElementUB );
+            maxElementLB = FloatUtils::max( getLowerBound( element ), maxElementLB );
+            maxElementUB = FloatUtils::max( getUpperBound( element ), maxElementUB );
         }
 
         // Treat the maxValueEliminated as an element
@@ -347,25 +349,25 @@ void MaxConstraint::getEntailedTightenings( List<Tightening> &tightenings ) cons
                 for ( const auto &element : _elements )
                 {
                     if ( FloatUtils::gt( getUpperBound( element ), fUB ) )
-                      tightenings.append( Tightening( element, fUB, Tightening::UB ) );
+                        tightenings.append( Tightening( element, fUB, Tightening::UB ) );
                 }
             }
         }
 
         // fLB cannot be smaller than maxElementLB
         if ( FloatUtils::lt( fLB, maxElementLB ) )
-          tightenings.append( Tightening( _f, maxElementLB, Tightening::LB ) );
+            tightenings.append( Tightening( _f, maxElementLB, Tightening::LB ) );
         // f_LB >= maxElementLB & single input element
         else if ( _elements.size() == 1 )
-          {
+        {
             // Special case: there is only one element. In that case, the tighter lower
             // bound (in this case, f's) wins.
             if ( !_eliminatedVariables || FloatUtils::gt( fLB, _maxValueOfEliminated ) )
-              tightenings.append( Tightening( *_elements.begin(), fLB, Tightening::LB ) );
-          }
+                tightenings.append( Tightening( *_elements.begin(), fLB, Tightening::LB ) );
+        }
 
         // TODO: can we derive additional bounds?
-      }
+    }
 }
 
 bool MaxConstraint::participatingVariable( unsigned variable ) const
@@ -385,11 +387,11 @@ List<unsigned> MaxConstraint::getParticipatingVariables() const
     if ( _cdInfeasibleCases )
     {
         for ( auto element : _elements )
-          if ( !isCaseInfeasible( element ) )
-            result.append( element );
+            if ( !isCaseInfeasible( element ) )
+                result.append( element );
 
         if ( !_elements.exists( _f ) && !isCaseInfeasible( _f ) )
-          result.append( _f );
+            result.append( _f );
     }
     else
     {

--- a/src/engine/MaxConstraint.cpp
+++ b/src/engine/MaxConstraint.cpp
@@ -381,11 +381,25 @@ bool MaxConstraint::wereVariablesEliminated() const
 List<unsigned> MaxConstraint::getParticipatingVariables() const
 {
     List<unsigned> result;
-    for ( auto element : _elements )
-        result.append( element );
 
-    if ( !_elements.exists( _f ) )
-        result.append( _f );
+    if ( _cdInfeasibleCases )
+    {
+        for ( auto element : _elements )
+          if ( !isCaseInfeasible( element ) )
+            result.append( element );
+
+        if ( !_elements.exists( _f ) && !isCaseInfeasible( _f ) )
+          result.append( _f );
+    }
+    else
+    {
+        for ( auto element : _elements )
+            result.append( element );
+
+        if ( !_elements.exists( _f ) )
+            result.append( _f );
+    }
+
     return result;
 }
 

--- a/src/engine/MaxConstraint.cpp
+++ b/src/engine/MaxConstraint.cpp
@@ -253,8 +253,8 @@ void MaxConstraint::notifyUpperBound( unsigned variable, double value )
 void MaxConstraint::getEntailedTightenings( List<Tightening> &tightenings ) const
 {
     // Lower and upper bounds for the f variable
-    double fLB = existsLowerBound( _f ) ? _lowerBounds.get( _f ) : FloatUtils::negativeInfinity();
-    double fUB = existsUpperBound( _f ) ? _upperBounds.get( _f ) : FloatUtils::infinity();
+    double fLB = existsLowerBound( _f ) ? getLowerBound( _f ) : FloatUtils::negativeInfinity();
+    double fUB = existsUpperBound( _f ) ? getUpperBound( _f ) : FloatUtils::infinity();
 
     // Compute the maximal bounds (lower and upper) for the elements
     double maxElementLB = FloatUtils::negativeInfinity();
@@ -285,9 +285,9 @@ void MaxConstraint::getEntailedTightenings( List<Tightening> &tightenings ) cons
         {
             tightenings.append( Tightening( _f, maxElementUB, Tightening::UB ) );
         }
-		else
+        else
         {
-			// f_UB <= maxElementUB
+            // f_UB <= maxElementUB
             for ( const auto &element : _elements )
             {
                 if ( !existsUpperBound( element ) || FloatUtils::gt( getUpperBound( element ), fUB ) )
@@ -299,8 +299,7 @@ void MaxConstraint::getEntailedTightenings( List<Tightening> &tightenings ) cons
     // fLB cannot be smaller than maxElementLB
     if ( FloatUtils::lt( fLB, maxElementLB ) )
         tightenings.append( Tightening( _f, maxElementLB, Tightening::LB ) );
-
-	// f_LB >= maxElementLB & single input element
+    // f_LB >= maxElementLB & single input element
     else if ( _elements.size() == 1 )
     {
         // Special case: there is only one element. In that case, the tighter lower

--- a/src/engine/MaxConstraint.cpp
+++ b/src/engine/MaxConstraint.cpp
@@ -9,23 +9,7 @@
  ** All rights reserved. See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** MaxConstraint implements the following constraint:
- ** _f = Max( e1, e2, ..., eM), where _elements = { e1, e2, ..., eM}
- **
- ** The constraint will refer to elements as its phases, by wrapping the
- ** variable identifiers as PhaseStatus enumeration. Additionally, during
- ** preprocessing one or more phases may be eliminated from the constraint. A
- ** maximum of such constraints is stored locally, and to denote this phase a
- ** special value PhaseStatus::MAX_PHASE_ELIMINATED is used.
- **
- ** MaxConstraint operates in two modes: preprocessing, which uses local bounds
- ** and values, and context-dependent mode which automatically backtracks the
- ** constraint state. A MaxConstraints object enters context-dependent mode upon
- ** invocation of MaxConstraint::initializeCDOs() and it cannot be undone.
- **
- ** Once in the context-dependent mode, MaxConstraint can be used for explicit
- ** exploration of the search space, using the markInfeasible/nextFeasibleCase
- ** methods.
+ ** See the description of the class in MaxConstraint.h.
  **/
 
 #include "MaxConstraint.h"

--- a/src/engine/MaxConstraint.h
+++ b/src/engine/MaxConstraint.h
@@ -28,8 +28,8 @@
 #ifndef __MaxConstraint_h__
 #define __MaxConstraint_h__
 
-#include "Map.h"
 #include "ContextDependentPiecewiseLinearConstraint.h"
+#include "Map.h"
 
 #define MAX_VARIABLE_TO_PHASE_OFFSET 1
 
@@ -174,7 +174,6 @@ public:
     bool wereVariablesEliminated() const;
 
 
-
     bool isImplication() const override;
 
 private:
@@ -228,16 +227,17 @@ private:
 
     inline PhaseStatus variableToPhase( unsigned variable ) const
     {
-        return ( variable == MAX_PHASE_ELIMINATED ) ? MAX_PHASE_ELIMINATED :
-               static_cast<PhaseStatus>( variable + MAX_VARIABLE_TO_PHASE_OFFSET  );
+        return ( variable == MAX_PHASE_ELIMINATED )
+                 ? MAX_PHASE_ELIMINATED
+                 : static_cast<PhaseStatus>( variable + MAX_VARIABLE_TO_PHASE_OFFSET );
     }
 
     inline unsigned phaseToVariable( PhaseStatus phase ) const
     {
-        return ( phase == MAX_PHASE_ELIMINATED ) ? MAX_PHASE_ELIMINATED :
-               static_cast<unsigned>( phase ) - MAX_VARIABLE_TO_PHASE_OFFSET;
+        return ( phase == MAX_PHASE_ELIMINATED )
+                 ? MAX_PHASE_ELIMINATED
+                 : static_cast<unsigned>( phase ) - MAX_VARIABLE_TO_PHASE_OFFSET;
     }
-
 };
 
 #endif // __MaxConstraint_h__

--- a/src/engine/MaxConstraint.h
+++ b/src/engine/MaxConstraint.h
@@ -238,7 +238,6 @@ private:
                static_cast<unsigned>( phase ) - MAX_VARIABLE_TO_PHASE_OFFSET;
     }
 
-
 };
 
 #endif // __MaxConstraint_h__

--- a/src/engine/MaxConstraint.h
+++ b/src/engine/MaxConstraint.h
@@ -12,17 +12,20 @@
  ** MaxConstraint implements the following constraint:
  ** _f = Max( e1, e2, ..., eM), where _elements = { e1, e2, ..., eM}
  **
- ** The constraint will refer to elements as its phases, by wrapping the
- ** variable identifiers as PhaseStatus enumeration. Additionally, during
- ** preprocessing one or more phases may be eliminated from the constraint. A
- ** maximum of such constraints is stored locally, and to denote this phase a
- ** special value PhaseStatus::MAX_PHASE_ELIMINATED is used.
+ ** MaxConstraint refers to elements as its phases, by wrapping the variable
+ ** identifiers as PhaseStatus enumeration. It allows elimination of elements
+ ** during preprocessing. Eliminated elements are abstracted in an aggregate
+ ** local member _maxValueOfEliminated, and its phase is a reserved value
+ ** PhaseStatus::MAX_PHASE_ELIMINATED.
  **
- ** The constraint operates in two modes: pre-processing mode, which stores
- ** bounds locally, and context dependent mode, which is used during the search.
+ ** The constraint is implemented as ContextDependentPiecewiseLinearConstraint
+ ** and operates in two modes:
+ **   * pre-processing mode, which stores bounds locally, and
+ **   * context dependent mode, used during the search.
+ **
  ** Invoking initializeCDOs method activates the context dependent mode, and the
- ** constraint object synchronizes its state automatically with the central context
- ** object.
+ ** MaxConstraint object synchronizes its state automatically with the central
+ ** Context object.
  **/
 
 #ifndef __MaxConstraint_h__

--- a/src/engine/PiecewiseLinearConstraint.h
+++ b/src/engine/PiecewiseLinearConstraint.h
@@ -257,12 +257,12 @@ public:
     /*
       Retrieve the current lower and upper bounds
     */
-    double getLowerBound( unsigned i ) const
+    virtual double getLowerBound( unsigned i ) const
     {
         return _lowerBounds[i];
     }
 
-    double getUpperBound( unsigned i ) const
+    virtual double getUpperBound( unsigned i ) const
     {
         return _upperBounds[i];
     }

--- a/src/engine/ReluConstraint.cpp
+++ b/src/engine/ReluConstraint.cpp
@@ -23,8 +23,8 @@
 #include "ITableau.h"
 #include "InputQuery.h"
 #include "MStringf.h"
-#include "PiecewiseLinearCaseSplit.h"
 #include "MarabouError.h"
+#include "PiecewiseLinearCaseSplit.h"
 #include "Statistics.h"
 #include "TableauRow.h"
 
@@ -393,7 +393,7 @@ List<PiecewiseLinearConstraint::Fix> ReluConstraint::getSmartFixes( ITableau *ta
 
         if ( !FloatUtils::areEqual( bDeltaToFDelta, 1.0 ) )
         {
-            double activeFixDelta = ( bValue - fValue )  / ( bDeltaToFDelta - 1 );
+            double activeFixDelta = ( bValue - fValue ) / ( bDeltaToFDelta - 1 );
             double activeFix = bValue + activeFixDelta;
             fixes.append( PiecewiseLinearConstraint::Fix( _b, activeFix ) );
         }
@@ -406,7 +406,7 @@ List<PiecewiseLinearConstraint::Fix> ReluConstraint::getSmartFixes( ITableau *ta
         */
         if ( !FloatUtils::areEqual( fDeltaToBDelta, 1.0 ) )
         {
-            double activeFixDelta = ( fValue - bValue )  / ( fDeltaToBDelta - 1 );
+            double activeFixDelta = ( fValue - bValue ) / ( fDeltaToBDelta - 1 );
             double activeFix = fValue + activeFixDelta;
             fixes.append( PiecewiseLinearConstraint::Fix( _f, activeFix ) );
         }

--- a/src/engine/ReluConstraint.cpp
+++ b/src/engine/ReluConstraint.cpp
@@ -9,7 +9,7 @@
  ** All rights reserved. See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** [[ Add lengthier description here ]]
+ ** See the description of the class in ReluConstraint.h.
  **/
 
 #include "ReluConstraint.h"

--- a/src/engine/ReluConstraint.h
+++ b/src/engine/ReluConstraint.h
@@ -234,6 +234,26 @@ private:
       Return true iff b or f are out of bounds.
     */
     bool haveOutOfBoundVariables() const;
+
+    inline double getLowerBound( unsigned var ) const
+    {
+      return ( _boundManager == nullptr ) ? _boundManager->getLowerBound( var ) : _lowerBounds[var];
+    }
+
+    inline double getUpperBound( unsigned var ) const
+    {
+      return ( _boundManager == nullptr ) ? _boundManager->getUpperBound( var ) : _upperBounds[var];
+    }
+
+    inline void setLowerBound( unsigned var, double value )
+    {
+      ( _boundManager == nullptr ) ? _boundManager->setLowerBound( var, value ) : _lowerBounds[var] = value;
+    }
+
+    inline void setUpperBound( unsigned var, double value )
+    {
+      ( _boundManager == nullptr ) ? _boundManager->setUpperBound( var, value ) : _upperBounds[var] = value;
+    }
 };
 
 #endif // __ReluConstraint_h__

--- a/src/engine/ReluConstraint.h
+++ b/src/engine/ReluConstraint.h
@@ -235,6 +235,16 @@ private:
     */
     bool haveOutOfBoundVariables() const;
 
+    inline bool existsLowerBound( unsigned var ) const
+    {
+      return _boundManager != nullptr || _lowerBounds.exists( var );
+    }
+
+    inline bool existsUpperBound( unsigned var ) const
+    {
+      return _boundManager != nullptr || _upperBounds.exists( var );
+    }
+
     inline double getLowerBound( unsigned var ) const
     {
       return ( _boundManager == nullptr ) ? _boundManager->getLowerBound( var ) : _lowerBounds[var];

--- a/src/engine/ReluConstraint.h
+++ b/src/engine/ReluConstraint.h
@@ -30,6 +30,7 @@
 #include "List.h"
 #include "Map.h"
 #include "PiecewiseLinearConstraint.h"
+
 #include <cmath>
 
 class ReluConstraint : public ContextDependentPiecewiseLinearConstraint
@@ -234,8 +235,6 @@ private:
       Return true iff b or f are out of bounds.
     */
     bool haveOutOfBoundVariables() const;
-
 };
 
 #endif // __ReluConstraint_h__
-

--- a/src/engine/ReluConstraint.h
+++ b/src/engine/ReluConstraint.h
@@ -235,35 +235,6 @@ private:
     */
     bool haveOutOfBoundVariables() const;
 
-    inline bool existsLowerBound( unsigned var ) const
-    {
-      return _boundManager != nullptr || _lowerBounds.exists( var );
-    }
-
-    inline bool existsUpperBound( unsigned var ) const
-    {
-      return _boundManager != nullptr || _upperBounds.exists( var );
-    }
-
-    inline double getLowerBound( unsigned var ) const
-    {
-      return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( var ) : _lowerBounds[var];
-    }
-
-    inline double getUpperBound( unsigned var ) const
-    {
-      return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( var ) : _upperBounds[var];
-    }
-
-    inline void setLowerBound( unsigned var, double value )
-    {
-      ( _boundManager != nullptr ) ? _boundManager->setLowerBound( var, value ) : _lowerBounds[var] = value;
-    }
-
-    inline void setUpperBound( unsigned var, double value )
-    {
-      ( _boundManager != nullptr ) ? _boundManager->setUpperBound( var, value ) : _upperBounds[var] = value;
-    }
 };
 
 #endif // __ReluConstraint_h__

--- a/src/engine/ReluConstraint.h
+++ b/src/engine/ReluConstraint.h
@@ -247,22 +247,22 @@ private:
 
     inline double getLowerBound( unsigned var ) const
     {
-      return ( _boundManager == nullptr ) ? _boundManager->getLowerBound( var ) : _lowerBounds[var];
+      return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( var ) : _lowerBounds[var];
     }
 
     inline double getUpperBound( unsigned var ) const
     {
-      return ( _boundManager == nullptr ) ? _boundManager->getUpperBound( var ) : _upperBounds[var];
+      return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( var ) : _upperBounds[var];
     }
 
     inline void setLowerBound( unsigned var, double value )
     {
-      ( _boundManager == nullptr ) ? _boundManager->setLowerBound( var, value ) : _lowerBounds[var] = value;
+      ( _boundManager != nullptr ) ? _boundManager->setLowerBound( var, value ) : _lowerBounds[var] = value;
     }
 
     inline void setUpperBound( unsigned var, double value )
     {
-      ( _boundManager == nullptr ) ? _boundManager->setUpperBound( var, value ) : _upperBounds[var] = value;
+      ( _boundManager != nullptr ) ? _boundManager->setUpperBound( var, value ) : _upperBounds[var] = value;
     }
 };
 

--- a/src/engine/ReluConstraint.h
+++ b/src/engine/ReluConstraint.h
@@ -10,17 +10,21 @@
  ** directory for licensing information.\endverbatim
  **
  ** ReluConstraint implements the following constraint:
- ** f = Max( 0, b )
+ ** f = Max( 0, b ) =    ( b > 0 -> f > 0 )
+ **                   /\ ( b <=0 -> f = 0 )
  **
  ** It distinguishes two relevant phases for search:
  ** RELU_PHASE_ACTIVE   : b > 0 and f > 0
  ** RELU_PHASE_INACTIVE : b <=0 and f = 0
  **
- ** The constraint operates in two modes: pre-processing mode, which stores
- ** bounds locally, and context dependent mode, which is used during the search.
+ ** The constraint is implemented as ContextDependentPiecewiseLinearConstraint
+ ** and operates in two modes:
+ **   * pre-processing mode, which stores bounds locally, and
+ **   * context dependent mode, used during the search.
+ **
  ** Invoking initializeCDOs method activates the context dependent mode, and the
- ** constraint object synchronizes its state automatically with the central context
- ** object.
+ ** ReluConstraint object synchronizes its state automatically with the central
+ ** Context object.
  **/
 
 #ifndef __ReluConstraint_h__

--- a/src/engine/SignConstraint.cpp
+++ b/src/engine/SignConstraint.cpp
@@ -124,19 +124,19 @@ List<PiecewiseLinearCaseSplit> SignConstraint::getCaseSplits() const
     if ( _phaseStatus != PHASE_NOT_FIXED )
         throw MarabouError( MarabouError::REQUESTED_CASE_SPLITS_FROM_FIXED_CONSTRAINT );
 
-    List <PiecewiseLinearCaseSplit> splits;
+    List<PiecewiseLinearCaseSplit> splits;
 
     if ( _direction == SIGN_PHASE_NEGATIVE )
     {
-      splits.append( getNegativeSplit() );
-      splits.append( getPositiveSplit() );
-      return splits;
+        splits.append( getNegativeSplit() );
+        splits.append( getPositiveSplit() );
+        return splits;
     }
     if ( _direction == SIGN_PHASE_POSITIVE )
     {
-      splits.append( getPositiveSplit() );
-      splits.append( getNegativeSplit() );
-      return splits;
+        splits.append( getPositiveSplit() );
+        splits.append( getNegativeSplit() );
+        return splits;
     }
 
     // If we have existing knowledge about the assignment, use it to
@@ -170,19 +170,19 @@ List<PhaseStatus> SignConstraint::getAllCases() const
         throw MarabouError( MarabouError::REQUESTED_CASE_SPLITS_FROM_FIXED_CONSTRAINT );
 
     if ( _direction == SIGN_PHASE_NEGATIVE )
-      return { SIGN_PHASE_NEGATIVE, SIGN_PHASE_POSITIVE };
+        return { SIGN_PHASE_NEGATIVE, SIGN_PHASE_POSITIVE };
 
     if ( _direction == SIGN_PHASE_POSITIVE )
-      return { SIGN_PHASE_POSITIVE, SIGN_PHASE_NEGATIVE };
+        return { SIGN_PHASE_POSITIVE, SIGN_PHASE_NEGATIVE };
 
     // If we have existing knowledge about the assignment, use it to
     // influence the order of splits
     if ( _assignment.exists( _f ) )
     {
         if ( FloatUtils::isPositive( _assignment[_f] ) )
-          return { SIGN_PHASE_POSITIVE, SIGN_PHASE_NEGATIVE };
+            return { SIGN_PHASE_POSITIVE, SIGN_PHASE_NEGATIVE };
         else
-          return { SIGN_PHASE_NEGATIVE, SIGN_PHASE_POSITIVE };
+            return { SIGN_PHASE_NEGATIVE, SIGN_PHASE_POSITIVE };
     }
 
     return { SIGN_PHASE_NEGATIVE, SIGN_PHASE_POSITIVE };
@@ -190,12 +190,12 @@ List<PhaseStatus> SignConstraint::getAllCases() const
 
 PiecewiseLinearCaseSplit SignConstraint::getCaseSplit( PhaseStatus phase ) const
 {
-  if ( phase == SIGN_PHASE_NEGATIVE )
-      return getNegativeSplit();
-  else if ( phase == SIGN_PHASE_POSITIVE )
-      return getPositiveSplit();
-  else
-      throw MarabouError( MarabouError::REQUESTED_NONEXISTENT_CASE_SPLIT );
+    if ( phase == SIGN_PHASE_NEGATIVE )
+        return getNegativeSplit();
+    else if ( phase == SIGN_PHASE_POSITIVE )
+        return getPositiveSplit();
+    else
+        throw MarabouError( MarabouError::REQUESTED_NONEXISTENT_CASE_SPLIT );
 }
 
 PiecewiseLinearCaseSplit SignConstraint::getNegativeSplit() const
@@ -233,7 +233,7 @@ PiecewiseLinearCaseSplit SignConstraint::getImpliedCaseSplit() const
 
 PiecewiseLinearCaseSplit SignConstraint::getValidCaseSplit() const
 {
-  return getImpliedCaseSplit();
+    return getImpliedCaseSplit();
 }
 
 bool SignConstraint::constraintObsolete() const
@@ -265,17 +265,17 @@ String SignConstraint::phaseToString( PhaseStatus phase )
 {
     switch ( phase )
     {
-        case PHASE_NOT_FIXED:
-            return "PHASE_NOT_FIXED";
+    case PHASE_NOT_FIXED:
+        return "PHASE_NOT_FIXED";
 
-        case SIGN_PHASE_POSITIVE:
-            return "SIGN_PHASE_POSITIVE";
+    case SIGN_PHASE_POSITIVE:
+        return "SIGN_PHASE_POSITIVE";
 
-        case SIGN_PHASE_NEGATIVE:
-            return "SIGN_PHASE_NEGATIVE";
+    case SIGN_PHASE_NEGATIVE:
+        return "SIGN_PHASE_NEGATIVE";
 
-        default:
-            return "UNKNOWN";
+    default:
+        return "UNKNOWN";
     }
 };
 
@@ -402,7 +402,7 @@ void SignConstraint::getEntailedTightenings( List<Tightening> &tightenings ) con
 
 void SignConstraint::updateVariableIndex( unsigned oldIndex, unsigned newIndex )
 {
-    ASSERT( oldIndex == _b || oldIndex == _f  );
+    ASSERT( oldIndex == _b || oldIndex == _f );
     ASSERT( !_boundManager );
     ASSERT( !_assignment.exists( newIndex ) &&
             !_lowerBounds.exists( newIndex ) &&
@@ -499,13 +499,13 @@ void SignConstraint::dump( String &output ) const
 
 double SignConstraint::computePolarity() const
 {
-  double currentLb = getLowerBound( _b );
-  double currentUb = getUpperBound( _b );
-  if ( !FloatUtils::isNegative( currentLb ) ) return 1;
-  if ( FloatUtils::isNegative( currentUb ) ) return -1;
-  double width = currentUb - currentLb;
-  double sum = currentUb + currentLb;
-  return sum / width;
+    double currentLb = getLowerBound( _b );
+    double currentUb = getUpperBound( _b );
+    if ( !FloatUtils::isNegative( currentLb ) ) return 1;
+    if ( FloatUtils::isNegative( currentUb ) ) return -1;
+    double width = currentUb - currentLb;
+    double sum = currentUb + currentLb;
+    return sum / width;
 }
 
 void SignConstraint::updateDirection()
@@ -516,15 +516,15 @@ void SignConstraint::updateDirection()
 
 PhaseStatus SignConstraint::getDirection() const
 {
-  return _direction;
+    return _direction;
 }
 
 void SignConstraint::updateScoreBasedOnPolarity()
 {
-  _score = std::abs( computePolarity() );
+    _score = std::abs( computePolarity() );
 }
 
 bool SignConstraint::supportPolarity() const
 {
-  return true;
+    return true;
 }

--- a/src/engine/SignConstraint.cpp
+++ b/src/engine/SignConstraint.cpp
@@ -9,7 +9,7 @@
  ** All rights reserved. See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** [[ Add lengthier description here ]]
+ ** See the description of the class in SignConstraint.h.
  **/
 
 #include "SignConstraint.h"

--- a/src/engine/SignConstraint.h
+++ b/src/engine/SignConstraint.h
@@ -210,38 +210,6 @@ private:
       Return true iff b or f are out of bounds.
     */
     bool haveOutOfBoundVariables() const;
-    /*
-       Bounds get/set wrappers
-     */
-    inline bool existsLowerBound( unsigned var ) const
-    {
-      return _boundManager != nullptr || _lowerBounds.exists( var );
-    }
-
-    inline bool existsUpperBound( unsigned var ) const
-    {
-      return _boundManager != nullptr || _upperBounds.exists( var );
-    }
-
-    inline double getLowerBound( unsigned var ) const
-    {
-      return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( var ) : _lowerBounds[var];
-    }
-
-    inline double getUpperBound( unsigned var ) const
-    {
-      return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( var ) : _upperBounds[var];
-    }
-
-    inline void setLowerBound( unsigned var, double value )
-    {
-      ( _boundManager != nullptr ) ? _boundManager->setLowerBound( var, value ) : _lowerBounds[var] = value;
-    }
-
-    inline void setUpperBound( unsigned var, double value )
-    {
-      ( _boundManager != nullptr ) ? _boundManager->setUpperBound( var, value ) : _upperBounds[var] = value;
-    }
 };
 
 #endif // __SignConstraint_h__

--- a/src/engine/SignConstraint.h
+++ b/src/engine/SignConstraint.h
@@ -210,6 +210,38 @@ private:
       Return true iff b or f are out of bounds.
     */
     bool haveOutOfBoundVariables() const;
+    /*
+       Bounds get/set wrappers
+     */
+    inline bool existsLowerBound( unsigned var ) const
+    {
+      return _boundManager != nullptr || _lowerBounds.exists( var );
+    }
+
+    inline bool existsUpperBound( unsigned var ) const
+    {
+      return _boundManager != nullptr || _upperBounds.exists( var );
+    }
+
+    inline double getLowerBound( unsigned var ) const
+    {
+      return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( var ) : _lowerBounds[var];
+    }
+
+    inline double getUpperBound( unsigned var ) const
+    {
+      return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( var ) : _upperBounds[var];
+    }
+
+    inline void setLowerBound( unsigned var, double value )
+    {
+      ( _boundManager != nullptr ) ? _boundManager->setLowerBound( var, value ) : _lowerBounds[var] = value;
+    }
+
+    inline void setUpperBound( unsigned var, double value )
+    {
+      ( _boundManager != nullptr ) ? _boundManager->setUpperBound( var, value ) : _upperBounds[var] = value;
+    }
 };
 
 #endif // __SignConstraint_h__

--- a/src/engine/SignConstraint.h
+++ b/src/engine/SignConstraint.h
@@ -10,17 +10,21 @@
  ** directory for licensing information.\endverbatim
  **
  ** SignConstraint implements the following constraint:
- ** f = Sign( b )
+ ** f = Sign( b ) =    ( b > 0 -> f =  1 )
+ **                 /\ ( b <=0 -> f = -1 )
  **
  ** It distinguishes two relevant phases for search:
- ** SIGN_PHASE_POSITIVE: b > 0 and f = 1
+ ** SIGN_PHASE_POSITIVE: b > 0 and f =  1
  ** SIGN_PHASE_NEGATIVE: b <=0 and f = -1
  **
- ** The constraint operates in two modes: pre-processing mode, which stores
- ** bounds locally, and context dependent mode, which is used during the search.
+ ** The constraint is implemented as ContextDependentPiecewiseLinearConstraint
+ ** and operates in two modes:
+ **   * pre-processing mode, which stores bounds locally, and
+ **   * context dependent mode, used during the search.
+ **
  ** Invoking initializeCDOs method activates the context dependent mode, and the
- ** constraint object synchronizes its state automatically with the central context
- ** object.
+ ** SignConstraint object synchronizes its state automatically with the central
+ ** Context object.
  **/
 
 #ifndef __SignConstraint_h__

--- a/src/engine/tests/Test_AbsoluteValueConstraint.h
+++ b/src/engine/tests/Test_AbsoluteValueConstraint.h
@@ -35,7 +35,7 @@ public:
 class TestAbsConstraint : public AbsoluteValueConstraint
 {
 public:
-    TestAbsConstraint(unsigned b, unsigned f)
+    TestAbsConstraint( unsigned b, unsigned f )
         : AbsoluteValueConstraint( b, f )
     {}
 
@@ -133,7 +133,7 @@ public:
         ++it;
         TS_ASSERT_EQUALS( *it, f );
 
-        TS_ASSERT_EQUALS( abs.getParticipatingVariables(), List<unsigned>( {1,4} ) );
+        TS_ASSERT_EQUALS( abs.getParticipatingVariables(), List<unsigned>( { 1, 4 } ) );
 
         TS_ASSERT( abs.participatingVariable( b ) );
         TS_ASSERT( abs.participatingVariable( f ) );
@@ -495,7 +495,7 @@ public:
             unsigned f = 4;
 
             AbsoluteValueConstraint abs( b, f );
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyUpperBound( b, 7 );
@@ -546,7 +546,7 @@ public:
             boundManager.initialize( 5 );
             abs.registerBoundManager( &boundManager );
 
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyUpperBound( b, 7 );
@@ -595,7 +595,7 @@ public:
             unsigned f = 4;
 
             AbsoluteValueConstraint abs( b, f );
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
 
             abs.notifyUpperBound( b, 6 );
             abs.notifyUpperBound( f, 5 );
@@ -618,7 +618,7 @@ public:
             boundManager.initialize( 5 );
             abs.registerBoundManager( &boundManager );
 
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
 
             abs.notifyUpperBound( b, 6 );
             abs.notifyUpperBound( f, 5 );
@@ -651,15 +651,14 @@ public:
             abs.getEntailedTightenings( entailedTightenings );
 
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( f, 0, Tightening::LB ),
 
-                                              Tightening( b, 0, Tightening::LB ),
-                                              Tightening( b, 10, Tightening::UB ),
-                                              Tightening( f, 5, Tightening::LB ),
-                                              Tightening( f, 10, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 0, Tightening::LB ),
+                                          Tightening( b, 10, Tightening::UB ),
+                                          Tightening( f, 5, Tightening::LB ),
+                                          Tightening( f, 10, Tightening::UB ),
+                                      } ) );
         }
 
         {   // With Bound Manager
@@ -684,15 +683,14 @@ public:
             abs.getEntailedTightenings( entailedTightenings );
 
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( f, 0, Tightening::LB ),
 
-                                              Tightening( b, 0, Tightening::LB ),
-                                              Tightening( b, 10, Tightening::UB ),
-                                              Tightening( f, 5, Tightening::LB ),
-                                              Tightening( f, 10, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 0, Tightening::LB ),
+                                          Tightening( b, 10, Tightening::UB ),
+                                          Tightening( f, 5, Tightening::LB ),
+                                          Tightening( f, 10, Tightening::UB ),
+                                      } ) );
         }
     }
 
@@ -703,7 +701,7 @@ public:
             unsigned f = 4;
 
             AbsoluteValueConstraint abs( b, f );
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -6 );
@@ -715,12 +713,11 @@ public:
             abs.getEntailedTightenings( entailedTightenings );
 
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -4, Tightening::LB ),
-                                              Tightening( b, 4, Tightening::UB ),
-                                              Tightening( f, 6, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 4, Tightening::UB ),
+                                          Tightening( f, 6, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
 
@@ -729,12 +726,11 @@ public:
             abs.getEntailedTightenings( entailedTightenings );
 
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -4, Tightening::LB ),
-                                              Tightening( b, 4, Tightening::UB ),
-                                              Tightening( f, 6, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 4, Tightening::UB ),
+                                          Tightening( f, 6, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
 
@@ -743,16 +739,15 @@ public:
             abs.getEntailedTightenings( entailedTightenings );
 
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -4, Tightening::LB ),
-                                              Tightening( b, 4, Tightening::UB ),
-                                              Tightening( f, 6, Tightening::UB ),
-                                              Tightening( b, -2, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 4, Tightening::UB ),
+                                          Tightening( f, 6, Tightening::UB ),
+                                          Tightening( b, -2, Tightening::UB ),
+                                      } ) );
         }
 
-        {   // With Bound Manager
+        { // With Bound Manager
             unsigned b = 1;
             unsigned f = 4;
 
@@ -762,7 +757,7 @@ public:
             boundManager.initialize( 5 );
             abs.registerBoundManager( &boundManager );
 
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -6 );
@@ -774,12 +769,11 @@ public:
             abs.getEntailedTightenings( entailedTightenings );
 
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -4, Tightening::LB ),
-                                              Tightening( b, 4, Tightening::UB ),
-                                              Tightening( f, 6, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 4, Tightening::UB ),
+                                          Tightening( f, 6, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
 
@@ -788,12 +782,11 @@ public:
             abs.getEntailedTightenings( entailedTightenings );
 
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -4, Tightening::LB ),
-                                              Tightening( b, 4, Tightening::UB ),
-                                              Tightening( f, 6, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 4, Tightening::UB ),
+                                          Tightening( f, 6, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
 
@@ -802,13 +795,12 @@ public:
             abs.getEntailedTightenings( entailedTightenings );
 
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -4, Tightening::LB ),
-                                              Tightening( b, 4, Tightening::UB ),
-                                              Tightening( f, 6, Tightening::UB ),
-                                              Tightening( b, -2, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 4, Tightening::UB ),
+                                          Tightening( f, 6, Tightening::UB ),
+                                          Tightening( b, -2, Tightening::UB ),
+                                      } ) );
         }
     }
 
@@ -819,7 +811,7 @@ public:
             unsigned f = 4;
 
             AbsoluteValueConstraint abs( b, f );
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -5 );
@@ -830,12 +822,11 @@ public:
             // -5 < x_b < 10 ,3 < x_f < 7
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -7, Tightening::LB ),
-                                              Tightening( b, 7, Tightening::UB ),
-                                              Tightening( f, 10, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 7, Tightening::UB ),
+                                          Tightening( f, 10, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
 
@@ -844,13 +835,12 @@ public:
 
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -7, Tightening::LB ),
-                                              Tightening( b, 7, Tightening::UB ),
-                                              Tightening( f, 10, Tightening::UB ),
-                                              Tightening( b, 6, Tightening::LB ),
-                                              }) );
+                                          Tightening( b, 7, Tightening::UB ),
+                                          Tightening( f, 10, Tightening::UB ),
+                                          Tightening( b, 6, Tightening::LB ),
+                                      } ) );
 
             entailedTightenings.clear();
 
@@ -862,17 +852,16 @@ public:
 
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -7, Tightening::LB ),
-                                              Tightening( b, 7, Tightening::UB ),
-                                              Tightening( f, 5, Tightening::UB ),
-                                              Tightening( b, 6, Tightening::LB ),
-                                              Tightening( b, -6, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 7, Tightening::UB ),
+                                          Tightening( f, 5, Tightening::UB ),
+                                          Tightening( b, 6, Tightening::LB ),
+                                          Tightening( b, -6, Tightening::UB ),
+                                      } ) );
         }
 
-        {   // With Bound Manager
+        { // With Bound Manager
             unsigned b = 1;
             unsigned f = 4;
 
@@ -882,7 +871,7 @@ public:
             boundManager.initialize( 5 );
             abs.registerBoundManager( &boundManager );
 
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -5 );
@@ -893,12 +882,11 @@ public:
             // -5 < x_b < 10 ,3 < x_f < 7
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -7, Tightening::LB ),
-                                              Tightening( b, 7, Tightening::UB ),
-                                              Tightening( f, 10, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 7, Tightening::UB ),
+                                          Tightening( f, 10, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
 
@@ -907,13 +895,12 @@ public:
 
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -7, Tightening::LB ),
-                                              Tightening( b, 7, Tightening::UB ),
-                                              Tightening( f, 10, Tightening::UB ),
-                                              Tightening( b, 6, Tightening::LB ),
-                                              }) );
+                                          Tightening( b, 7, Tightening::UB ),
+                                          Tightening( f, 10, Tightening::UB ),
+                                          Tightening( b, 6, Tightening::LB ),
+                                      } ) );
 
             entailedTightenings.clear();
 
@@ -925,14 +912,13 @@ public:
 
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -7, Tightening::LB ),
-                                              Tightening( b, 7, Tightening::UB ),
-                                              Tightening( f, 5, Tightening::UB ),
-                                              Tightening( b, 6, Tightening::LB ),
-                                              Tightening( b, -6, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 7, Tightening::UB ),
+                                          Tightening( f, 5, Tightening::UB ),
+                                          Tightening( b, 6, Tightening::LB ),
+                                          Tightening( b, -6, Tightening::UB ),
+                                      } ) );
         }
     }
 
@@ -942,8 +928,8 @@ public:
             unsigned b = 1;
             unsigned f = 4;
 
-            AbsoluteValueConstraint abs(b, f);
-            List <Tightening> entailedTightenings;
+            AbsoluteValueConstraint abs( b, f );
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -1 );
@@ -954,27 +940,26 @@ public:
             // -1 < x_b < 1 ,2 < x_f < 4
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -4, Tightening::LB ),
-                                              Tightening( b, 4, Tightening::UB ),
-                                              Tightening( f, 1, Tightening::UB ),
-                                              Tightening( b, 2, Tightening::LB ),
-                                              Tightening( b, -2, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 4, Tightening::UB ),
+                                          Tightening( f, 1, Tightening::UB ),
+                                          Tightening( b, 2, Tightening::LB ),
+                                          Tightening( b, -2, Tightening::UB ),
+                                      } ) );
         }
 
-        {   // With Bound Manager
+        { // With Bound Manager
             unsigned b = 1;
             unsigned f = 4;
 
-            AbsoluteValueConstraint abs(b, f);
+            AbsoluteValueConstraint abs( b, f );
             Context context;
             BoundManager boundManager( context );
             boundManager.initialize( 5 );
             abs.registerBoundManager( &boundManager );
 
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -1 );
@@ -985,14 +970,13 @@ public:
             // -1 < x_b < 1 ,2 < x_f < 4
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -4, Tightening::LB ),
-                                              Tightening( b, 4, Tightening::UB ),
-                                              Tightening( f, 1, Tightening::UB ),
-                                              Tightening( b, 2, Tightening::LB ),
-                                              Tightening( b, -2, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 4, Tightening::UB ),
+                                          Tightening( f, 1, Tightening::UB ),
+                                          Tightening( b, 2, Tightening::LB ),
+                                          Tightening( b, -2, Tightening::UB ),
+                                      } ) );
         }
     }
 
@@ -1003,7 +987,7 @@ public:
             unsigned f = 4;
 
             AbsoluteValueConstraint abs( b, f );
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -7 );
@@ -1014,12 +998,11 @@ public:
             // -7 < x_b < 7 ,0 < x_f < 6
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -6, Tightening::LB ),
-                                              Tightening( b, 6, Tightening::UB ),
-                                              Tightening( f, 7, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 6, Tightening::UB ),
+                                          Tightening( f, 7, Tightening::UB ),
+                                      } ) );
 
 
             entailedTightenings.clear();
@@ -1028,25 +1011,23 @@ public:
             abs.notifyUpperBound( b, 5 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -6, Tightening::LB ),
-                                              Tightening( b, 6, Tightening::UB ),
-                                              Tightening( f, 7, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 6, Tightening::UB ),
+                                          Tightening( f, 7, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
             // 0 < x_b < 5 ,0 < x_f < 6
             abs.notifyLowerBound( b, 0 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, 0, Tightening::LB ),
-                                              Tightening( b, 6, Tightening::UB ),
-                                              Tightening( f, 0, Tightening::LB ),
-                                              Tightening( f, 5, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 6, Tightening::UB ),
+                                          Tightening( f, 0, Tightening::LB ),
+                                          Tightening( f, 5, Tightening::UB ),
+                                      } ) );
 
 
             entailedTightenings.clear();
@@ -1055,19 +1036,19 @@ public:
             abs.notifyLowerBound( b, 3 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, 0, Tightening::LB ),
-                                              Tightening( b, 6, Tightening::UB ),
-                                              Tightening( f, 3, Tightening::LB ),
-                                              Tightening( f, 5, Tightening::UB ),
-                                              }) );
-        }{
+                                          Tightening( b, 6, Tightening::UB ),
+                                          Tightening( f, 3, Tightening::LB ),
+                                          Tightening( f, 5, Tightening::UB ),
+                                      } ) );
+        }
+        {
             unsigned b = 1;
             unsigned f = 4;
 
             AbsoluteValueConstraint abs( b, f );
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -7 );
@@ -1078,12 +1059,11 @@ public:
             // -7 < x_b < 7 ,0 < x_f < 6
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -6, Tightening::LB ),
-                                              Tightening( b, 6, Tightening::UB ),
-                                              Tightening( f, 7, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 6, Tightening::UB ),
+                                          Tightening( f, 7, Tightening::UB ),
+                                      } ) );
 
 
             entailedTightenings.clear();
@@ -1092,25 +1072,23 @@ public:
             abs.notifyUpperBound( b, 5 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -6, Tightening::LB ),
-                                              Tightening( b, 6, Tightening::UB ),
-                                              Tightening( f, 7, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 6, Tightening::UB ),
+                                          Tightening( f, 7, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
             // 0 < x_b < 5 ,0 < x_f < 6
             abs.notifyLowerBound( b, 0 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, 0, Tightening::LB ),
-                                              Tightening( b, 6, Tightening::UB ),
-                                              Tightening( f, 0, Tightening::LB ),
-                                              Tightening( f, 5, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 6, Tightening::UB ),
+                                          Tightening( f, 0, Tightening::LB ),
+                                          Tightening( f, 5, Tightening::UB ),
+                                      } ) );
 
 
             entailedTightenings.clear();
@@ -1119,15 +1097,14 @@ public:
             abs.notifyLowerBound( b, 3 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, 0, Tightening::LB ),
-                                              Tightening( b, 6, Tightening::UB ),
-                                              Tightening( f, 3, Tightening::LB ),
-                                              Tightening( f, 5, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 6, Tightening::UB ),
+                                          Tightening( f, 3, Tightening::LB ),
+                                          Tightening( f, 5, Tightening::UB ),
+                                      } ) );
         }
-        {   // With Bound Manager
+        { // With Bound Manager
             unsigned b = 1;
             unsigned f = 4;
 
@@ -1137,7 +1114,7 @@ public:
             boundManager.initialize( 5 );
             abs.registerBoundManager( &boundManager );
 
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -7 );
@@ -1148,12 +1125,11 @@ public:
             // -7 < x_b < 7 ,0 < x_f < 6
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -6, Tightening::LB ),
-                                              Tightening( b, 6, Tightening::UB ),
-                                              Tightening( f, 7, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 6, Tightening::UB ),
+                                          Tightening( f, 7, Tightening::UB ),
+                                      } ) );
 
 
             entailedTightenings.clear();
@@ -1162,25 +1138,23 @@ public:
             abs.notifyUpperBound( b, 5 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -6, Tightening::LB ),
-                                              Tightening( b, 6, Tightening::UB ),
-                                              Tightening( f, 7, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 6, Tightening::UB ),
+                                          Tightening( f, 7, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
             // 0 < x_b < 5 ,0 < x_f < 6
             abs.notifyLowerBound( b, 0 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, 0, Tightening::LB ),
-                                              Tightening( b, 6, Tightening::UB ),
-                                              Tightening( f, 0, Tightening::LB ),
-                                              Tightening( f, 5, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 6, Tightening::UB ),
+                                          Tightening( f, 0, Tightening::LB ),
+                                          Tightening( f, 5, Tightening::UB ),
+                                      } ) );
 
 
             entailedTightenings.clear();
@@ -1189,13 +1163,12 @@ public:
             abs.notifyLowerBound( b, 3 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, 0, Tightening::LB ),
-                                              Tightening( b, 6, Tightening::UB ),
-                                              Tightening( f, 3, Tightening::LB ),
-                                              Tightening( f, 5, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 6, Tightening::UB ),
+                                          Tightening( f, 3, Tightening::LB ),
+                                          Tightening( f, 5, Tightening::UB ),
+                                      } ) );
         }
     }
 
@@ -1206,7 +1179,7 @@ public:
             unsigned f = 4;
 
             AbsoluteValueConstraint abs( b, f );
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -20 );
@@ -1217,13 +1190,12 @@ public:
             // -20 < x_b < -2 ,0 < x_f < 15
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -15, Tightening::LB ),
-                                              Tightening( b, 0, Tightening::UB ),
-                                              Tightening( f, 2, Tightening::LB ),
-                                              Tightening( f, 20, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 0, Tightening::UB ),
+                                          Tightening( f, 2, Tightening::LB ),
+                                          Tightening( f, 20, Tightening::UB ),
+                                      } ) );
 
 
             entailedTightenings.clear();
@@ -1232,13 +1204,12 @@ public:
             abs.notifyLowerBound( f, 7 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -15, Tightening::LB ),
-                                              Tightening( b, -7, Tightening::UB ),
-                                              Tightening( f, 2, Tightening::LB ),
-                                              Tightening( f, 20, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, -7, Tightening::UB ),
+                                          Tightening( f, 2, Tightening::LB ),
+                                          Tightening( f, 20, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
 
@@ -1246,13 +1217,12 @@ public:
             abs.notifyLowerBound( b, -12 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -15, Tightening::LB ),
-                                              Tightening( b, -7, Tightening::UB ),
-                                              Tightening( f, 2, Tightening::LB ),
-                                              Tightening( f, 12, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, -7, Tightening::UB ),
+                                          Tightening( f, 2, Tightening::LB ),
+                                          Tightening( f, 12, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
 
@@ -1260,13 +1230,12 @@ public:
             abs.notifyUpperBound( b, -8 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -15, Tightening::LB ),
-                                              Tightening( b, -7, Tightening::UB ),
-                                              Tightening( f, 8, Tightening::LB ),
-                                              Tightening( f, 12, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, -7, Tightening::UB ),
+                                          Tightening( f, 8, Tightening::LB ),
+                                          Tightening( f, 12, Tightening::UB ),
+                                      } ) );
         }
         {   // With Bound Manager
             unsigned b = 1;
@@ -1278,7 +1247,7 @@ public:
             boundManager.initialize( 5 );
             abs.registerBoundManager( &boundManager );
 
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -20 );
@@ -1289,13 +1258,12 @@ public:
             // -20 < x_b < -2 ,0 < x_f < 15
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -15, Tightening::LB ),
-                                              Tightening( b, 0, Tightening::UB ),
-                                              Tightening( f, 2, Tightening::LB ),
-                                              Tightening( f, 20, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, 0, Tightening::UB ),
+                                          Tightening( f, 2, Tightening::LB ),
+                                          Tightening( f, 20, Tightening::UB ),
+                                      } ) );
 
 
             entailedTightenings.clear();
@@ -1304,13 +1272,12 @@ public:
             abs.notifyLowerBound( f, 7 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -15, Tightening::LB ),
-                                              Tightening( b, -7, Tightening::UB ),
-                                              Tightening( f, 2, Tightening::LB ),
-                                              Tightening( f, 20, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, -7, Tightening::UB ),
+                                          Tightening( f, 2, Tightening::LB ),
+                                          Tightening( f, 20, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
 
@@ -1318,13 +1285,12 @@ public:
             abs.notifyLowerBound( b, -12 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -15, Tightening::LB ),
-                                              Tightening( b, -7, Tightening::UB ),
-                                              Tightening( f, 2, Tightening::LB ),
-                                              Tightening( f, 12, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, -7, Tightening::UB ),
+                                          Tightening( f, 2, Tightening::LB ),
+                                          Tightening( f, 12, Tightening::UB ),
+                                      } ) );
 
             entailedTightenings.clear();
 
@@ -1332,13 +1298,12 @@ public:
             abs.notifyUpperBound( b, -8 );
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -15, Tightening::LB ),
-                                              Tightening( b, -7, Tightening::UB ),
-                                              Tightening( f, 8, Tightening::LB ),
-                                              Tightening( f, 12, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, -7, Tightening::UB ),
+                                          Tightening( f, 8, Tightening::LB ),
+                                          Tightening( f, 12, Tightening::UB ),
+                                      } ) );
         }
     }
 
@@ -1349,7 +1314,7 @@ public:
             unsigned f = 4;
 
             AbsoluteValueConstraint abs( b, f );
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -20 );
@@ -1360,13 +1325,12 @@ public:
             // -20 < x_b < -2 ,25 < x_f < 30
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -30, Tightening::LB ),
-                                              Tightening( b, -25, Tightening::UB ),
-                                              Tightening( f, 2, Tightening::LB ),
-                                              Tightening( f, 20, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, -25, Tightening::UB ),
+                                          Tightening( f, 2, Tightening::LB ),
+                                          Tightening( f, 20, Tightening::UB ),
+                                      } ) );
         }
 
         {   // With Bound Manager
@@ -1379,7 +1343,7 @@ public:
             boundManager.initialize( 5 );
             abs.registerBoundManager( &boundManager );
 
-            List <Tightening> entailedTightenings;
+            List<Tightening> entailedTightenings;
             List<Tightening>::iterator it;
 
             abs.notifyLowerBound( b, -20 );
@@ -1390,13 +1354,12 @@ public:
             // -20 < x_b < -2 ,25 < x_f < 30
             abs.getEntailedTightenings( entailedTightenings );
             assert_tightenings_match( entailedTightenings,
-                                      List<Tightening>
-                                      ({
+                                      List<Tightening>( {
                                           Tightening( b, -30, Tightening::LB ),
-                                              Tightening( b, -25, Tightening::UB ),
-                                              Tightening( f, 2, Tightening::LB ),
-                                              Tightening( f, 20, Tightening::UB ),
-                                              }) );
+                                          Tightening( b, -25, Tightening::UB ),
+                                          Tightening( f, 2, Tightening::LB ),
+                                          Tightening( f, 20, Tightening::UB ),
+                                      } ) );
         }
     }
 
@@ -1660,7 +1623,7 @@ public:
         List<Tightening>::iterator it;
         it = entailedTightenings.begin();
 
-        TS_ASSERT_EQUALS( entailedTightenings.size(),4U );
+        TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
         TS_ASSERT_EQUALS( it->_variable, f );
         TS_ASSERT_EQUALS( it->_value, fLower );
         TS_ASSERT_EQUALS( it->_type, Tightening::LB );
@@ -1674,7 +1637,7 @@ public:
         TS_ASSERT_EQUALS( it->_type, Tightening::UB );
         it++;
         TS_ASSERT_EQUALS( it->_variable, b );
-        TS_ASSERT_EQUALS( it->_value, bUpper);
+        TS_ASSERT_EQUALS( it->_value, bUpper );
         TS_ASSERT_EQUALS( it->_type, Tightening::UB );
     }
 
@@ -1737,22 +1700,21 @@ public:
             List<Tightening> tightenings;
             TS_ASSERT_THROWS_NOTHING( abs.getEntailedTightenings( tightenings ) );
 
-            List<Tightening> expectedTightenings =
-                {
-                 // B var, from f bounds
-                 Tightening( b, -7, Tightening::LB ),
-                 Tightening( b, 7, Tightening::UB ),
+            List<Tightening> expectedTightenings = {
+                // B var, from f bounds
+                Tightening( b, -7, Tightening::LB ),
+                Tightening( b, 7, Tightening::UB ),
 
-                 // F var, from b bounds
-                 Tightening( f, 7, Tightening::UB ),
+                // F var, from b bounds
+                Tightening( f, 7, Tightening::UB ),
 
-                 // Aux vars
-                 Tightening( posAux, 0, Tightening::LB ),
-                 Tightening( negAux, 0, Tightening::LB ),
+                // Aux vars
+                Tightening( posAux, 0, Tightening::LB ),
+                Tightening( negAux, 0, Tightening::LB ),
 
-                 Tightening( posAux, 12, Tightening::UB ),
-                 Tightening( negAux, 14, Tightening::UB ),
-                };
+                Tightening( posAux, 12, Tightening::UB ),
+                Tightening( negAux, 14, Tightening::UB ),
+            };
 
             TS_ASSERT_EQUALS( expectedTightenings.size(), tightenings.size() );
 
@@ -1812,22 +1774,21 @@ public:
             List<Tightening> tightenings;
             TS_ASSERT_THROWS_NOTHING( abs.getEntailedTightenings( tightenings ) );
 
-            List<Tightening> expectedTightenings =
-                {
-                 // B var, from f bounds
-                 Tightening( b, -7, Tightening::LB ),
-                 Tightening( b, 7, Tightening::UB ),
+            List<Tightening> expectedTightenings = {
+                // B var, from f bounds
+                Tightening( b, -7, Tightening::LB ),
+                Tightening( b, 7, Tightening::UB ),
 
-                 // F var, from b bounds
-                 Tightening( f, 7, Tightening::UB ),
+                // F var, from b bounds
+                Tightening( f, 7, Tightening::UB ),
 
-                 // Aux vars
-                 Tightening( posAux, 0, Tightening::LB ),
-                 Tightening( negAux, 0, Tightening::LB ),
+                // Aux vars
+                Tightening( posAux, 0, Tightening::LB ),
+                Tightening( negAux, 0, Tightening::LB ),
 
-                 Tightening( posAux, 12, Tightening::UB ),
-                 Tightening( negAux, 14, Tightening::UB ),
-                };
+                Tightening( posAux, 12, Tightening::UB ),
+                Tightening( negAux, 14, Tightening::UB ),
+            };
 
             TS_ASSERT_EQUALS( expectedTightenings.size(), tightenings.size() );
 
@@ -1899,8 +1860,8 @@ public:
 
         List<PiecewiseLinearCaseSplit> splits = abs.getCaseSplits();
         TS_ASSERT_EQUALS( splits.size(), 2u );
-        TS_ASSERT_EQUALS( splits.front(), abs.getCaseSplit( ABS_PHASE_NEGATIVE ) ) ;
-        TS_ASSERT_EQUALS( splits.back(), abs.getCaseSplit( ABS_PHASE_POSITIVE ) ) ;
+        TS_ASSERT_EQUALS( splits.front(), abs.getCaseSplit( ABS_PHASE_NEGATIVE ) );
+        TS_ASSERT_EQUALS( splits.back(), abs.getCaseSplit( ABS_PHASE_POSITIVE ) );
     }
 
     /*

--- a/src/engine/tests/Test_AbsoluteValueConstraint.h
+++ b/src/engine/tests/Test_AbsoluteValueConstraint.h
@@ -296,487 +296,1108 @@ public:
 
     void test_abs_entailed_tightenings_positive_phase_1()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs( b, f );
-        List<Tightening> entailedTightenings;
+            AbsoluteValueConstraint abs( b, f );
+            List<Tightening> entailedTightenings;
 
-        abs.notifyLowerBound( b, 1 );
-        abs.notifyLowerBound( f, 2 );
-        abs.notifyUpperBound( b, 7 );
-        abs.notifyUpperBound( f, 7 );
+            abs.notifyLowerBound( b, 1 );
+            abs.notifyLowerBound( f, 2 );
+            abs.notifyUpperBound( b, 7 );
+            abs.notifyUpperBound( f, 7 );
 
-        // 1 < x_b < 7 , 2 < x_f < 7 -> 2 < x_b
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 1, 2, 7, 7, entailedTightenings );
+            // 1 < x_b < 7 , 2 < x_f < 7 -> 2 < x_b
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 1, 2, 7, 7, entailedTightenings );
 
-        abs.notifyLowerBound( b, 3 );
-        // 3 < x_b < 7 , 2 < x_f < 7
-        entailedTightenings.clear();
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 3, 2, 7, 7, entailedTightenings );
+            abs.notifyLowerBound( b, 3 );
+            // 3 < x_b < 7 , 2 < x_f < 7
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 3, 2, 7, 7, entailedTightenings );
 
-        abs.notifyLowerBound( f, 3 );
-        abs.notifyUpperBound( b, 6 );
-        // 3 < x_b < 6 , 3 < x_f < 7
-        entailedTightenings.clear();
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 3, 3, 6, 7, entailedTightenings );
+            abs.notifyLowerBound( f, 3 );
+            abs.notifyUpperBound( b, 6 );
+            // 3 < x_b < 6 , 3 < x_f < 7
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 3, 3, 6, 7, entailedTightenings );
 
-        abs.notifyUpperBound( f, 6 );
-        abs.notifyUpperBound( b, 7 );
-        // 3 < x_b < 6 , 3 < x_f < 6
-        //  --> x_b < 6
-        entailedTightenings.clear();
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 3, 3, 6, 6, entailedTightenings );
+            abs.notifyUpperBound( f, 6 );
+            abs.notifyUpperBound( b, 7 );
+            // 3 < x_b < 6 , 3 < x_f < 6
+            //  --> x_b < 6
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 3, 3, 6, 6, entailedTightenings );
 
-        abs.notifyLowerBound( f, -3 );
-        // 3 < x_b < 6 , 3 < x_f < 6
-        // --> 3 < x_f
-        entailedTightenings.clear();
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 3, 3, 6, 6, entailedTightenings );
+            abs.notifyLowerBound( f, -3 );
+            // 3 < x_b < 6 , 3 < x_f < 6
+            // --> 3 < x_f
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 3, 3, 6, 6, entailedTightenings );
 
-        abs.notifyLowerBound( b, 5 );
-        abs.notifyUpperBound( f, 5 );
-        // 5 < x_b < 6 , 3 < x_f < 5
-        entailedTightenings.clear();
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 5, 3, 6, 5, entailedTightenings );
+            abs.notifyLowerBound( b, 5 );
+            abs.notifyUpperBound( f, 5 );
+            // 5 < x_b < 6 , 3 < x_f < 5
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 5, 3, 6, 5, entailedTightenings );
+        }
+
+        {   // With BoundManager
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+            abs.registerBoundManager( &boundManager );
+
+            List<Tightening> entailedTightenings;
+
+            abs.notifyLowerBound( b, 1 );
+            abs.notifyLowerBound( f, 2 );
+            abs.notifyUpperBound( b, 7 );
+            abs.notifyUpperBound( f, 7 );
+
+            // 1 < x_b < 7 , 2 < x_f < 7 -> 2 < x_b
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 1, 2, 7, 7, entailedTightenings );
+
+            abs.notifyLowerBound( b, 3 );
+            // 3 < x_b < 7 , 2 < x_f < 7
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 3, 2, 7, 7, entailedTightenings );
+
+            abs.notifyLowerBound( f, 3 );
+            abs.notifyUpperBound( b, 6 );
+            // 3 < x_b < 6 , 3 < x_f < 7
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 3, 3, 6, 7, entailedTightenings );
+
+            abs.notifyUpperBound( f, 6 );
+            abs.notifyUpperBound( b, 7 );
+            // 3 < x_b < 6 , 3 < x_f < 6
+            //  --> x_b < 6
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 3, 3, 6, 6, entailedTightenings );
+
+            abs.notifyLowerBound( f, -3 );
+            // 3 < x_b < 6 , 3 < x_f < 6
+            // --> 3 < x_f
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 3, 3, 6, 6, entailedTightenings );
+
+            abs.notifyLowerBound( b, 5 );
+            abs.notifyUpperBound( f, 5 );
+            // 5 < x_b < 6 , 3 < x_f < 5
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 5, 3, 6, 5, entailedTightenings );
+        }
     }
 
     void test_abs_entailed_tightenings_positive_phase_2()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs( b, f );
-        List<Tightening> entailedTightenings;
+            AbsoluteValueConstraint abs( b, f );
+            List<Tightening> entailedTightenings;
 
-        // 8 < b < 18, 48 < f < 64
-        abs.notifyUpperBound( b, 18 );
-        abs.notifyUpperBound( f, 64 );
-        abs.notifyLowerBound( b, 8 );
-        abs.notifyLowerBound( f, 48 );
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 8, 48, 18, 64, entailedTightenings );
+            // 8 < b < 18, 48 < f < 64
+            abs.notifyUpperBound( b, 18 );
+            abs.notifyUpperBound( f, 64 );
+            abs.notifyLowerBound( b, 8 );
+            abs.notifyLowerBound( f, 48 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 8, 48, 18, 64, entailedTightenings );
+        }
+
+        {   //With BoundManage
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+
+            abs.registerBoundManager( &boundManager );
+
+            List<Tightening> entailedTightenings;
+
+            // 8 < b < 18, 48 < f < 64
+            abs.notifyUpperBound( b, 18 );
+            abs.notifyUpperBound( f, 64 );
+            abs.notifyLowerBound( b, 8 );
+            abs.notifyLowerBound( f, 48 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 8, 48, 18, 64, entailedTightenings );
+        }
     }
 
     void test_abs_entailed_tightenings_positive_phase_3()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs( b, f );
-        List<Tightening> entailedTightenings;
+            AbsoluteValueConstraint abs( b, f );
+            List<Tightening> entailedTightenings;
 
-        // 3 < b < 4, 1 < f < 2
-        abs.notifyUpperBound( b, 4 );
-        abs.notifyUpperBound( f, 2 );
-        abs.notifyLowerBound( b, 3 );
-        abs.notifyLowerBound( f, 1 );
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 3, 1, 4, 2, entailedTightenings );
+            // 3 < b < 4, 1 < f < 2
+            abs.notifyUpperBound( b, 4 );
+            abs.notifyUpperBound( f, 2 );
+            abs.notifyLowerBound( b, 3 );
+            abs.notifyLowerBound( f, 1 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 3, 1, 4, 2, entailedTightenings );
+        }
+
+        {   // With Bound Manager
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+
+            abs.registerBoundManager( &boundManager );
+
+            List<Tightening> entailedTightenings;
+
+            // 3 < b < 4, 1 < f < 2
+            abs.notifyUpperBound( b, 4 );
+            abs.notifyUpperBound( f, 2 );
+            abs.notifyLowerBound( b, 3 );
+            abs.notifyLowerBound( f, 1 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 3, 1, 4, 2, entailedTightenings );
+        }
     }
 
     void test_abs_entailed_tightenings_positive_phase_4()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs( b, f );
-        List <Tightening> entailedTightenings;
-        List<Tightening>::iterator it;
+            AbsoluteValueConstraint abs( b, f );
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
 
-        abs.notifyUpperBound( b, 7 );
-        abs.notifyUpperBound( f, 6 );
-        abs.notifyLowerBound( b, 0 );
-        abs.notifyLowerBound( f, 0 );
+            abs.notifyUpperBound( b, 7 );
+            abs.notifyUpperBound( f, 6 );
+            abs.notifyLowerBound( b, 0 );
+            abs.notifyLowerBound( f, 0 );
 
-        // 0 < x_b < 7 ,0 < x_f < 6
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 0, 0, 7, 6, entailedTightenings );
+            // 0 < x_b < 7 ,0 < x_f < 6
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 0, 0, 7, 6, entailedTightenings );
 
-        abs.notifyUpperBound( b, 5 );
-        // 0 < x_b < 5 ,0 < x_f < 6
-        entailedTightenings.clear();
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 0, 0, 5, 6, entailedTightenings );
+            abs.notifyUpperBound( b, 5 );
+            // 0 < x_b < 5 ,0 < x_f < 6
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 0, 0, 5, 6, entailedTightenings );
 
-        abs.notifyLowerBound( b, 1 );
-        // 1 < x_b < 5 ,0 < x_f < 6
-        entailedTightenings.clear();
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 1, 0, 5, 6, entailedTightenings );
+            abs.notifyLowerBound( b, 1 );
+            // 1 < x_b < 5 ,0 < x_f < 6
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 1, 0, 5, 6, entailedTightenings );
 
-        abs.notifyUpperBound( f, 4 );
-        // 1 < x_b < 5 ,0 < x_f < 4
-        entailedTightenings.clear();
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 1, 0, 5, 4, entailedTightenings );
+            abs.notifyUpperBound( f, 4 );
+            // 1 < x_b < 5 ,0 < x_f < 4
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 1, 0, 5, 4, entailedTightenings );
 
-        // Non overlap
-        abs.notifyUpperBound( f, 2 );
-        abs.notifyLowerBound( b, 3 );
+            // Non overlap
+            abs.notifyUpperBound( f, 2 );
+            abs.notifyLowerBound( b, 3 );
 
-        // 3 < x_b < 5 ,0 < x_f < 2
-        entailedTightenings.clear();
-        abs.getEntailedTightenings( entailedTightenings );
-        TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
-        assert_lower_upper_bound( f, b, 3, 0, 5, 2, entailedTightenings );
+            // 3 < x_b < 5 ,0 < x_f < 2
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
+            assert_lower_upper_bound( f, b, 3, 0, 5, 2, entailedTightenings );
+        }
+
+        {   // With Bound Manager
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+            abs.registerBoundManager( &boundManager );
+
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
+
+            abs.notifyUpperBound( b, 7 );
+            abs.notifyUpperBound( f, 6 );
+            abs.notifyLowerBound( b, 0 );
+            abs.notifyLowerBound( f, 0 );
+
+            // 0 < x_b < 7 ,0 < x_f < 6
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 0, 0, 7, 6, entailedTightenings );
+
+            abs.notifyUpperBound( b, 5 );
+            // 0 < x_b < 5 ,0 < x_f < 6
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 0, 0, 5, 6, entailedTightenings );
+
+            abs.notifyLowerBound( b, 1 );
+            // 1 < x_b < 5 ,0 < x_f < 6
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 1, 0, 5, 6, entailedTightenings );
+
+            abs.notifyUpperBound( f, 4 );
+            // 1 < x_b < 5 ,0 < x_f < 4
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 1, 0, 5, 4, entailedTightenings );
+
+            // Non overlap
+            abs.notifyUpperBound( f, 2 );
+            abs.notifyLowerBound( b, 3 );
+
+            // 3 < x_b < 5 ,0 < x_f < 2
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
+            assert_lower_upper_bound( f, b, 3, 0, 5, 2, entailedTightenings );
+        }
     }
 
     void test_abs_entailed_tightenings_positive_phase_5()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs( b, f );
-        List <Tightening> entailedTightenings;
+            AbsoluteValueConstraint abs( b, f );
+            List <Tightening> entailedTightenings;
 
-        abs.notifyUpperBound( b, 6 );
-        abs.notifyUpperBound( f, 5 );
-        abs.notifyLowerBound( b, 4 );
-        abs.notifyLowerBound( f, 3 );
+            abs.notifyUpperBound( b, 6 );
+            abs.notifyUpperBound( f, 5 );
+            abs.notifyLowerBound( b, 4 );
+            abs.notifyLowerBound( f, 3 );
 
-        // 4 < x_b < 6 ,3 < x_f < 5
-        entailedTightenings.clear();
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_lower_upper_bound( f, b, 4, 3, 6, 5, entailedTightenings );
+            // 4 < x_b < 6 ,3 < x_f < 5
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 4, 3, 6, 5, entailedTightenings );
+        }
+
+        {   // With Bound Manager
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+            abs.registerBoundManager( &boundManager );
+
+            List <Tightening> entailedTightenings;
+
+            abs.notifyUpperBound( b, 6 );
+            abs.notifyUpperBound( f, 5 );
+            abs.notifyLowerBound( b, 4 );
+            abs.notifyLowerBound( f, 3 );
+
+            // 4 < x_b < 6 ,3 < x_f < 5
+            entailedTightenings.clear();
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_lower_upper_bound( f, b, 4, 3, 6, 5, entailedTightenings );
+        }
     }
 
     void test_abs_entailed_tightenings_positive_phase_6()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs( b, f );
-        List<Tightening> entailedTightenings;
-        List<Tightening>::iterator it;
+            AbsoluteValueConstraint abs( b, f );
+            List<Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
 
-        abs.notifyLowerBound( b, 5 );
-        abs.notifyUpperBound( b, 10 );
-        abs.notifyLowerBound( f, -1 );
-        abs.notifyUpperBound( f, 10 );
+            abs.notifyLowerBound( b, 5 );
+            abs.notifyUpperBound( b, 10 );
+            abs.notifyLowerBound( f, -1 );
+            abs.notifyUpperBound( f, 10 );
 
-        TS_ASSERT( abs.phaseFixed() );
-        abs.getEntailedTightenings( entailedTightenings );
+            TS_ASSERT( abs.phaseFixed() );
+            abs.getEntailedTightenings( entailedTightenings );
 
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( f, 0, Tightening::LB ),
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( f, 0, Tightening::LB ),
 
-                                      Tightening( b, 0, Tightening::LB ),
-                                      Tightening( b, 10, Tightening::UB ),
-                                      Tightening( f, 5, Tightening::LB ),
-                                      Tightening( f, 10, Tightening::UB ),
-                                  }) );
+                                              Tightening( b, 0, Tightening::LB ),
+                                              Tightening( b, 10, Tightening::UB ),
+                                              Tightening( f, 5, Tightening::LB ),
+                                              Tightening( f, 10, Tightening::UB ),
+                                              }) );
+        }
+
+        {   // With Bound Manager
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+            abs.registerBoundManager( &boundManager );
+
+            List<Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
+
+            abs.notifyLowerBound( b, 5 );
+            abs.notifyUpperBound( b, 10 );
+            abs.notifyLowerBound( f, -1 );
+            abs.notifyUpperBound( f, 10 );
+
+            TS_ASSERT( abs.phaseFixed() );
+            abs.getEntailedTightenings( entailedTightenings );
+
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( f, 0, Tightening::LB ),
+
+                                              Tightening( b, 0, Tightening::LB ),
+                                              Tightening( b, 10, Tightening::UB ),
+                                              Tightening( f, 5, Tightening::LB ),
+                                              Tightening( f, 10, Tightening::UB ),
+                                              }) );
+        }
     }
 
     void test_abs_entailed_tightenings_phase_not_fixed_f_strictly_positive()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs( b, f );
-        List <Tightening> entailedTightenings;
-        List<Tightening>::iterator it;
+            AbsoluteValueConstraint abs( b, f );
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
 
-        abs.notifyLowerBound( b, -6 );
-        abs.notifyUpperBound( b, 3 );
-        abs.notifyLowerBound( f, 2 );
-        abs.notifyUpperBound( f, 4 );
+            abs.notifyLowerBound( b, -6 );
+            abs.notifyUpperBound( b, 3 );
+            abs.notifyLowerBound( f, 2 );
+            abs.notifyUpperBound( f, 4 );
 
-        // -6 < x_b < 3 ,2 < x_f < 4
-        abs.getEntailedTightenings( entailedTightenings );
+            // -6 < x_b < 3 ,2 < x_f < 4
+            abs.getEntailedTightenings( entailedTightenings );
 
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -4, Tightening::LB ),
-                                      Tightening( b, 4, Tightening::UB ),
-                                      Tightening( f, 6, Tightening::UB ),
-                                  }) );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -4, Tightening::LB ),
+                                              Tightening( b, 4, Tightening::UB ),
+                                              Tightening( f, 6, Tightening::UB ),
+                                              }) );
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        // -6 < x_b < 2 ,2 < x_f < 4
-        abs.notifyUpperBound( b, 2 );
-        abs.getEntailedTightenings( entailedTightenings );
+            // -6 < x_b < 2 ,2 < x_f < 4
+            abs.notifyUpperBound( b, 2 );
+            abs.getEntailedTightenings( entailedTightenings );
 
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -4, Tightening::LB ),
-                                      Tightening( b, 4, Tightening::UB ),
-                                      Tightening( f, 6, Tightening::UB ),
-                                  }) );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -4, Tightening::LB ),
+                                              Tightening( b, 4, Tightening::UB ),
+                                              Tightening( f, 6, Tightening::UB ),
+                                              }) );
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        // -6 < x_b < 1 ,2 < x_f < 4, now stuck in negative phase
-        abs.notifyUpperBound( b, 1 );
-        abs.getEntailedTightenings( entailedTightenings );
+            // -6 < x_b < 1 ,2 < x_f < 4, now stuck in negative phase
+            abs.notifyUpperBound( b, 1 );
+            abs.getEntailedTightenings( entailedTightenings );
 
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -4, Tightening::LB ),
-                                      Tightening( b, 4, Tightening::UB ),
-                                      Tightening( f, 6, Tightening::UB ),
-                                      Tightening( b, -2, Tightening::UB ),
-                                  }) );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -4, Tightening::LB ),
+                                              Tightening( b, 4, Tightening::UB ),
+                                              Tightening( f, 6, Tightening::UB ),
+                                              Tightening( b, -2, Tightening::UB ),
+                                              }) );
+        }
+
+        {   // With Bound Manager
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+            abs.registerBoundManager( &boundManager );
+
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
+
+            abs.notifyLowerBound( b, -6 );
+            abs.notifyUpperBound( b, 3 );
+            abs.notifyLowerBound( f, 2 );
+            abs.notifyUpperBound( f, 4 );
+
+            // -6 < x_b < 3 ,2 < x_f < 4
+            abs.getEntailedTightenings( entailedTightenings );
+
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -4, Tightening::LB ),
+                                              Tightening( b, 4, Tightening::UB ),
+                                              Tightening( f, 6, Tightening::UB ),
+                                              }) );
+
+            entailedTightenings.clear();
+
+            // -6 < x_b < 2 ,2 < x_f < 4
+            abs.notifyUpperBound( b, 2 );
+            abs.getEntailedTightenings( entailedTightenings );
+
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -4, Tightening::LB ),
+                                              Tightening( b, 4, Tightening::UB ),
+                                              Tightening( f, 6, Tightening::UB ),
+                                              }) );
+
+            entailedTightenings.clear();
+
+            // -6 < x_b < 1 ,2 < x_f < 4, now stuck in negative phase
+            abs.notifyUpperBound( b, 1 );
+            abs.getEntailedTightenings( entailedTightenings );
+
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -4, Tightening::LB ),
+                                              Tightening( b, 4, Tightening::UB ),
+                                              Tightening( f, 6, Tightening::UB ),
+                                              Tightening( b, -2, Tightening::UB ),
+                                              }) );
+        }
     }
 
     void test_abs_entailed_tightenings_phase_not_fixed_f_strictly_positive_2()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs( b, f );
-        List <Tightening> entailedTightenings;
-        List<Tightening>::iterator it;
+            AbsoluteValueConstraint abs( b, f );
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
 
-        abs.notifyLowerBound( b, -5 );
-        abs.notifyUpperBound( b, 10 );
-        abs.notifyLowerBound( f, 3 );
-        abs.notifyUpperBound( f, 7 );
+            abs.notifyLowerBound( b, -5 );
+            abs.notifyUpperBound( b, 10 );
+            abs.notifyLowerBound( f, 3 );
+            abs.notifyUpperBound( f, 7 );
 
-        // -5 < x_b < 10 ,3 < x_f < 7
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -7, Tightening::LB ),
-                                      Tightening( b, 7, Tightening::UB ),
-                                      Tightening( f, 10, Tightening::UB ),
-                                  }) );
+            // -5 < x_b < 10 ,3 < x_f < 7
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -7, Tightening::LB ),
+                                              Tightening( b, 7, Tightening::UB ),
+                                              Tightening( f, 10, Tightening::UB ),
+                                              }) );
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        // -5 < x_b < 10 ,6 < x_f < 7, positive phase
-        abs.notifyLowerBound( f, 6 );
+            // -5 < x_b < 10 ,6 < x_f < 7, positive phase
+            abs.notifyLowerBound( f, 6 );
 
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -7, Tightening::LB ),
-                                      Tightening( b, 7, Tightening::UB ),
-                                      Tightening( f, 10, Tightening::UB ),
-                                      Tightening( b, 6, Tightening::LB ),
-                                  }) );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -7, Tightening::LB ),
+                                              Tightening( b, 7, Tightening::UB ),
+                                              Tightening( f, 10, Tightening::UB ),
+                                              Tightening( b, 6, Tightening::LB ),
+                                              }) );
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        // -5 < x_b < 3 ,6 < x_f < 7
+            // -5 < x_b < 3 ,6 < x_f < 7
 
-        // Extreme case, disjoint ranges
+            // Extreme case, disjoint ranges
 
-        abs.notifyUpperBound( b, 3 );
+            abs.notifyUpperBound( b, 3 );
 
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -7, Tightening::LB ),
-                                      Tightening( b, 7, Tightening::UB ),
-                                      Tightening( f, 5, Tightening::UB ),
-                                      Tightening( b, 6, Tightening::LB ),
-                                      Tightening( b, -6, Tightening::UB ),
-                                  }) );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -7, Tightening::LB ),
+                                              Tightening( b, 7, Tightening::UB ),
+                                              Tightening( f, 5, Tightening::UB ),
+                                              Tightening( b, 6, Tightening::LB ),
+                                              Tightening( b, -6, Tightening::UB ),
+                                              }) );
+        }
+
+        {   // With Bound Manager
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+            abs.registerBoundManager( &boundManager );
+
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
+
+            abs.notifyLowerBound( b, -5 );
+            abs.notifyUpperBound( b, 10 );
+            abs.notifyLowerBound( f, 3 );
+            abs.notifyUpperBound( f, 7 );
+
+            // -5 < x_b < 10 ,3 < x_f < 7
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -7, Tightening::LB ),
+                                              Tightening( b, 7, Tightening::UB ),
+                                              Tightening( f, 10, Tightening::UB ),
+                                              }) );
+
+            entailedTightenings.clear();
+
+            // -5 < x_b < 10 ,6 < x_f < 7, positive phase
+            abs.notifyLowerBound( f, 6 );
+
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -7, Tightening::LB ),
+                                              Tightening( b, 7, Tightening::UB ),
+                                              Tightening( f, 10, Tightening::UB ),
+                                              Tightening( b, 6, Tightening::LB ),
+                                              }) );
+
+            entailedTightenings.clear();
+
+            // -5 < x_b < 3 ,6 < x_f < 7
+
+            // Extreme case, disjoint ranges
+
+            abs.notifyUpperBound( b, 3 );
+
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -7, Tightening::LB ),
+                                              Tightening( b, 7, Tightening::UB ),
+                                              Tightening( f, 5, Tightening::UB ),
+                                              Tightening( b, 6, Tightening::LB ),
+                                              Tightening( b, -6, Tightening::UB ),
+                                              }) );
+        }
     }
 
     void test_abs_entailed_tightenings_phase_not_fixed_f_strictly_positive_3()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs(b, f);
-        List <Tightening> entailedTightenings;
-        List<Tightening>::iterator it;
+            AbsoluteValueConstraint abs(b, f);
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
 
-        abs.notifyLowerBound( b, -1 );
-        abs.notifyUpperBound( b, 1 );
-        abs.notifyLowerBound( f, 2 );
-        abs.notifyUpperBound( f, 4 );
+            abs.notifyLowerBound( b, -1 );
+            abs.notifyUpperBound( b, 1 );
+            abs.notifyLowerBound( f, 2 );
+            abs.notifyUpperBound( f, 4 );
 
-        // -1 < x_b < 1 ,2 < x_f < 4
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -4, Tightening::LB ),
-                                      Tightening( b, 4, Tightening::UB ),
-                                      Tightening( f, 1, Tightening::UB ),
-                                      Tightening( b, 2, Tightening::LB ),
-                                      Tightening( b, -2, Tightening::UB ),
-                                  }) );
+            // -1 < x_b < 1 ,2 < x_f < 4
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -4, Tightening::LB ),
+                                              Tightening( b, 4, Tightening::UB ),
+                                              Tightening( f, 1, Tightening::UB ),
+                                              Tightening( b, 2, Tightening::LB ),
+                                              Tightening( b, -2, Tightening::UB ),
+                                              }) );
+        }
+
+        {   // With Bound Manager
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs(b, f);
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+            abs.registerBoundManager( &boundManager );
+
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
+
+            abs.notifyLowerBound( b, -1 );
+            abs.notifyUpperBound( b, 1 );
+            abs.notifyLowerBound( f, 2 );
+            abs.notifyUpperBound( f, 4 );
+
+            // -1 < x_b < 1 ,2 < x_f < 4
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -4, Tightening::LB ),
+                                              Tightening( b, 4, Tightening::UB ),
+                                              Tightening( f, 1, Tightening::UB ),
+                                              Tightening( b, 2, Tightening::LB ),
+                                              Tightening( b, -2, Tightening::UB ),
+                                              }) );
+        }
     }
 
     void test_abs_entailed_tightenings_phase_not_fixed_f_non_negative()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs( b, f );
-        List <Tightening> entailedTightenings;
-        List<Tightening>::iterator it;
+            AbsoluteValueConstraint abs( b, f );
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
 
-        abs.notifyLowerBound( b, -7 );
-        abs.notifyUpperBound( b, 7 );
-        abs.notifyLowerBound( f, 0 );
-        abs.notifyUpperBound( f, 6 );
+            abs.notifyLowerBound( b, -7 );
+            abs.notifyUpperBound( b, 7 );
+            abs.notifyLowerBound( f, 0 );
+            abs.notifyUpperBound( f, 6 );
 
-        // -7 < x_b < 7 ,0 < x_f < 6
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -6, Tightening::LB ),
-                                      Tightening( b, 6, Tightening::UB ),
-                                      Tightening( f, 7, Tightening::UB ),
-                                  }) );
-
-
-        entailedTightenings.clear();
-
-        // -7 < x_b < 5 ,0 < x_f < 6
-        abs.notifyUpperBound( b, 5 );
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -6, Tightening::LB ),
-                                      Tightening( b, 6, Tightening::UB ),
-                                      Tightening( f, 7, Tightening::UB ),
-                                  }) );
-
-        entailedTightenings.clear();
-        // 0 < x_b < 5 ,0 < x_f < 6
-        abs.notifyLowerBound( b, 0 );
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, 0, Tightening::LB ),
-                                      Tightening( b, 6, Tightening::UB ),
-                                      Tightening( f, 0, Tightening::LB ),
-                                      Tightening( f, 5, Tightening::UB ),
-                                  }) );
+            // -7 < x_b < 7 ,0 < x_f < 6
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -6, Tightening::LB ),
+                                              Tightening( b, 6, Tightening::UB ),
+                                              Tightening( f, 7, Tightening::UB ),
+                                              }) );
 
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        // 3 < x_b < 5 ,0 < x_f < 6
-        abs.notifyLowerBound( b, 3 );
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, 0, Tightening::LB ),
-                                      Tightening( b, 6, Tightening::UB ),
-                                      Tightening( f, 3, Tightening::LB ),
-                                      Tightening( f, 5, Tightening::UB ),
-                                  }) );
+            // -7 < x_b < 5 ,0 < x_f < 6
+            abs.notifyUpperBound( b, 5 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -6, Tightening::LB ),
+                                              Tightening( b, 6, Tightening::UB ),
+                                              Tightening( f, 7, Tightening::UB ),
+                                              }) );
+
+            entailedTightenings.clear();
+            // 0 < x_b < 5 ,0 < x_f < 6
+            abs.notifyLowerBound( b, 0 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, 0, Tightening::LB ),
+                                              Tightening( b, 6, Tightening::UB ),
+                                              Tightening( f, 0, Tightening::LB ),
+                                              Tightening( f, 5, Tightening::UB ),
+                                              }) );
+
+
+            entailedTightenings.clear();
+
+            // 3 < x_b < 5 ,0 < x_f < 6
+            abs.notifyLowerBound( b, 3 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, 0, Tightening::LB ),
+                                              Tightening( b, 6, Tightening::UB ),
+                                              Tightening( f, 3, Tightening::LB ),
+                                              Tightening( f, 5, Tightening::UB ),
+                                              }) );
+        }{
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs( b, f );
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
+
+            abs.notifyLowerBound( b, -7 );
+            abs.notifyUpperBound( b, 7 );
+            abs.notifyLowerBound( f, 0 );
+            abs.notifyUpperBound( f, 6 );
+
+            // -7 < x_b < 7 ,0 < x_f < 6
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -6, Tightening::LB ),
+                                              Tightening( b, 6, Tightening::UB ),
+                                              Tightening( f, 7, Tightening::UB ),
+                                              }) );
+
+
+            entailedTightenings.clear();
+
+            // -7 < x_b < 5 ,0 < x_f < 6
+            abs.notifyUpperBound( b, 5 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -6, Tightening::LB ),
+                                              Tightening( b, 6, Tightening::UB ),
+                                              Tightening( f, 7, Tightening::UB ),
+                                              }) );
+
+            entailedTightenings.clear();
+            // 0 < x_b < 5 ,0 < x_f < 6
+            abs.notifyLowerBound( b, 0 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, 0, Tightening::LB ),
+                                              Tightening( b, 6, Tightening::UB ),
+                                              Tightening( f, 0, Tightening::LB ),
+                                              Tightening( f, 5, Tightening::UB ),
+                                              }) );
+
+
+            entailedTightenings.clear();
+
+            // 3 < x_b < 5 ,0 < x_f < 6
+            abs.notifyLowerBound( b, 3 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, 0, Tightening::LB ),
+                                              Tightening( b, 6, Tightening::UB ),
+                                              Tightening( f, 3, Tightening::LB ),
+                                              Tightening( f, 5, Tightening::UB ),
+                                              }) );
+        }
+        {   // With Bound Manager
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+            abs.registerBoundManager( &boundManager );
+
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
+
+            abs.notifyLowerBound( b, -7 );
+            abs.notifyUpperBound( b, 7 );
+            abs.notifyLowerBound( f, 0 );
+            abs.notifyUpperBound( f, 6 );
+
+            // -7 < x_b < 7 ,0 < x_f < 6
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -6, Tightening::LB ),
+                                              Tightening( b, 6, Tightening::UB ),
+                                              Tightening( f, 7, Tightening::UB ),
+                                              }) );
+
+
+            entailedTightenings.clear();
+
+            // -7 < x_b < 5 ,0 < x_f < 6
+            abs.notifyUpperBound( b, 5 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -6, Tightening::LB ),
+                                              Tightening( b, 6, Tightening::UB ),
+                                              Tightening( f, 7, Tightening::UB ),
+                                              }) );
+
+            entailedTightenings.clear();
+            // 0 < x_b < 5 ,0 < x_f < 6
+            abs.notifyLowerBound( b, 0 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, 0, Tightening::LB ),
+                                              Tightening( b, 6, Tightening::UB ),
+                                              Tightening( f, 0, Tightening::LB ),
+                                              Tightening( f, 5, Tightening::UB ),
+                                              }) );
+
+
+            entailedTightenings.clear();
+
+            // 3 < x_b < 5 ,0 < x_f < 6
+            abs.notifyLowerBound( b, 3 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, 0, Tightening::LB ),
+                                              Tightening( b, 6, Tightening::UB ),
+                                              Tightening( f, 3, Tightening::LB ),
+                                              Tightening( f, 5, Tightening::UB ),
+                                              }) );
+        }
     }
 
     void test_abs_entailed_tightenings_negative_phase()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs( b, f );
-        List <Tightening> entailedTightenings;
-        List<Tightening>::iterator it;
+            AbsoluteValueConstraint abs( b, f );
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
 
-        abs.notifyLowerBound( b, -20 );
-        abs.notifyUpperBound( b, -2 );
-        abs.notifyLowerBound( f, 0 );
-        abs.notifyUpperBound( f, 15 );
+            abs.notifyLowerBound( b, -20 );
+            abs.notifyUpperBound( b, -2 );
+            abs.notifyLowerBound( f, 0 );
+            abs.notifyUpperBound( f, 15 );
 
-        // -20 < x_b < -2 ,0 < x_f < 15
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -15, Tightening::LB ),
-                                      Tightening( b, 0, Tightening::UB ),
-                                      Tightening( f, 2, Tightening::LB ),
-                                      Tightening( f, 20, Tightening::UB ),
-                                  }) );
+            // -20 < x_b < -2 ,0 < x_f < 15
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -15, Tightening::LB ),
+                                              Tightening( b, 0, Tightening::UB ),
+                                              Tightening( f, 2, Tightening::LB ),
+                                              Tightening( f, 20, Tightening::UB ),
+                                              }) );
 
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        // -20 < x_b < -2 ,7 < x_f < 15
-        abs.notifyLowerBound( f, 7 );
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -15, Tightening::LB ),
-                                      Tightening( b, -7, Tightening::UB ),
-                                      Tightening( f, 2, Tightening::LB ),
-                                      Tightening( f, 20, Tightening::UB ),
-                                  }) );
+            // -20 < x_b < -2 ,7 < x_f < 15
+            abs.notifyLowerBound( f, 7 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -15, Tightening::LB ),
+                                              Tightening( b, -7, Tightening::UB ),
+                                              Tightening( f, 2, Tightening::LB ),
+                                              Tightening( f, 20, Tightening::UB ),
+                                              }) );
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        // -12 < x_b < -2 ,7 < x_f < 15
-        abs.notifyLowerBound( b, -12 );
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -15, Tightening::LB ),
-                                      Tightening( b, -7, Tightening::UB ),
-                                      Tightening( f, 2, Tightening::LB ),
-                                      Tightening( f, 12, Tightening::UB ),
-                                  }) );
+            // -12 < x_b < -2 ,7 < x_f < 15
+            abs.notifyLowerBound( b, -12 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -15, Tightening::LB ),
+                                              Tightening( b, -7, Tightening::UB ),
+                                              Tightening( f, 2, Tightening::LB ),
+                                              Tightening( f, 12, Tightening::UB ),
+                                              }) );
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        // -12 < x_b < -8 ,7 < x_f < 15
-        abs.notifyUpperBound( b, -8 );
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -15, Tightening::LB ),
-                                      Tightening( b, -7, Tightening::UB ),
-                                      Tightening( f, 8, Tightening::LB ),
-                                      Tightening( f, 12, Tightening::UB ),
-                                  }) );
+            // -12 < x_b < -8 ,7 < x_f < 15
+            abs.notifyUpperBound( b, -8 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -15, Tightening::LB ),
+                                              Tightening( b, -7, Tightening::UB ),
+                                              Tightening( f, 8, Tightening::LB ),
+                                              Tightening( f, 12, Tightening::UB ),
+                                              }) );
+        }
+        {   // With Bound Manager
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+            abs.registerBoundManager( &boundManager );
+
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
+
+            abs.notifyLowerBound( b, -20 );
+            abs.notifyUpperBound( b, -2 );
+            abs.notifyLowerBound( f, 0 );
+            abs.notifyUpperBound( f, 15 );
+
+            // -20 < x_b < -2 ,0 < x_f < 15
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -15, Tightening::LB ),
+                                              Tightening( b, 0, Tightening::UB ),
+                                              Tightening( f, 2, Tightening::LB ),
+                                              Tightening( f, 20, Tightening::UB ),
+                                              }) );
+
+
+            entailedTightenings.clear();
+
+            // -20 < x_b < -2 ,7 < x_f < 15
+            abs.notifyLowerBound( f, 7 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -15, Tightening::LB ),
+                                              Tightening( b, -7, Tightening::UB ),
+                                              Tightening( f, 2, Tightening::LB ),
+                                              Tightening( f, 20, Tightening::UB ),
+                                              }) );
+
+            entailedTightenings.clear();
+
+            // -12 < x_b < -2 ,7 < x_f < 15
+            abs.notifyLowerBound( b, -12 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -15, Tightening::LB ),
+                                              Tightening( b, -7, Tightening::UB ),
+                                              Tightening( f, 2, Tightening::LB ),
+                                              Tightening( f, 12, Tightening::UB ),
+                                              }) );
+
+            entailedTightenings.clear();
+
+            // -12 < x_b < -8 ,7 < x_f < 15
+            abs.notifyUpperBound( b, -8 );
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -15, Tightening::LB ),
+                                              Tightening( b, -7, Tightening::UB ),
+                                              Tightening( f, 8, Tightening::LB ),
+                                              Tightening( f, 12, Tightening::UB ),
+                                              }) );
+        }
     }
 
     void test_abs_entailed_tightenings_negative_phase_2()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs( b, f );
-        List <Tightening> entailedTightenings;
-        List<Tightening>::iterator it;
+            AbsoluteValueConstraint abs( b, f );
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
 
-        abs.notifyLowerBound( b, -20 );
-        abs.notifyUpperBound( b, -2 );
-        abs.notifyLowerBound( f, 25 );
-        abs.notifyUpperBound( f, 30 );
+            abs.notifyLowerBound( b, -20 );
+            abs.notifyUpperBound( b, -2 );
+            abs.notifyLowerBound( f, 25 );
+            abs.notifyUpperBound( f, 30 );
 
-        // -20 < x_b < -2 ,25 < x_f < 30
-        abs.getEntailedTightenings( entailedTightenings );
-        assert_tightenings_match( entailedTightenings,
-                                  List<Tightening>
-                                  ({
-                                      Tightening( b, -30, Tightening::LB ),
-                                      Tightening( b, -25, Tightening::UB ),
-                                      Tightening( f, 2, Tightening::LB ),
-                                      Tightening( f, 20, Tightening::UB ),
-                                  }) );
+            // -20 < x_b < -2 ,25 < x_f < 30
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -30, Tightening::LB ),
+                                              Tightening( b, -25, Tightening::UB ),
+                                              Tightening( f, 2, Tightening::LB ),
+                                              Tightening( f, 20, Tightening::UB ),
+                                              }) );
+        }
+
+        {   // With Bound Manager
+            unsigned b = 1;
+            unsigned f = 4;
+
+            AbsoluteValueConstraint abs( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+            abs.registerBoundManager( &boundManager );
+
+            List <Tightening> entailedTightenings;
+            List<Tightening>::iterator it;
+
+            abs.notifyLowerBound( b, -20 );
+            abs.notifyUpperBound( b, -2 );
+            abs.notifyLowerBound( f, 25 );
+            abs.notifyUpperBound( f, 30 );
+
+            // -20 < x_b < -2 ,25 < x_f < 30
+            abs.getEntailedTightenings( entailedTightenings );
+            assert_tightenings_match( entailedTightenings,
+                                      List<Tightening>
+                                      ({
+                                          Tightening( b, -30, Tightening::LB ),
+                                              Tightening( b, -25, Tightening::UB ),
+                                              Tightening( f, 2, Tightening::LB ),
+                                              Tightening( f, 20, Tightening::UB ),
+                                              }) );
+        }
     }
 
     void test_abs_case_splits()
@@ -1086,74 +1707,151 @@ public:
 
     void test_abs_with_aux_vars()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        AbsoluteValueConstraint abs( b, f );
+            AbsoluteValueConstraint abs( b, f );
 
-        InputQuery ipq;
-        ipq.setNumberOfVariables( 10 );
-        unsigned posAux = 10;
-        unsigned negAux = 11;
+            InputQuery ipq;
+            ipq.setNumberOfVariables( 10 );
+            unsigned posAux = 10;
+            unsigned negAux = 11;
 
-        abs.notifyLowerBound( b, -5 );
-        abs.notifyUpperBound( b, 7 );
-        abs.notifyLowerBound( f, 0 );
-        abs.notifyUpperBound( f, 7 );
+            abs.notifyLowerBound( b, -5 );
+            abs.notifyUpperBound( b, 7 );
+            abs.notifyLowerBound( f, 0 );
+            abs.notifyUpperBound( f, 7 );
 
-        TS_ASSERT( !abs.participatingVariable( posAux ) );
-        TS_ASSERT( !abs.participatingVariable( negAux ) );
+            TS_ASSERT( !abs.participatingVariable( posAux ) );
+            TS_ASSERT( !abs.participatingVariable( negAux ) );
 
-        TS_ASSERT_THROWS_NOTHING( abs.addAuxiliaryEquations( ipq ) );
+            TS_ASSERT_THROWS_NOTHING( abs.addAuxiliaryEquations( ipq ) );
 
-        TS_ASSERT_EQUALS( abs.getParticipatingVariables(),
-                          List<unsigned>( { b, f, posAux, negAux } ) );
+            TS_ASSERT_EQUALS( abs.getParticipatingVariables(),
+                              List<unsigned>( { b, f, posAux, negAux } ) );
 
-        TS_ASSERT( abs.participatingVariable( posAux ) );
-        TS_ASSERT( abs.participatingVariable( negAux ) );
+            TS_ASSERT( abs.participatingVariable( posAux ) );
+            TS_ASSERT( abs.participatingVariable( negAux ) );
 
-        List<Tightening> tightenings;
-        TS_ASSERT_THROWS_NOTHING( abs.getEntailedTightenings( tightenings ) );
+            List<Tightening> tightenings;
+            TS_ASSERT_THROWS_NOTHING( abs.getEntailedTightenings( tightenings ) );
 
-        List<Tightening> expectedTightenings =
-            {
-                // B var, from f bounds
-                Tightening( b, -7, Tightening::LB ),
-                Tightening( b, 7, Tightening::UB ),
+            List<Tightening> expectedTightenings =
+                {
+                 // B var, from f bounds
+                 Tightening( b, -7, Tightening::LB ),
+                 Tightening( b, 7, Tightening::UB ),
 
-                // F var, from b bounds
-                Tightening( f, 7, Tightening::UB ),
+                 // F var, from b bounds
+                 Tightening( f, 7, Tightening::UB ),
 
-                // Aux vars
-                Tightening( posAux, 0, Tightening::LB ),
-                Tightening( negAux, 0, Tightening::LB ),
+                 // Aux vars
+                 Tightening( posAux, 0, Tightening::LB ),
+                 Tightening( negAux, 0, Tightening::LB ),
 
-                Tightening( posAux, 12, Tightening::UB ),
-                Tightening( negAux, 14, Tightening::UB ),
-            };
+                 Tightening( posAux, 12, Tightening::UB ),
+                 Tightening( negAux, 14, Tightening::UB ),
+                };
 
-        TS_ASSERT_EQUALS( expectedTightenings.size(), tightenings.size() );
+            TS_ASSERT_EQUALS( expectedTightenings.size(), tightenings.size() );
 
-        for ( const auto &it : tightenings )
-            TS_ASSERT( expectedTightenings.exists( it ) );
+            for ( const auto &it : tightenings )
+                TS_ASSERT( expectedTightenings.exists( it ) );
 
-        String serialized = abs.serializeToString();
+            String serialized = abs.serializeToString();
 
-        TS_TRACE( serialized.ascii() );
+            TS_TRACE( serialized.ascii() );
 
-        AbsoluteValueConstraint abs2( serialized );
+            AbsoluteValueConstraint abs2( serialized );
 
-        TS_ASSERT( !abs2.phaseFixed() );
-        abs2.notifyLowerBound( b, 2 );
-        TS_ASSERT( abs2.phaseFixed() );
+            TS_ASSERT( !abs2.phaseFixed() );
+            abs2.notifyLowerBound( b, 2 );
+            TS_ASSERT( abs2.phaseFixed() );
 
-        PiecewiseLinearCaseSplit validSplit = abs2.getValidCaseSplit();
-        TS_ASSERT( validSplit.getEquations().empty() );
-        TS_ASSERT_EQUALS( validSplit.getBoundTightenings().size(), 2U );
-        TS_ASSERT_EQUALS( *validSplit.getBoundTightenings().begin(),
-                          Tightening( b, 0, Tightening::LB ) );
-        TS_ASSERT_EQUALS( *validSplit.getBoundTightenings().rbegin(),
-                          Tightening( posAux, 0, Tightening::UB ) );
+            PiecewiseLinearCaseSplit validSplit = abs2.getValidCaseSplit();
+            TS_ASSERT( validSplit.getEquations().empty() );
+            TS_ASSERT_EQUALS( validSplit.getBoundTightenings().size(), 2U );
+            TS_ASSERT_EQUALS( *validSplit.getBoundTightenings().begin(),
+                              Tightening( b, 0, Tightening::LB ) );
+            TS_ASSERT_EQUALS( *validSplit.getBoundTightenings().rbegin(),
+                              Tightening( posAux, 0, Tightening::UB ) );
+        }
+
+        {   // With Bound Manager
+            unsigned b = 1;
+            unsigned f = 4;
+
+            InputQuery ipq;
+            ipq.setNumberOfVariables( 10 );
+            unsigned posAux = 10;
+            unsigned negAux = 11;
+
+            AbsoluteValueConstraint abs( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 12 );
+            abs.registerBoundManager( &boundManager );
+
+            abs.notifyLowerBound( b, -5 );
+            abs.notifyUpperBound( b, 7 );
+            abs.notifyLowerBound( f, 0 );
+            abs.notifyUpperBound( f, 7 );
+
+            TS_ASSERT( !abs.participatingVariable( posAux ) );
+            TS_ASSERT( !abs.participatingVariable( negAux ) );
+
+            TS_ASSERT_THROWS_NOTHING( abs.addAuxiliaryEquations( ipq ) );
+
+            TS_ASSERT_EQUALS( abs.getParticipatingVariables(),
+                              List<unsigned>( { b, f, posAux, negAux } ) );
+
+            TS_ASSERT( abs.participatingVariable( posAux ) );
+            TS_ASSERT( abs.participatingVariable( negAux ) );
+
+            List<Tightening> tightenings;
+            TS_ASSERT_THROWS_NOTHING( abs.getEntailedTightenings( tightenings ) );
+
+            List<Tightening> expectedTightenings =
+                {
+                 // B var, from f bounds
+                 Tightening( b, -7, Tightening::LB ),
+                 Tightening( b, 7, Tightening::UB ),
+
+                 // F var, from b bounds
+                 Tightening( f, 7, Tightening::UB ),
+
+                 // Aux vars
+                 Tightening( posAux, 0, Tightening::LB ),
+                 Tightening( negAux, 0, Tightening::LB ),
+
+                 Tightening( posAux, 12, Tightening::UB ),
+                 Tightening( negAux, 14, Tightening::UB ),
+                };
+
+            TS_ASSERT_EQUALS( expectedTightenings.size(), tightenings.size() );
+
+            for ( const auto &it : tightenings )
+                TS_ASSERT( expectedTightenings.exists( it ) );
+
+            String serialized = abs.serializeToString();
+
+            TS_TRACE( serialized.ascii() );
+
+            AbsoluteValueConstraint abs2( serialized );
+
+            TS_ASSERT( !abs2.phaseFixed() );
+            abs2.notifyLowerBound( b, 2 );
+            TS_ASSERT( abs2.phaseFixed() );
+
+            PiecewiseLinearCaseSplit validSplit = abs2.getValidCaseSplit();
+            TS_ASSERT( validSplit.getEquations().empty() );
+            TS_ASSERT_EQUALS( validSplit.getBoundTightenings().size(), 2U );
+            TS_ASSERT_EQUALS( *validSplit.getBoundTightenings().begin(),
+                              Tightening( b, 0, Tightening::LB ) );
+            TS_ASSERT_EQUALS( *validSplit.getBoundTightenings().rbegin(),
+                              Tightening( posAux, 0, Tightening::UB ) );
+        }
     }
 
     void test_initialization_of_CDOs()

--- a/src/engine/tests/Test_DisjunctionConstraint.h
+++ b/src/engine/tests/Test_DisjunctionConstraint.h
@@ -31,7 +31,7 @@ public:
 class TestDisjunctionConstraint : public DisjunctionConstraint
 {
 public:
-    TestDisjunctionConstraint( const List<PiecewiseLinearCaseSplit> elements  )
+    TestDisjunctionConstraint( const List<PiecewiseLinearCaseSplit> elements )
         : DisjunctionConstraint( elements )
     {}
 
@@ -499,8 +499,5 @@ public:
         dc.markInfeasible( dc.getPhaseStatus() );
         TS_ASSERT( !dc.isFeasible() );
         TS_ASSERT_EQUALS( dc.nextFeasibleCase(), CONSTRAINT_INFEASIBLE );
-
     }
-
 };
-

--- a/src/engine/tests/Test_MaxConstraint.h
+++ b/src/engine/tests/Test_MaxConstraint.h
@@ -3223,11 +3223,3 @@ public:
     }
 };
 
-
-//
-// Local Variables:
-// compile-command: "make -C ../../.. "
-// tags-file-name: "../../../TAGS"
-// c-basic-offset: 4
-// End:
-//

--- a/src/engine/tests/Test_MaxConstraint.h
+++ b/src/engine/tests/Test_MaxConstraint.h
@@ -1011,155 +1011,224 @@ public:
         TS_ASSERT( max2.serializeToString() == "max,1,1,2,e,0,0" );
         TS_ASSERT( max2.getParticipatingVariables().exists( 2 ) );
     }
+    void test_max_var_elims_with_bound_manager()
+    {
+        unsigned f = 1;
+        Set<unsigned> elements;
+
+        elements.insert( 2 );
+        elements.insert( 3 );
+
+        MaxConstraint max( f, elements );
+        Context context;
+        BoundManager boundManager( context );
+        boundManager.initialize( 11 );
+        max.registerBoundManager( &boundManager );
+
+        max.notifyUpperBound( 2, 8 );
+        max.notifyLowerBound( 2, 1 );
+        max.notifyUpperBound( 3, 6 );
+        max.notifyLowerBound( 3, 1 );
+
+        max.notifyUpperBound( 1, 10 );
+        max.notifyLowerBound( 1, 0 );
+        TS_ASSERT( max.getParticipatingVariables().exists( 2 ) );
+        TS_ASSERT( max.getParticipatingVariables().exists( 3 ) );
+
+        max.notifyLowerBound( 1, 6 );
+        TS_ASSERT( max.getParticipatingVariables().exists( 2 ) );
+        TS_ASSERT( max.getParticipatingVariables().exists( 3 ) );
+
+        max.notifyLowerBound( 2, 7 );
+        TS_ASSERT( max.getParticipatingVariables().exists( 2 ) );
+        TS_ASSERT( !max.getParticipatingVariables().exists( 3 ) );
+
+        //
+        // From here, the test is going to run tests for the case that f is included in elements.
+        //
+        Set<unsigned> elements2;
+
+        elements2.insert( 1 );
+        elements2.insert( 2 );
+        elements2.insert( 3 );
+
+        MaxConstraint max2( f, elements2 );
+        BoundManager boundManager2( context );
+        boundManager2.initialize( 11 );
+        max2.registerBoundManager( &boundManager2 );
+
+
+        max2.notifyUpperBound( 2, 8 );
+        max2.notifyLowerBound( 2, 1 );
+
+        max2.notifyUpperBound( 3, 6 );
+        max2.notifyLowerBound( 3, 1 );
+
+
+        max2.notifyUpperBound( 1, 6 );
+        max2.notifyLowerBound( 1, 0 );
+
+        TS_ASSERT( max2.getParticipatingVariables().exists( 1 ) );
+        TS_ASSERT( max2.getParticipatingVariables().exists( 2 ) );
+        TS_ASSERT( max2.getParticipatingVariables().exists( 3 ) );
+
+        max2.notifyLowerBound( 2, 7 );
+        TS_ASSERT( max2.getParticipatingVariables().exists( 1 ) );
+        TS_ASSERT( max2.getParticipatingVariables().exists( 2 ) );
+        TS_ASSERT( !max2.getParticipatingVariables().exists( 3 ) );
+
+        max2.notifyUpperBound( 1, 5 );
+
+        TS_ASSERT( max2.serializeToString() == "max,1,1,2,e,0,0" );
+        TS_ASSERT( max2.getParticipatingVariables().exists( 2 ) );
+    }
 
     void test_get_entailed_tightenings()
     {
-        {
-            unsigned f = 1;
-            Set<unsigned> elements;
+        unsigned f = 1;
+        Set<unsigned> elements;
 
-            elements.insert( 2 );
-            elements.insert( 3 );
+        elements.insert( 2 );
+        elements.insert( 3 );
 
-            MaxConstraint max( f, elements );
+        MaxConstraint max( f, elements );
 
-            max.notifyLowerBound( 2, 1 );
-            max.notifyUpperBound( 2, 8 );
-            // No lower bound for 3
-            max.notifyUpperBound( 3, 6 );
+        max.notifyLowerBound( 2, 1 );
+        max.notifyUpperBound( 2, 8 );
+        // No lower bound for 3
+        max.notifyUpperBound( 3, 6 );
 
-            List<Tightening> tightenings;
-            TS_ASSERT_THROWS_NOTHING( max.getEntailedTightenings( tightenings ) );
+        List<Tightening> tightenings;
+        TS_ASSERT_THROWS_NOTHING( max.getEntailedTightenings( tightenings ) );
 
-            // expect f to be in the range [1, 8]
-            TS_ASSERT_EQUALS( tightenings.size(), 2U );
-            auto it = tightenings.begin();
+        // expect f to be in the range [1, 8]
+        TS_ASSERT_EQUALS( tightenings.size(), 2U );
+        auto it = tightenings.begin();
 
-            TS_ASSERT_EQUALS( it->_variable, 1U );
-            TS_ASSERT_EQUALS( it->_value, 8 );
-            TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+        TS_ASSERT_EQUALS( it->_variable, 1U );
+        TS_ASSERT_EQUALS( it->_value, 8 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
 
-            ++it;
+        ++it;
 
-            TS_ASSERT_EQUALS( it->_variable, 1U );
-            TS_ASSERT_EQUALS( it->_value, 1 );
-            TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+        TS_ASSERT_EQUALS( it->_variable, 1U );
+        TS_ASSERT_EQUALS( it->_value, 1 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+
+        //
+        // From here, the test is going to run tests for the case that f is included in elements.
+        //
+        Set<unsigned> elements2;
+        elements2.insert( 1 );
+        elements2.insert( 2 );
+        elements2.insert( 3 );
+
+        MaxConstraint max2( f, elements2 );
+
+        // No lower bound for 1
+        max2.notifyUpperBound( 1, 7 );
+
+        max2.notifyLowerBound( 2, 1 );
+        max2.notifyUpperBound( 2, 8 );
+
+        // No lower bound for 3
+        max2.notifyUpperBound( 3, 6 );
+
+        List<Tightening> tightenings2;
+        TS_ASSERT_THROWS_NOTHING( max2.getEntailedTightenings( tightenings2 ) );
+
+        // expect f to be in the range [1, 7], x2 to be in the range [1, 7]
+        TS_ASSERT_EQUALS( tightenings2.size(), 2U );
+        it = tightenings2.begin();
+
+        TS_ASSERT_EQUALS( it->_variable, 2U );
+        TS_ASSERT_EQUALS( it->_value, 7 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+        ++it;
+
+        TS_ASSERT_EQUALS( it->_variable, 1U );
+        TS_ASSERT_EQUALS( it->_value, 1 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+    }
+
+    void test_get_entailed_tightenings_with_bound_manager()
+    {
+        unsigned f = 1;
+        Set<unsigned> elements;
+
+        elements.insert( 2 );
+        elements.insert( 3 );
+
+        MaxConstraint max( f, elements );
+        Context context;
+        BoundManager boundManager( context );
+        boundManager.initialize( 5 );
+        max.registerBoundManager( &boundManager );
+
+        TS_ASSERT_THROWS_NOTHING( max.notifyLowerBound( 2, 1 ) );
+        TS_ASSERT_EQUALS( boundManager.getLowerBound( 2 ),  1 );
+        TS_ASSERT_THROWS_NOTHING( max.notifyUpperBound( 2, 8 ) );
+        TS_ASSERT_EQUALS( boundManager.getUpperBound( 2 ),  8 );
+        // No lower bound for 3
+        TS_ASSERT_THROWS_NOTHING( max.notifyUpperBound( 3, 6 ) );
+
+        List<Tightening> tightenings;
+        TS_ASSERT_THROWS_NOTHING( max.getEntailedTightenings( tightenings ) );
+
+        // expect f to be in the range [1, 8]
+        TS_ASSERT_EQUALS( tightenings.size(), 2U );
+        auto it = tightenings.begin();
+
+        TS_ASSERT_EQUALS( it->_variable, 1U );
+        TS_ASSERT_EQUALS( it->_value, 8 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+        ++it;
+
+        TS_ASSERT_EQUALS( it->_variable, 1U );
+        TS_ASSERT_EQUALS( it->_value, 1 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
 
 
-            //
-            // From here, the test is going to run tests for the case that f is included in elements.
-            //
-            Set<unsigned> elements2;
-            elements2.insert( 1 );
-            elements2.insert( 2 );
-            elements2.insert( 3 );
+        //
+        // From here, the test is going to run tests for the case that f is included in elements.
+        //
+        Set<unsigned> elements2;
+        elements2.insert( 1 );
+        elements2.insert( 2 );
+        elements2.insert( 3 );
 
-            MaxConstraint max2( f, elements2 );
+        MaxConstraint max2( f, elements2 );
+        BoundManager boundManager2( context );
+        boundManager2.initialize( 5 );
+        max2.registerBoundManager( &boundManager2 );
 
-            // No lower bound for 1
-            max2.notifyUpperBound( 1, 7 );
+        // No lower bound for 1
+        max2.notifyUpperBound( 1, 7 );
 
-            max2.notifyLowerBound( 2, 1 );
-            max2.notifyUpperBound( 2, 8 );
+        max2.notifyLowerBound( 2, 1 );
+        max2.notifyUpperBound( 2, 8 );
 
-            // No lower bound for 3
-            max2.notifyUpperBound( 3, 6 );
+        // No lower bound for 3
+        max2.notifyUpperBound( 3, 6 );
 
-            List<Tightening> tightenings2;
-            TS_ASSERT_THROWS_NOTHING( max2.getEntailedTightenings( tightenings2 ) );
+        List<Tightening> tightenings2;
+        TS_ASSERT_THROWS_NOTHING( max2.getEntailedTightenings( tightenings2 ) );
 
-            // expect f to be in the range [1, 7], x2 to be in the range [1, 7]
-            TS_ASSERT_EQUALS( tightenings2.size(), 2U );
-            it = tightenings2.begin();
+        // expect f to be in the range [1, 7], x2 to be in the range [1, 7]
+        TS_ASSERT_EQUALS( tightenings2.size(), 2U );
+        it = tightenings2.begin();
 
-            TS_ASSERT_EQUALS( it->_variable, 2U );
-            TS_ASSERT_EQUALS( it->_value, 7 );
-            TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+        TS_ASSERT_EQUALS( it->_variable, 2U );
+        TS_ASSERT_EQUALS( it->_value, 7 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
 
-            ++it;
+        ++it;
 
-            TS_ASSERT_EQUALS( it->_variable, 1U );
-            TS_ASSERT_EQUALS( it->_value, 1 );
-            TS_ASSERT_EQUALS( it->_type, Tightening::LB );
-        }
-
-        { // With Bound Manager
-            unsigned f = 1;
-            Set<unsigned> elements;
-
-            elements.insert( 2 );
-            elements.insert( 3 );
-
-            MaxConstraint max( f, elements );
-            Context context;
-            BoundManager boundManager( context );
-            boundManager.initialize( 5 );
-            max.registerBoundManager( &boundManager );
-
-            TS_ASSERT_THROWS_NOTHING( max.notifyLowerBound( 2, 1 ) );
-            TS_ASSERT_EQUALS( boundManager.getLowerBound( 2 ),  1 );
-            TS_ASSERT_THROWS_NOTHING( max.notifyUpperBound( 2, 8 ) );
-            TS_ASSERT_EQUALS( boundManager.getUpperBound( 2 ),  8 );
-            // No lower bound for 3
-            TS_ASSERT_THROWS_NOTHING( max.notifyUpperBound( 3, 6 ) );
-
-            List<Tightening> tightenings;
-            TS_ASSERT_THROWS_NOTHING( max.getEntailedTightenings( tightenings ) );
-
-            // expect f to be in the range [1, 8]
-            TS_ASSERT_EQUALS( tightenings.size(), 2U );
-            auto it = tightenings.begin();
-
-            TS_ASSERT_EQUALS( it->_variable, 1U );
-            TS_ASSERT_EQUALS( it->_value, 8 );
-            TS_ASSERT_EQUALS( it->_type, Tightening::UB );
-
-            ++it;
-
-            TS_ASSERT_EQUALS( it->_variable, 1U );
-            TS_ASSERT_EQUALS( it->_value, 1 );
-            TS_ASSERT_EQUALS( it->_type, Tightening::LB );
-
-
-            //
-            // From here, the test is going to run tests for the case that f is included in elements.
-            //
-            Set<unsigned> elements2;
-            elements2.insert( 1 );
-            elements2.insert( 2 );
-            elements2.insert( 3 );
-
-            MaxConstraint max2( f, elements2 );
-            BoundManager boundManager2( context );
-            boundManager2.initialize( 5 );
-            max2.registerBoundManager( &boundManager2 );
-
-            // No lower bound for 1
-            max2.notifyUpperBound( 1, 7 );
-
-            max2.notifyLowerBound( 2, 1 );
-            max2.notifyUpperBound( 2, 8 );
-
-            // No lower bound for 3
-            max2.notifyUpperBound( 3, 6 );
-
-            List<Tightening> tightenings2;
-            TS_ASSERT_THROWS_NOTHING( max2.getEntailedTightenings( tightenings2 ) );
-
-            // expect f to be in the range [1, 7], x2 to be in the range [1, 7]
-            TS_ASSERT_EQUALS( tightenings2.size(), 2U );
-            it = tightenings2.begin();
-
-            TS_ASSERT_EQUALS( it->_variable, 2U );
-            TS_ASSERT_EQUALS( it->_value, 7 );
-            TS_ASSERT_EQUALS( it->_type, Tightening::UB );
-
-            ++it;
-
-            TS_ASSERT_EQUALS( it->_variable, 1U );
-            TS_ASSERT_EQUALS( it->_value, 1 );
-            TS_ASSERT_EQUALS( it->_type, Tightening::LB );
-        }
+        TS_ASSERT_EQUALS( it->_variable, 1U );
+        TS_ASSERT_EQUALS( it->_value, 1 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
     }
 
     void test_max_obsolete()
@@ -1192,6 +1261,50 @@ public:
 
         TS_ASSERT( max3.constraintObsolete() );
     }
+
+    void test_max_obsolete_with_bound_manager()
+    {
+        unsigned f = 1;
+        Set<unsigned> elements;
+
+        for ( unsigned i = 2; i < 10; ++i )
+            elements.insert( i );
+
+        MaxConstraint max( f, elements );
+        Context context;
+        BoundManager boundManager( context );
+        boundManager.initialize( 11 );
+        max.registerBoundManager( &boundManager );
+
+        TS_ASSERT( !max.constraintObsolete() );
+        for ( unsigned i = 2; i < 10; ++i )
+            max.eliminateVariable( i, 0 );
+        TS_ASSERT( max.constraintObsolete() );
+
+        MaxConstraint max2( f, elements );
+        BoundManager boundManager2( context );
+        boundManager2.initialize( 11 );
+        max2.registerBoundManager( &boundManager2 );
+
+
+        for(unsigned i = 3; i < 10; i++ )
+            max2.eliminateVariable( i, 0 );
+
+        TS_ASSERT( !max2.constraintObsolete() );
+        max2.eliminateVariable( 1, 0 );
+        TS_ASSERT( max2.constraintObsolete() );
+
+        elements.insert( 1 );
+        MaxConstraint max3( f, elements );
+        BoundManager boundManager3( context );
+        boundManager3.initialize( 11 );
+        max3.registerBoundManager( &boundManager3 );
+        for(unsigned i = 2; i < 10; i++ )
+            max3.eliminateVariable( i, 0 );
+
+        TS_ASSERT( max3.constraintObsolete() );
+    }
+
 
     void test_register_as_watcher()
     {
@@ -1333,6 +1446,62 @@ public:
             elements2.insert( i );
 
         MaxConstraint max2( f2, elements2 );
+
+        TS_ASSERT( !max2.wereVariablesEliminated() );
+        max2.eliminateVariable( 1, -11 );
+        TS_ASSERT( max2.wereVariablesEliminated() );
+        max2.eliminateVariable( 2, 12 );
+        max2.eliminateVariable( 3, 13 );
+        // 13 is the maximum value eliminated
+
+        max2.notifyLowerBound( 0,12.5 );
+        max2.notifyUpperBound( 0,13.5 );
+        TS_ASSERT( !max2.phaseFixed() )
+
+        max2.notifyLowerBound( 0,13 );
+        TS_ASSERT( max2.phaseFixed() )
+    }
+
+    void test_phase_fixed_with_variable_elimination_and_bound_manager()
+    {
+        // Check phase fixed after eliminating - and upper bound updated
+        unsigned f = 4;
+        Set<unsigned> elements;
+
+        for ( unsigned i = 0; i < 4; ++i )
+            elements.insert( i );
+
+        MaxConstraint max( f, elements );
+        Context context;
+        BoundManager boundManager( context );
+        boundManager.initialize( 11 );
+        max.registerBoundManager( &boundManager );
+
+        TS_ASSERT( !max.wereVariablesEliminated() );
+        max.eliminateVariable( 1, -11 );
+        TS_ASSERT( max.wereVariablesEliminated() );
+        max.eliminateVariable( 2, 12 );
+        max.eliminateVariable( 3, 13 );
+        // 13 is the maximum value eliminated
+
+        max.notifyLowerBound( 0,1 );
+        max.notifyUpperBound( 0,14 );
+        TS_ASSERT( !max.phaseFixed() )
+
+        max.notifyUpperBound( 0,13 );
+        TS_ASSERT( max.phaseFixed() )
+
+        // Check phase fixed after eliminating - and lower bound updated
+        unsigned f2 = 44;
+        Set<unsigned> elements2;
+
+        for ( unsigned i = 0; i < 4; ++i )
+            elements2.insert( i );
+
+        MaxConstraint max2( f2, elements2 );
+        BoundManager boundManager2( context );
+        boundManager2.initialize( 11 );
+        max2.registerBoundManager( &boundManager2 );
 
         TS_ASSERT( !max2.wereVariablesEliminated() );
         max2.eliminateVariable( 1, -11 );
@@ -1503,6 +1672,167 @@ public:
             ++cur;
         }
     }
+    void test_max_case_splits_with_variable_elimination_with_bound_manager()
+    {
+        unsigned f = 1;
+        Set<unsigned> elements;
+
+        for ( unsigned i = 2; i < 6; ++i )
+            elements.insert( i );
+
+        MaxConstraint max( f, elements );
+        Context context;
+        BoundManager boundManager( context );
+        boundManager.initialize( 11 );
+        max.registerBoundManager( &boundManager );
+
+        for ( unsigned i = 2; i < 6; ++i )
+            max.notifyVariableValue( i, i );
+
+        max.notifyVariableValue( f, 1 );
+        // f = max(x_2 ... x_5)
+        // f = 1
+
+        TS_ASSERT( !max.wereVariablesEliminated() );
+        // Eliminate single variable x_5 = 5
+        unsigned eliminatedVariableValue = 5;
+        max.eliminateVariable( 5,eliminatedVariableValue );
+        TS_ASSERT( max.wereVariablesEliminated() );
+
+        List<PiecewiseLinearCaseSplit> splits = max.getCaseSplits();
+
+        // There are 4 possible phases: f1=b2, f1=b3, f1=b4, f1=maxValueOfEliminated
+        TS_ASSERT_EQUALS( splits.size(), 4U );
+
+        // Check first two phases: f1=b2, f1=b3
+        auto split = splits.begin();
+        for ( unsigned i = 2; i < 5; ++i, ++split )
+        {
+            List<Tightening> bounds = split->getBoundTightenings();
+
+            // For each split, there is a single LB element >= maxValueEliminated
+            TS_ASSERT_EQUALS( bounds.size(), 1U );
+
+            auto it = bounds.begin();
+
+            TS_ASSERT_EQUALS( it->_variable, i );
+            TS_ASSERT_EQUALS( it->_value, eliminatedVariableValue );
+            TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+
+            auto equations = split->getEquations();
+
+            TS_ASSERT_EQUALS( equations.size(), 3U );
+
+            auto cur = equations.begin();
+
+            // Check equation f = b_i
+            TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+            TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+            TS_ASSERT_EQUALS( cur->_type, Equation::EQ );
+
+            auto addend = cur->_addends.begin();
+
+            TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+            TS_ASSERT_EQUALS( addend->_variable, i );
+
+            ++addend;
+
+            TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+            TS_ASSERT_EQUALS( addend->_variable, f );
+
+            ++cur;
+
+            for ( unsigned j = 2; j < 5;  ++j )
+            {
+                // Check that there is bi >= bj for each couple (i, j) of input elements
+                if ( i == j ) continue;
+
+                TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+                TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+                TS_ASSERT_EQUALS( cur->_type, Equation::GE );
+
+                auto addend = cur->_addends.begin();
+
+                TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+                TS_ASSERT_EQUALS( addend->_variable, j );
+
+                ++addend;
+
+                TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+                TS_ASSERT_EQUALS( addend->_variable, i );
+
+                ++cur;
+            }
+        }
+
+        //
+        // From here, the test is going to run tests for the case that f is included in elements.
+        //
+        elements.insert( f );
+        MaxConstraint max2( f, elements );
+        BoundManager boundManager2( context );
+        boundManager2.initialize( 11 );
+        max2.registerBoundManager( &boundManager2 );
+
+        for ( unsigned i = 1; i < 6; ++i )
+            max2.notifyVariableValue( i, i );
+
+        // f = max(x_1 ... x_5)
+        // f = 1
+        max2.notifyVariableValue( f, 1 );
+
+        TS_ASSERT( !max2.wereVariablesEliminated() );
+        // Eliminate single variable x_5 = 5
+        double eliminatedVariableValue2 = 5;
+        max2.eliminateVariable( 5,eliminatedVariableValue2 );
+        TS_ASSERT( max2.wereVariablesEliminated() );
+
+        splits = max2.getCaseSplits();
+
+        // There is one possible phase (because 7 is an element now)
+        TS_ASSERT_EQUALS( splits.size(), 1U );
+
+        split = splits.begin();
+
+        List<Tightening> bounds = split->getBoundTightenings();
+
+        // Check single bound f >= maxValueEliminated
+        TS_ASSERT_EQUALS( bounds.size(), 1U );
+
+        auto it = bounds.begin();
+
+        TS_ASSERT_EQUALS( it->_variable, f );
+        TS_ASSERT_EQUALS( it->_value, eliminatedVariableValue2 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+
+        auto equations = split->getEquations();
+
+        // f >= x2, f >= x3, f >= x4
+        TS_ASSERT_EQUALS( equations.size(), 3U );
+
+        // First phase is the one without max=_maxEliminated
+        auto cur = equations.begin();
+
+        for ( unsigned i = 2; i < 5;  ++i )
+        {
+            // Check that there is f >= bj for each input element j
+            TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+            TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+            TS_ASSERT_EQUALS( cur->_type, Equation::GE );
+
+            auto addend = cur->_addends.begin();
+
+            TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+            TS_ASSERT_EQUALS( addend->_variable, i );
+
+            ++addend;
+
+            TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+            TS_ASSERT_EQUALS( addend->_variable, f );
+
+            ++cur;
+        }
+    }
 
     void test_max_phase_fixed_with_variable_elimination()
     {
@@ -1517,6 +1847,185 @@ public:
             elements.insert( i );
 
         MaxConstraint max( f, elements );
+
+        // All input variables initially between 1 and 10
+        for ( unsigned i = 2; i < 6; i++ ) {
+            max.notifyUpperBound( i, 10 );
+            max.notifyLowerBound( i, 1 );
+        }
+
+        TS_ASSERT( !max.wereVariablesEliminated() );
+        // Eliminate single variable x_5 = 5.5
+        max.eliminateVariable( 5, 5.5 );
+        TS_ASSERT( max.wereVariablesEliminated() );
+
+        TS_ASSERT( !max.phaseFixed() );
+
+        // Set x_2 to be at least 6, and x_3 and x_4 to be at most 5
+        max.notifyLowerBound( 2, 6 );
+        for ( unsigned i = 3; i < 5; i++)
+            max.notifyUpperBound( i, 5 );
+
+        max.notifyVariableValue( 2, 7 );
+        // Now, phase should be fixed to x_2; all other variables should be removed
+        TS_ASSERT( max.phaseFixed() );
+        TS_ASSERT_EQUALS( max.getParticipatingVariables().size(), 2U );
+
+        // In the case f is no in the input elements, and variables were eliminated
+        PiecewiseLinearCaseSplit validSplit = max.getValidCaseSplit();
+
+        List<Tightening> bounds = validSplit.getBoundTightenings();
+
+        // Check single bound f >= maxValueEliminated
+        TS_ASSERT_EQUALS( bounds.size(), 1U );
+
+        auto it = bounds.begin();
+
+        TS_ASSERT_EQUALS( it->_variable, 2U );
+        TS_ASSERT_EQUALS( it->_value, 5.5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+
+        // The equation is: f=x_2
+        auto equations = validSplit.getEquations();
+
+        TS_ASSERT_EQUALS( equations.size(), 1U );
+
+        auto cur = equations.begin();
+        TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+        TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+        TS_ASSERT_EQUALS( cur->_type, Equation::EQ );
+
+        auto addend = cur->_addends.begin();
+
+        TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, 2U );
+
+        ++addend;
+
+        TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, f );
+
+        ++cur;
+
+        // Case 2
+        // Check the case in which the eliminated variable is the maximum
+
+        unsigned f2 = 1;
+        Set<unsigned> elements2;
+
+        for ( unsigned i = 2; i < 6; ++i )
+            elements2.insert( i );
+
+        MaxConstraint max2( f2, elements2 );
+
+        // All input variables initially between 1 and 10
+        for ( unsigned i = 2; i < 6; i++ ) {
+            max2.notifyUpperBound( i, 10 );
+            max2.notifyLowerBound( i, 1 );
+        }
+
+        TS_ASSERT( !max2.wereVariablesEliminated() );
+        // Eliminate single variable x_5 = 9.5
+        max2.eliminateVariable(5, 9.5 );
+        TS_ASSERT( max2.wereVariablesEliminated() );
+
+        TS_ASSERT( !max2.phaseFixed() );
+
+        // Set x_2 to be at least 6, and x_3 and x_4 to be at most 5
+        for ( unsigned i = 3; i < 5; i++ ) {
+            max2.notifyUpperBound( i, 5 );
+        }
+
+        max2.notifyLowerBound( 2, 6 );
+        // notifyUpperBound should eliminate x2 because UB_x2 <= _maxLowerBound = 9.5
+        max2.notifyUpperBound( 2, 8 );
+
+
+        // Now, phase should be fixed - there are no variables but there is an eliminatedValue
+        TS_ASSERT( max2.phaseFixed() );
+        // f is the single participating variable
+        TS_ASSERT_EQUALS( max2.getParticipatingVariables().size(), 1U );
+
+        // In the case f is not in the input elements, and variables were eliminated
+        PiecewiseLinearCaseSplit validSplit2 = max2.getValidCaseSplit();
+
+        bounds = validSplit2.getBoundTightenings();
+
+        // f = maxValueEliminated
+        // Check 2 bounds bound f >= maxValueEliminated, f <= maxValueEliminated
+        TS_ASSERT_EQUALS( bounds.size(), 2U );
+
+        it = bounds.begin();
+
+        TS_ASSERT_EQUALS( it->_variable, f2 );
+        TS_ASSERT_EQUALS( it->_value, 9.5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+
+        it++;
+
+        TS_ASSERT_EQUALS( it->_variable, f2 );
+        TS_ASSERT_EQUALS( it->_value, 9.5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+        // No additional equations
+        auto equations2 = validSplit2.getEquations();
+
+        TS_ASSERT_EQUALS( equations2.size(), 0U );
+
+        // Case 3
+        // Check the case in which the eliminated variable is the range of the single variable which is larger than the rest
+        // (but may or may not be larger than the eliminated value)
+
+        unsigned f3 = 1;
+        Set<unsigned> elements3;
+
+        for ( unsigned i = 2; i < 6; ++i )
+            elements3.insert( i );
+
+        MaxConstraint max3( f3, elements3 );
+
+        // All input variables initially between 1 and 10
+        for ( unsigned i = 2; i < 6; i++ ) {
+            max3.notifyUpperBound( i, 10 );
+            max3.notifyLowerBound( i, 1 );
+        }
+
+        TS_ASSERT( !max3.wereVariablesEliminated() );
+        // Eliminate single variable x_5 = 7.5
+        max3.eliminateVariable( 5, 7.5 );
+        TS_ASSERT( max3.wereVariablesEliminated() );
+
+        TS_ASSERT( !max3.phaseFixed() );
+
+        // Set x_2 to be at least 6, and x_3 and x_4 to be at most 5
+        for ( unsigned i = 3; i < 5; i++ ) {
+            max3.notifyUpperBound( i, 5 );
+        }
+
+        max3.notifyLowerBound( 2, 6 );
+        max3.notifyUpperBound( 2, 9 );
+
+        // Now, phase should not be fixed! because maxEliminated = 7.5 in range of X_2 = [6, 9]
+        TS_ASSERT( !max3.phaseFixed() );
+    }
+
+    void test_max_phase_fixed_with_variable_elimination_with_bound_manager()
+    {
+        // For all the following tests the f variable is not in the input (in the next test it is)
+
+        // Case 1
+        // Check the case in which an input variable is the max, and higher than the eliminated one
+        unsigned f = 1;
+        Set<unsigned> elements;
+
+        for ( unsigned i = 2; i < 6; ++i )
+            elements.insert( i );
+
+        MaxConstraint max( f, elements );
+        Context context;
+        BoundManager boundManager( context );
+        boundManager.initialize( 11 );
+        max.registerBoundManager( &boundManager );
 
         // All input variables initially between 1 and 10
         for ( unsigned i = 2; i < 6; i++ ) {
@@ -1990,6 +2499,324 @@ public:
         TS_ASSERT_EQUALS( addend->_variable, f3 );
     }
 
+    void test_max_phase_fixed_with_variable_elimination_2_with_bound_manager()
+    {
+        // For all the following tests the f variable is in the input (unlike the previous test)
+
+        // Case 1
+        // Check the case in which an input variable is the max, and higher than the eliminated one
+        unsigned f = 1;
+        Set<unsigned> elements;
+
+        for ( unsigned i = 1; i < 10; ++i )
+            elements.insert( i );
+
+        MaxConstraint max( f, elements );
+        Context context;
+        BoundManager boundManager( context );
+        boundManager.initialize( 11 );
+        max.registerBoundManager( &boundManager );
+
+        // All variables initially between 1 and 10
+        for ( unsigned i = 1; i < 10; i++ )
+        {
+            max.notifyUpperBound( i, 10 );
+            max.notifyLowerBound( i, 1 );
+        }
+
+        // Set x_2 and x_3 to be at least 6, others to be at most 5
+        max.notifyLowerBound( 2, 6 );
+        max.notifyLowerBound( 3, 6 );
+        for( unsigned i = 5; i < 10; i++ )
+            max.notifyUpperBound( i, 5 );
+        max.notifyUpperBound( f, 5 );
+
+        max.notifyVariableValue( f, 5);
+        // Now, phase should be fixed to x_2 and x_3; all other variables should be removed
+        TS_ASSERT( max.phaseFixed() );
+
+        TS_ASSERT( !max.wereVariablesEliminated() );
+        // Eliminate single variable x_4 = 5.5
+        max.eliminateVariable( 4, 5.5 );
+        TS_ASSERT( max.wereVariablesEliminated() );
+
+        TS_ASSERT_EQUALS( max.getParticipatingVariables().size(), 3U );
+
+        PiecewiseLinearCaseSplit validSplit = max.getValidCaseSplit();
+
+        List<Tightening> bounds = validSplit.getBoundTightenings();
+
+        // Check 3 bounds
+        TS_ASSERT_EQUALS( bounds.size(), 3U );
+
+        auto it = bounds.begin();
+
+        // x2 <= UB(f)=5
+        TS_ASSERT_EQUALS( it->_variable, 2U );
+        TS_ASSERT_EQUALS( it->_value, 5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+        it++;
+
+        // x3 <= UB(f)=5
+        TS_ASSERT_EQUALS( it->_variable, 3U );
+        TS_ASSERT_EQUALS( it->_value, 5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+        it++;
+
+        // f >= maxValueEliminated = 5.5
+        TS_ASSERT_EQUALS( it->_variable, f );
+        TS_ASSERT_EQUALS( it->_value, 5.5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+
+        auto equations = validSplit.getEquations();
+
+        TS_ASSERT_EQUALS( equations.size(), 2U );
+
+        auto cur = equations.begin();
+        // f >= x_2
+        TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+        TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+        TS_ASSERT_EQUALS( cur->_type, Equation::GE );
+
+        auto addend = cur->_addends.begin();
+
+        TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, 2U );
+
+        ++addend;
+
+        TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, f );
+
+        ++cur;
+        // f >= x_3
+        TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+        TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+        TS_ASSERT_EQUALS( cur->_type, Equation::GE );
+
+        addend = cur->_addends.begin();
+
+        TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, 3U );
+
+        ++addend;
+
+        TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, f );
+
+
+        // Case 2
+        // The eliminated variable is larger than f
+        unsigned f2 = 1;
+        Set<unsigned> elements2;
+
+        for ( unsigned i = 1; i < 10; ++i )
+            elements2.insert( i );
+
+        MaxConstraint max2( f2, elements2 );
+        BoundManager boundManager2( context );
+        boundManager2.initialize( 11 );
+        max2.registerBoundManager( &boundManager2 );
+
+        // All variables initially between 1 and 10
+        for ( unsigned i = 1; i < 10; i++ )
+        {
+            max2.notifyUpperBound( i, 10 );
+            max2.notifyLowerBound( i, 1 );
+        }
+
+        // Set x_2 and x_3 to be at least 6, others to be at most 5
+        max2.notifyUpperBound( 2, 8 );
+        max2.notifyLowerBound( 2, 6 );
+
+        max2.notifyUpperBound( 3, 8 );
+        max2.notifyLowerBound( 3, 6 );
+
+        for( unsigned i = 5; i < 10; i++ )
+            max2.notifyUpperBound( i, 5 );
+        max2.notifyUpperBound( f2, 5 );
+
+        max2.notifyVariableValue( f2, 5 );
+        // Now, phase should be fixed to x_2 and x_3; all other variables should be removed
+        TS_ASSERT( max2.phaseFixed() );
+
+        TS_ASSERT( !max2.wereVariablesEliminated() );
+        // Eliminate single variable x_4 = 9.5
+        max2.eliminateVariable( 4, 9.5);
+        TS_ASSERT( max2.wereVariablesEliminated() );
+
+        TS_ASSERT_EQUALS( max2.getParticipatingVariables().size(), 3U );
+
+        PiecewiseLinearCaseSplit validSplit2 = max2.getValidCaseSplit();
+
+        bounds = validSplit2.getBoundTightenings();
+
+        // Check 3 bounds
+        TS_ASSERT_EQUALS( bounds.size(), 3U );
+
+        it = bounds.begin();
+
+        // x2 <= UB(f)=5
+        TS_ASSERT_EQUALS( it->_variable, 2U );
+        TS_ASSERT_EQUALS( it->_value, 5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+        it++;
+
+        // x3 <= UB(f)=5
+        TS_ASSERT_EQUALS( it->_variable, 3U );
+        TS_ASSERT_EQUALS( it->_value, 5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+        it++;
+
+        // f >= maxValueEliminated = 9.5
+        TS_ASSERT_EQUALS( it->_variable, f2 );
+        TS_ASSERT_EQUALS( it->_value, 9.5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+
+        auto equations2 = validSplit2.getEquations();
+
+        TS_ASSERT_EQUALS( equations2.size(), 2U );
+
+        cur = equations2.begin();
+        // f >= x_2
+        TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+        TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+        TS_ASSERT_EQUALS( cur->_type, Equation::GE );
+
+        addend = cur->_addends.begin();
+
+        TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, 2U );
+
+        ++addend;
+
+        TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, f2 );
+
+        ++cur;
+        // f >= x_3
+        TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+        TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+        TS_ASSERT_EQUALS( cur->_type, Equation::GE );
+
+        addend = cur->_addends.begin();
+
+        TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, 3U );
+
+        ++addend;
+
+        TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, f2 );
+
+        // Case 3
+        // The eliminated variable is in f's range
+        unsigned f3 = 1;
+        Set<unsigned> elements3;
+
+        for ( unsigned i = 1; i < 10; ++i )
+            elements3.insert( i );
+
+        MaxConstraint max3( f3, elements3 );
+
+        // All variables initially between 1 and 10
+        for ( unsigned i = 1; i < 10; i++ )
+        {
+            max3.notifyUpperBound( i, 10 );
+            max3.notifyLowerBound( i, 1 );
+        }
+
+        // Set x_2 and x_3 to be at least 6, others to be at most 5
+        max3.notifyUpperBound( 2, 8 );
+        max3.notifyLowerBound( 2, 6 );
+
+        max3.notifyUpperBound( 3, 8 );
+        max3.notifyLowerBound( 3, 6 );
+
+        for( unsigned i = 5; i < 10; i++ )
+            max3.notifyUpperBound( i, 5 );
+        max3.notifyUpperBound( f3, 5 );
+
+        max3.notifyVariableValue( f3, 5);
+        // Now, phase should be fixed to x_2 and x_3; all other variables should be removed
+        TS_ASSERT( max3.phaseFixed() );
+
+        TS_ASSERT( !max3.wereVariablesEliminated() );
+        // Eliminate single variable x_4 = 7
+        max3.eliminateVariable( 4, 7 );
+        TS_ASSERT( max3.wereVariablesEliminated() );
+
+        TS_ASSERT_EQUALS( max3.getParticipatingVariables().size(), 3U );
+
+        PiecewiseLinearCaseSplit validSplit3 = max3.getValidCaseSplit();
+
+        bounds = validSplit3.getBoundTightenings();
+
+        // Check 3 bounds
+        TS_ASSERT_EQUALS( bounds.size(), 3U );
+
+        it = bounds.begin();
+
+        // x2 <= UB(f)=5
+        TS_ASSERT_EQUALS( it->_variable, 2U );
+        TS_ASSERT_EQUALS( it->_value, 5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+        it++;
+
+        // x3 <= UB(f)=5
+        TS_ASSERT_EQUALS( it->_variable, 3U );
+        TS_ASSERT_EQUALS( it->_value, 5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+        it++;
+
+        // f >= maxValueEliminated = 7
+        TS_ASSERT_EQUALS( it->_variable, f3 );
+        TS_ASSERT_EQUALS( it->_value, 7 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+
+        auto equations3 = validSplit3.getEquations();
+
+        TS_ASSERT_EQUALS( equations3.size(), 2U );
+
+        cur = equations3.begin();
+        // f >= x_2
+        TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+        TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+        TS_ASSERT_EQUALS( cur->_type, Equation::GE );
+
+        addend = cur->_addends.begin();
+
+        TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, 2U );
+
+        ++addend;
+
+        TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, f3 );
+
+        ++cur;
+        // f >= x_3
+        TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
+        TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
+        TS_ASSERT_EQUALS( cur->_type, Equation::GE );
+
+        addend = cur->_addends.begin();
+
+        TS_ASSERT_EQUALS( addend->_coefficient, -1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, 3U );
+
+        ++addend;
+
+        TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
+        TS_ASSERT_EQUALS( addend->_variable, f3 );
+    }
+
     void test_get_entailed_tightenings_with_elimination()
     {
         unsigned f = 1;
@@ -2041,6 +2868,100 @@ public:
         elements2.insert( 4 );
 
         MaxConstraint max2( f, elements2 );
+
+        // No lower bound for 1
+        max2.notifyUpperBound( 1, 7 );
+
+        max2.notifyLowerBound( 2, 1 );
+        max2.notifyUpperBound( 2, 8 );
+
+        // No lower bound for 3
+        max2.notifyUpperBound( 3, 6 );
+
+        // Eliminate variable x_4 = 9.5
+        TS_ASSERT( !max2.wereVariablesEliminated() );
+        max2.eliminateVariable( 4, 9.5 );
+        TS_ASSERT( max2.wereVariablesEliminated() );
+
+        List<Tightening> tightenings2;
+        TS_ASSERT_THROWS_NOTHING( max2.getEntailedTightenings( tightenings2 ) );
+
+        // Expect f to be in the range [1, 7], x2 to be in the range [1, 7]
+        TS_ASSERT_EQUALS( tightenings2.size(), 2U );
+        it = tightenings2.begin();
+
+        // Update X_2_UB = 7
+        TS_ASSERT_EQUALS( it->_variable, 2U );
+        TS_ASSERT_EQUALS( it->_value, 7 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+        ++it;
+
+        // Update f_LB = 9.5
+        TS_ASSERT_EQUALS( it->_variable, 1U );
+        TS_ASSERT_EQUALS( it->_value, 9.5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+    }
+
+    void test_get_entailed_tightenings_with_elimination_with_bound_manager()
+    {
+        unsigned f = 1;
+        Set<unsigned> elements;
+
+        elements.insert( 2 );
+        elements.insert( 3 );
+        elements.insert( 4 );
+
+        MaxConstraint max( f, elements );
+        Context context;
+        BoundManager boundManager( context );
+        boundManager.initialize( 11 );
+        max.registerBoundManager( &boundManager );
+
+        // Eliminate variable x_4 = 2.5
+        TS_ASSERT( !max.wereVariablesEliminated() );
+        max.eliminateVariable( 4, 2.5 );
+        TS_ASSERT( max.wereVariablesEliminated() );
+
+        max.notifyLowerBound( 2, 1 );
+        max.notifyUpperBound( 2, 8 );
+        // No lower bound for 3
+        max.notifyUpperBound( 3, 6 );
+
+        List<Tightening> tightenings;
+        TS_ASSERT_THROWS_NOTHING( max.getEntailedTightenings( tightenings ) );
+
+        // Expect f to be in the range [1, 8]
+        TS_ASSERT_EQUALS( tightenings.size(), 2U );
+        auto it = tightenings.begin();
+
+        // Update f_UB to have the value of max_(Element_UB) = 8 (=x_2_UB)
+        TS_ASSERT_EQUALS( it->_variable, 1U );
+        TS_ASSERT_EQUALS( it->_value, 8 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+        ++it;
+
+        // Update f_LB to have the value of max_(Element_LB) = 2.5 (= maxValueEliminated)
+        TS_ASSERT_EQUALS( it->_variable, 1U );
+        TS_ASSERT_EQUALS( it->_value, 2.5 );
+        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+
+        //From here, the test is going to run tests for the case that f is included in elements.
+        // also here - with a value eliminated
+
+        Set<unsigned> elements2;
+        elements2.insert( 1 );
+        elements2.insert( 2 );
+        elements2.insert( 3 );
+        // add variable to be eliminated
+        elements2.insert( 4 );
+
+        MaxConstraint max2( f, elements2 );
+        BoundManager boundManager2( context );
+        boundManager2.initialize( 11 );
+        max2.registerBoundManager( &boundManager2 );
+
 
         // No lower bound for 1
         max2.notifyUpperBound( 1, 7 );

--- a/src/engine/tests/Test_MaxConstraint.h
+++ b/src/engine/tests/Test_MaxConstraint.h
@@ -563,72 +563,150 @@ public:
 
     void test_get_entailed_tightenings()
     {
-        unsigned f = 1;
-        Set<unsigned> elements;
+        {
+            unsigned f = 1;
+            Set<unsigned> elements;
 
-        elements.insert( 2 );
-        elements.insert( 3 );
+            elements.insert( 2 );
+            elements.insert( 3 );
 
-        MaxConstraint max( f, elements );
+            MaxConstraint max( f, elements );
 
-        max.notifyLowerBound( 2, 1 );
-        max.notifyUpperBound( 2, 8 );
-        // No lower bound for 3
-        max.notifyUpperBound( 3, 6 );
+            max.notifyLowerBound( 2, 1 );
+            max.notifyUpperBound( 2, 8 );
+            // No lower bound for 3
+            max.notifyUpperBound( 3, 6 );
 
-        List<Tightening> tightenings;
-        TS_ASSERT_THROWS_NOTHING( max.getEntailedTightenings( tightenings ) );
+            List<Tightening> tightenings;
+            TS_ASSERT_THROWS_NOTHING( max.getEntailedTightenings( tightenings ) );
 
-        // expect f to be in the range [1, 8]
-        TS_ASSERT_EQUALS( tightenings.size(), 2U );
-        auto it = tightenings.begin();
+            // expect f to be in the range [1, 8]
+            TS_ASSERT_EQUALS( tightenings.size(), 2U );
+            auto it = tightenings.begin();
 
-        TS_ASSERT_EQUALS( it->_variable, 1U );
-        TS_ASSERT_EQUALS( it->_value, 8 );
-        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+            TS_ASSERT_EQUALS( it->_variable, 1U );
+            TS_ASSERT_EQUALS( it->_value, 8 );
+            TS_ASSERT_EQUALS( it->_type, Tightening::UB );
 
-        ++it;
+            ++it;
 
-        TS_ASSERT_EQUALS( it->_variable, 1U );
-        TS_ASSERT_EQUALS( it->_value, 1 );
-        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+            TS_ASSERT_EQUALS( it->_variable, 1U );
+            TS_ASSERT_EQUALS( it->_value, 1 );
+            TS_ASSERT_EQUALS( it->_type, Tightening::LB );
 
 
-        //
-        // From here, the test is going to run tests for the case that f is included in elements.
-        //
-        Set<unsigned> elements2;
-        elements2.insert( 1 );
-        elements2.insert( 2 );
-        elements2.insert( 3 );
+            //
+            // From here, the test is going to run tests for the case that f is included in elements.
+            //
+            Set<unsigned> elements2;
+            elements2.insert( 1 );
+            elements2.insert( 2 );
+            elements2.insert( 3 );
 
-        MaxConstraint max2( f, elements2 );
+            MaxConstraint max2( f, elements2 );
 
-        // No lower bound for 1
-        max2.notifyUpperBound( 1, 7 );
+            // No lower bound for 1
+            max2.notifyUpperBound( 1, 7 );
 
-        max2.notifyLowerBound( 2, 1 );
-        max2.notifyUpperBound( 2, 8 );
+            max2.notifyLowerBound( 2, 1 );
+            max2.notifyUpperBound( 2, 8 );
 
-        // No lower bound for 3
-        max2.notifyUpperBound( 3, 6 );
+            // No lower bound for 3
+            max2.notifyUpperBound( 3, 6 );
 
-        List<Tightening> tightenings2;
-        TS_ASSERT_THROWS_NOTHING( max2.getEntailedTightenings( tightenings2 ) );
+            List<Tightening> tightenings2;
+            TS_ASSERT_THROWS_NOTHING( max2.getEntailedTightenings( tightenings2 ) );
 
-        // expect f to be in the range [1, 7], x2 to be in the range [1, 7]
-        TS_ASSERT_EQUALS( tightenings2.size(), 2U );
-        it = tightenings2.begin();
+            // expect f to be in the range [1, 7], x2 to be in the range [1, 7]
+            TS_ASSERT_EQUALS( tightenings2.size(), 2U );
+            it = tightenings2.begin();
 
-        TS_ASSERT_EQUALS( it->_variable, 2U );
-        TS_ASSERT_EQUALS( it->_value, 7 );
-        TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+            TS_ASSERT_EQUALS( it->_variable, 2U );
+            TS_ASSERT_EQUALS( it->_value, 7 );
+            TS_ASSERT_EQUALS( it->_type, Tightening::UB );
 
-        ++it;
+            ++it;
 
-        TS_ASSERT_EQUALS( it->_variable, 1U );
-        TS_ASSERT_EQUALS( it->_value, 1 );
-        TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+            TS_ASSERT_EQUALS( it->_variable, 1U );
+            TS_ASSERT_EQUALS( it->_value, 1 );
+            TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+        }
+
+        { // With Bound Manager
+            unsigned f = 1;
+            Set<unsigned> elements;
+
+            elements.insert( 2 );
+            elements.insert( 3 );
+
+            MaxConstraint max( f, elements );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+            max.registerBoundManager( &boundManager );
+
+            TS_ASSERT_THROWS_NOTHING( max.notifyLowerBound( 2, 1 ) );
+            TS_ASSERT_THROWS_NOTHING( max.notifyUpperBound( 2, 8 ) );
+            // No lower bound for 3
+            TS_ASSERT_THROWS_NOTHING( max.notifyUpperBound( 3, 6 ) );
+
+            List<Tightening> tightenings;
+            TS_ASSERT_THROWS_NOTHING( max.getEntailedTightenings( tightenings ) );
+
+            // expect f to be in the range [1, 8]
+            TS_ASSERT_EQUALS( tightenings.size(), 2U );
+            auto it = tightenings.begin();
+
+            TS_ASSERT_EQUALS( it->_variable, 1U );
+            TS_ASSERT_EQUALS( it->_value, 8 );
+            TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+            ++it;
+
+            TS_ASSERT_EQUALS( it->_variable, 1U );
+            TS_ASSERT_EQUALS( it->_value, 1 );
+            TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+
+
+            //
+            // From here, the test is going to run tests for the case that f is included in elements.
+            //
+            Set<unsigned> elements2;
+            elements2.insert( 1 );
+            elements2.insert( 2 );
+            elements2.insert( 3 );
+
+            MaxConstraint max2( f, elements2 );
+            BoundManager boundManager2( context );
+            boundManager2.initialize( 5 );
+            max2.registerBoundManager( &boundManager2 );
+
+            // No lower bound for 1
+            max2.notifyUpperBound( 1, 7 );
+
+            max2.notifyLowerBound( 2, 1 );
+            max2.notifyUpperBound( 2, 8 );
+
+            // No lower bound for 3
+            max2.notifyUpperBound( 3, 6 );
+
+            List<Tightening> tightenings2;
+            TS_ASSERT_THROWS_NOTHING( max2.getEntailedTightenings( tightenings2 ) );
+
+            // expect f to be in the range [1, 7], x2 to be in the range [1, 7]
+            TS_ASSERT_EQUALS( tightenings2.size(), 2U );
+            it = tightenings2.begin();
+
+            TS_ASSERT_EQUALS( it->_variable, 2U );
+            TS_ASSERT_EQUALS( it->_value, 7 );
+            TS_ASSERT_EQUALS( it->_type, Tightening::UB );
+
+            ++it;
+
+            TS_ASSERT_EQUALS( it->_variable, 1U );
+            TS_ASSERT_EQUALS( it->_value, 1 );
+            TS_ASSERT_EQUALS( it->_type, Tightening::LB );
+        }
     }
 
     void test_max_obsolete()

--- a/src/engine/tests/Test_MaxConstraint.h
+++ b/src/engine/tests/Test_MaxConstraint.h
@@ -947,6 +947,7 @@ public:
         TS_ASSERT_EQUALS( addend->_coefficient, 1.0 );
         TS_ASSERT_EQUALS( addend->_variable, f );
     }
+
     void test_max_var_elims()
     {
         unsigned f = 1;

--- a/src/engine/tests/Test_MaxConstraint.h
+++ b/src/engine/tests/Test_MaxConstraint.h
@@ -15,11 +15,11 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "InputQuery.h"
+#include "MarabouError.h"
 #include "MaxConstraint.h"
 #include "MockTableau.h"
 #include "PiecewiseLinearCaseSplit.h"
-#include "MarabouError.h"
-#include "InputQuery.h"
 
 #include <string.h>
 
@@ -79,7 +79,7 @@ public:
 
         auto it = participatingVariables.begin();
         for ( unsigned i = 1; i < 10; ++i, ++it )
-        TS_ASSERT( max.participatingVariable( i ) );
+            TS_ASSERT( max.participatingVariable( i ) );
 
         TS_ASSERT( !max.participatingVariable( 20 ) );
         TS_ASSERT( !max.participatingVariable( 15 ) );
@@ -132,7 +132,7 @@ public:
 
         it = participatingVariables.begin();
         for ( unsigned i = 1; i < 10; ++i, ++it )
-        TS_ASSERT( max2.participatingVariable( i ) );
+            TS_ASSERT( max2.participatingVariable( i ) );
 
         TS_ASSERT( !max2.participatingVariable( 20 ) );
         TS_ASSERT( !max2.participatingVariable( 15 ) );
@@ -208,7 +208,7 @@ public:
 
         auto it = participatingVariables.begin();
         for ( unsigned i = 1; i < 10; ++i, ++it )
-        TS_ASSERT( max.participatingVariable( i ) );
+            TS_ASSERT( max.participatingVariable( i ) );
 
         TS_ASSERT( !max.participatingVariable( 20 ) );
         TS_ASSERT( !max.participatingVariable( 15 ) );
@@ -261,7 +261,7 @@ public:
 
         it = participatingVariables.begin();
         for ( unsigned i = 1; i < 10; ++i, ++it )
-        TS_ASSERT( max2.participatingVariable( i ) );
+            TS_ASSERT( max2.participatingVariable( i ) );
 
         TS_ASSERT( !max2.participatingVariable( 20 ) );
         TS_ASSERT( !max2.participatingVariable( 15 ) );
@@ -356,8 +356,8 @@ public:
         TS_ASSERT_EQUALS( it->_value, 6 );
 
         ++it;
-        TS_ASSERT_EQUALS ( it->_variable, 2U );
-        TS_ASSERT_EQUALS ( it->_value, 5 );
+        TS_ASSERT_EQUALS( it->_variable, 2U );
+        TS_ASSERT_EQUALS( it->_value, 5 );
 
         //
         // From here, the test is going to run tests for the case that f is included in elements.
@@ -381,9 +381,8 @@ public:
         TS_ASSERT_EQUALS( it->_value, 6 );
 
         ++it;
-        TS_ASSERT_EQUALS ( it->_variable, 2U );
-        TS_ASSERT_EQUALS ( it->_value, 5 );
-
+        TS_ASSERT_EQUALS( it->_variable, 2U );
+        TS_ASSERT_EQUALS( it->_value, 5 );
     }
 
     void test_max_fixes_with_bound_manager()
@@ -430,8 +429,8 @@ public:
         TS_ASSERT_EQUALS( it->_value, 6 );
 
         ++it;
-        TS_ASSERT_EQUALS ( it->_variable, 2U );
-        TS_ASSERT_EQUALS ( it->_value, 5 );
+        TS_ASSERT_EQUALS( it->_variable, 2U );
+        TS_ASSERT_EQUALS( it->_value, 5 );
 
         //
         // From here, the test is going to run tests for the case that f is included in elements.
@@ -455,9 +454,8 @@ public:
         TS_ASSERT_EQUALS( it->_value, 6 );
 
         ++it;
-        TS_ASSERT_EQUALS ( it->_variable, 2U );
-        TS_ASSERT_EQUALS ( it->_value, 5 );
-
+        TS_ASSERT_EQUALS( it->_variable, 2U );
+        TS_ASSERT_EQUALS( it->_value, 5 );
     }
 
     void test_max_case_splits()
@@ -512,7 +510,7 @@ public:
 
             ++cur;
 
-            for ( unsigned j = 2; j < 10;  ++j )
+            for ( unsigned j = 2; j < 10; ++j )
             {
                 if ( i == j ) continue;
 
@@ -565,7 +563,7 @@ public:
 
         auto cur = equations.begin();
 
-        for ( unsigned i = 2; i < 10;  ++i )
+        for ( unsigned i = 2; i < 10; ++i )
         {
             TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
             TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
@@ -641,7 +639,7 @@ public:
 
             ++cur;
 
-            for ( unsigned j = 2; j < 10;  ++j )
+            for ( unsigned j = 2; j < 10; ++j )
             {
                 if ( i == j ) continue;
 
@@ -694,7 +692,7 @@ public:
 
         auto cur = equations.begin();
 
-        for ( unsigned i = 2; i < 10;  ++i )
+        for ( unsigned i = 2; i < 10; ++i )
         {
             TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
             TS_ASSERT_EQUALS( cur->_scalar, 0.0 );
@@ -735,10 +733,10 @@ public:
 
         // set x_2 to be at least 6, others to be at most 5
         max.notifyLowerBound( 2, 6 );
-        for( unsigned i = 3; i < 10; i++ )
+        for ( unsigned i = 3; i < 10; i++ )
             max.notifyUpperBound( i, 5 );
 
-        max.notifyVariableValue( 2, 7);
+        max.notifyVariableValue( 2, 7 );
         // now, phase should be fixed to x_2; all other variables should be removed
         TS_ASSERT( max.phaseFixed() );
         TS_ASSERT_EQUALS( max.getParticipatingVariables().size(), 2U );
@@ -784,11 +782,11 @@ public:
         // set x_2 and x_3 to be at least 6, others to be at most 5
         max2.notifyLowerBound( 2, 6 );
         max2.notifyLowerBound( 3, 6 );
-        for( unsigned i = 4; i < 10; i++ )
+        for ( unsigned i = 4; i < 10; i++ )
             max2.notifyUpperBound( i, 5 );
         max2.notifyUpperBound( f, 5 );
 
-        max2.notifyVariableValue( f, 5);
+        max2.notifyVariableValue( f, 5 );
         // now, phase should be fixed to x_2 and x_3; all other variables should be removed
         TS_ASSERT( max2.phaseFixed() );
         TS_ASSERT_EQUALS( max2.getParticipatingVariables().size(), 3U );
@@ -854,10 +852,10 @@ public:
 
         // set x_2 to be at least 6, others to be at most 5
         max.notifyLowerBound( 2, 6 );
-        for( unsigned i = 3; i < 10; i++ )
+        for ( unsigned i = 3; i < 10; i++ )
             max.notifyUpperBound( i, 5 );
 
-        max.notifyVariableValue( 2, 7);
+        max.notifyVariableValue( 2, 7 );
         // now, phase should be fixed to x_2; all other variables should be removed
         TS_ASSERT( max.phaseFixed() );
         TS_ASSERT_EQUALS( max.getParticipatingVariables().size(), 2U );
@@ -903,11 +901,11 @@ public:
         // set x_2 and x_3 to be at least 6, others to be at most 5
         max2.notifyLowerBound( 2, 6 );
         max2.notifyLowerBound( 3, 6 );
-        for( unsigned i = 4; i < 10; i++ )
+        for ( unsigned i = 4; i < 10; i++ )
             max2.notifyUpperBound( i, 5 );
         max2.notifyUpperBound( f, 5 );
 
-        max2.notifyVariableValue( f, 5);
+        max2.notifyVariableValue( f, 5 );
         // now, phase should be fixed to x_2 and x_3; all other variables should be removed
         TS_ASSERT( max2.phaseFixed() );
         TS_ASSERT_EQUALS( max2.getParticipatingVariables().size(), 3U );
@@ -1167,9 +1165,9 @@ public:
         max.registerBoundManager( &boundManager );
 
         TS_ASSERT_THROWS_NOTHING( max.notifyLowerBound( 2, 1 ) );
-        TS_ASSERT_EQUALS( boundManager.getLowerBound( 2 ),  1 );
+        TS_ASSERT_EQUALS( boundManager.getLowerBound( 2 ), 1 );
         TS_ASSERT_THROWS_NOTHING( max.notifyUpperBound( 2, 8 ) );
-        TS_ASSERT_EQUALS( boundManager.getUpperBound( 2 ),  8 );
+        TS_ASSERT_EQUALS( boundManager.getUpperBound( 2 ), 8 );
         // No lower bound for 3
         TS_ASSERT_THROWS_NOTHING( max.notifyUpperBound( 3, 6 ) );
 
@@ -1247,7 +1245,7 @@ public:
         TS_ASSERT( max.constraintObsolete() );
 
         MaxConstraint max2( f, elements );
-        for(unsigned i = 3; i < 10; i++ )
+        for ( unsigned i = 3; i < 10; i++ )
             max2.eliminateVariable( i, 0 );
 
         TS_ASSERT( !max2.constraintObsolete() );
@@ -1256,7 +1254,7 @@ public:
 
         elements.insert( 1 );
         MaxConstraint max3( f, elements );
-        for(unsigned i = 2; i < 10; i++ )
+        for ( unsigned i = 2; i < 10; i++ )
             max3.eliminateVariable( i, 0 );
 
         TS_ASSERT( max3.constraintObsolete() );
@@ -1287,7 +1285,7 @@ public:
         max2.registerBoundManager( &boundManager2 );
 
 
-        for(unsigned i = 3; i < 10; i++ )
+        for ( unsigned i = 3; i < 10; i++ )
             max2.eliminateVariable( i, 0 );
 
         TS_ASSERT( !max2.constraintObsolete() );
@@ -1299,7 +1297,7 @@ public:
         BoundManager boundManager3( context );
         boundManager3.initialize( 11 );
         max3.registerBoundManager( &boundManager3 );
-        for(unsigned i = 2; i < 10; i++ )
+        for ( unsigned i = 2; i < 10; i++ )
             max3.eliminateVariable( i, 0 );
 
         TS_ASSERT( max3.constraintObsolete() );
@@ -1385,7 +1383,7 @@ public:
 
         MaxConstraint originalMax( f, elements );
         String originalSerialized = originalMax.serializeToString();
-        MaxConstraint recoveredMax(  originalSerialized );
+        MaxConstraint recoveredMax( originalSerialized );
 
         TS_ASSERT_EQUALS( originalMax.serializeToString(),
                           recoveredMax.serializeToString() );
@@ -1401,13 +1399,13 @@ public:
 
         MaxConstraint originalMax( f, elements );
 
-        originalMax.eliminateVariable(2, 12);
-        originalMax.eliminateVariable(1, 11);
-        originalMax.eliminateVariable(3, 13);
+        originalMax.eliminateVariable( 2, 12 );
+        originalMax.eliminateVariable( 1, 11 );
+        originalMax.eliminateVariable( 3, 13 );
 
 
         String originalSerialized = originalMax.serializeToString();
-        MaxConstraint recoveredMax(  originalSerialized );
+        MaxConstraint recoveredMax( originalSerialized );
 
         TS_ASSERT_EQUALS( originalMax.serializeToString(),
                           recoveredMax.serializeToString() );
@@ -1431,11 +1429,11 @@ public:
         max.eliminateVariable( 3, 13 );
         // 13 is the maximum value eliminated
 
-        max.notifyLowerBound( 0,1 );
-        max.notifyUpperBound( 0,14 );
+        max.notifyLowerBound( 0, 1 );
+        max.notifyUpperBound( 0, 14 );
         TS_ASSERT( !max.phaseFixed() )
 
-        max.notifyUpperBound( 0,13 );
+        max.notifyUpperBound( 0, 13 );
         TS_ASSERT( max.phaseFixed() )
 
         // Check phase fixed after eliminating - and lower bound updated
@@ -1454,11 +1452,11 @@ public:
         max2.eliminateVariable( 3, 13 );
         // 13 is the maximum value eliminated
 
-        max2.notifyLowerBound( 0,12.5 );
-        max2.notifyUpperBound( 0,13.5 );
+        max2.notifyLowerBound( 0, 12.5 );
+        max2.notifyUpperBound( 0, 13.5 );
         TS_ASSERT( !max2.phaseFixed() )
 
-        max2.notifyLowerBound( 0,13 );
+        max2.notifyLowerBound( 0, 13 );
         TS_ASSERT( max2.phaseFixed() )
     }
 
@@ -1484,11 +1482,11 @@ public:
         max.eliminateVariable( 3, 13 );
         // 13 is the maximum value eliminated
 
-        max.notifyLowerBound( 0,1 );
-        max.notifyUpperBound( 0,14 );
+        max.notifyLowerBound( 0, 1 );
+        max.notifyUpperBound( 0, 14 );
         TS_ASSERT( !max.phaseFixed() )
 
-        max.notifyUpperBound( 0,13 );
+        max.notifyUpperBound( 0, 13 );
         TS_ASSERT( max.phaseFixed() )
 
         // Check phase fixed after eliminating - and lower bound updated
@@ -1510,11 +1508,11 @@ public:
         max2.eliminateVariable( 3, 13 );
         // 13 is the maximum value eliminated
 
-        max2.notifyLowerBound( 0,12.5 );
-        max2.notifyUpperBound( 0,13.5 );
+        max2.notifyLowerBound( 0, 12.5 );
+        max2.notifyUpperBound( 0, 13.5 );
         TS_ASSERT( !max2.phaseFixed() )
 
-        max2.notifyLowerBound( 0,13 );
+        max2.notifyLowerBound( 0, 13 );
         TS_ASSERT( max2.phaseFixed() )
     }
 
@@ -1538,7 +1536,7 @@ public:
         TS_ASSERT( !max.wereVariablesEliminated() );
         // Eliminate single variable x_5 = 5
         unsigned eliminatedVariableValue = 5;
-        max.eliminateVariable( 5,eliminatedVariableValue );
+        max.eliminateVariable( 5, eliminatedVariableValue );
         TS_ASSERT( max.wereVariablesEliminated() );
 
         List<PiecewiseLinearCaseSplit> splits = max.getCaseSplits();
@@ -1584,7 +1582,7 @@ public:
 
             ++cur;
 
-            for ( unsigned j = 2; j < 5;  ++j )
+            for ( unsigned j = 2; j < 5; ++j )
             {
                 // Check that there is bi >= bj for each couple (i, j) of input elements
                 if ( i == j ) continue;
@@ -1623,7 +1621,7 @@ public:
         TS_ASSERT( !max2.wereVariablesEliminated() );
         // Eliminate single variable x_5 = 5
         double eliminatedVariableValue2 = 5;
-        max2.eliminateVariable( 5,eliminatedVariableValue2 );
+        max2.eliminateVariable( 5, eliminatedVariableValue2 );
         TS_ASSERT( max2.wereVariablesEliminated() );
 
         splits = max2.getCaseSplits();
@@ -1652,7 +1650,7 @@ public:
         // First phase is the one without max=_maxEliminated
         auto cur = equations.begin();
 
-        for ( unsigned i = 2; i < 5;  ++i )
+        for ( unsigned i = 2; i < 5; ++i )
         {
             // Check that there is f >= bj for each input element j
             TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
@@ -1696,7 +1694,7 @@ public:
         TS_ASSERT( !max.wereVariablesEliminated() );
         // Eliminate single variable x_5 = 5
         unsigned eliminatedVariableValue = 5;
-        max.eliminateVariable( 5,eliminatedVariableValue );
+        max.eliminateVariable( 5, eliminatedVariableValue );
         TS_ASSERT( max.wereVariablesEliminated() );
 
         List<PiecewiseLinearCaseSplit> splits = max.getCaseSplits();
@@ -1742,7 +1740,7 @@ public:
 
             ++cur;
 
-            for ( unsigned j = 2; j < 5;  ++j )
+            for ( unsigned j = 2; j < 5; ++j )
             {
                 // Check that there is bi >= bj for each couple (i, j) of input elements
                 if ( i == j ) continue;
@@ -1784,7 +1782,7 @@ public:
         TS_ASSERT( !max2.wereVariablesEliminated() );
         // Eliminate single variable x_5 = 5
         double eliminatedVariableValue2 = 5;
-        max2.eliminateVariable( 5,eliminatedVariableValue2 );
+        max2.eliminateVariable( 5, eliminatedVariableValue2 );
         TS_ASSERT( max2.wereVariablesEliminated() );
 
         splits = max2.getCaseSplits();
@@ -1813,7 +1811,7 @@ public:
         // First phase is the one without max=_maxEliminated
         auto cur = equations.begin();
 
-        for ( unsigned i = 2; i < 5;  ++i )
+        for ( unsigned i = 2; i < 5; ++i )
         {
             // Check that there is f >= bj for each input element j
             TS_ASSERT_EQUALS( cur->_addends.size(), 2U );
@@ -1849,7 +1847,8 @@ public:
         MaxConstraint max( f, elements );
 
         // All input variables initially between 1 and 10
-        for ( unsigned i = 2; i < 6; i++ ) {
+        for ( unsigned i = 2; i < 6; i++ )
+        {
             max.notifyUpperBound( i, 10 );
             max.notifyLowerBound( i, 1 );
         }
@@ -1863,7 +1862,7 @@ public:
 
         // Set x_2 to be at least 6, and x_3 and x_4 to be at most 5
         max.notifyLowerBound( 2, 6 );
-        for ( unsigned i = 3; i < 5; i++)
+        for ( unsigned i = 3; i < 5; i++ )
             max.notifyUpperBound( i, 5 );
 
         max.notifyVariableValue( 2, 7 );
@@ -1919,20 +1918,22 @@ public:
         MaxConstraint max2( f2, elements2 );
 
         // All input variables initially between 1 and 10
-        for ( unsigned i = 2; i < 6; i++ ) {
+        for ( unsigned i = 2; i < 6; i++ )
+        {
             max2.notifyUpperBound( i, 10 );
             max2.notifyLowerBound( i, 1 );
         }
 
         TS_ASSERT( !max2.wereVariablesEliminated() );
         // Eliminate single variable x_5 = 9.5
-        max2.eliminateVariable(5, 9.5 );
+        max2.eliminateVariable( 5, 9.5 );
         TS_ASSERT( max2.wereVariablesEliminated() );
 
         TS_ASSERT( !max2.phaseFixed() );
 
         // Set x_2 to be at least 6, and x_3 and x_4 to be at most 5
-        for ( unsigned i = 3; i < 5; i++ ) {
+        for ( unsigned i = 3; i < 5; i++ )
+        {
             max2.notifyUpperBound( i, 5 );
         }
 
@@ -1973,8 +1974,8 @@ public:
         TS_ASSERT_EQUALS( equations2.size(), 0U );
 
         // Case 3
-        // Check the case in which the eliminated variable is the range of the single variable which is larger than the rest
-        // (but may or may not be larger than the eliminated value)
+        // Check the case in which the eliminated variable is the range of the single variable which
+        // is larger than the rest (but may or may not be larger than the eliminated value)
 
         unsigned f3 = 1;
         Set<unsigned> elements3;
@@ -1985,7 +1986,8 @@ public:
         MaxConstraint max3( f3, elements3 );
 
         // All input variables initially between 1 and 10
-        for ( unsigned i = 2; i < 6; i++ ) {
+        for ( unsigned i = 2; i < 6; i++ )
+        {
             max3.notifyUpperBound( i, 10 );
             max3.notifyLowerBound( i, 1 );
         }
@@ -1998,7 +2000,8 @@ public:
         TS_ASSERT( !max3.phaseFixed() );
 
         // Set x_2 to be at least 6, and x_3 and x_4 to be at most 5
-        for ( unsigned i = 3; i < 5; i++ ) {
+        for ( unsigned i = 3; i < 5; i++ )
+        {
             max3.notifyUpperBound( i, 5 );
         }
 
@@ -2028,7 +2031,8 @@ public:
         max.registerBoundManager( &boundManager );
 
         // All input variables initially between 1 and 10
-        for ( unsigned i = 2; i < 6; i++ ) {
+        for ( unsigned i = 2; i < 6; i++ )
+        {
             max.notifyUpperBound( i, 10 );
             max.notifyLowerBound( i, 1 );
         }
@@ -2042,7 +2046,7 @@ public:
 
         // Set x_2 to be at least 6, and x_3 and x_4 to be at most 5
         max.notifyLowerBound( 2, 6 );
-        for ( unsigned i = 3; i < 5; i++)
+        for ( unsigned i = 3; i < 5; i++ )
             max.notifyUpperBound( i, 5 );
 
         max.notifyVariableValue( 2, 7 );
@@ -2098,20 +2102,22 @@ public:
         MaxConstraint max2( f2, elements2 );
 
         // All input variables initially between 1 and 10
-        for ( unsigned i = 2; i < 6; i++ ) {
+        for ( unsigned i = 2; i < 6; i++ )
+        {
             max2.notifyUpperBound( i, 10 );
             max2.notifyLowerBound( i, 1 );
         }
 
         TS_ASSERT( !max2.wereVariablesEliminated() );
         // Eliminate single variable x_5 = 9.5
-        max2.eliminateVariable(5, 9.5 );
+        max2.eliminateVariable( 5, 9.5 );
         TS_ASSERT( max2.wereVariablesEliminated() );
 
         TS_ASSERT( !max2.phaseFixed() );
 
         // Set x_2 to be at least 6, and x_3 and x_4 to be at most 5
-        for ( unsigned i = 3; i < 5; i++ ) {
+        for ( unsigned i = 3; i < 5; i++ )
+        {
             max2.notifyUpperBound( i, 5 );
         }
 
@@ -2152,8 +2158,8 @@ public:
         TS_ASSERT_EQUALS( equations2.size(), 0U );
 
         // Case 3
-        // Check the case in which the eliminated variable is the range of the single variable which is larger than the rest
-        // (but may or may not be larger than the eliminated value)
+        // Check the case in which the eliminated variable is the range of the single variable which
+        // is larger than the rest (but may or may not be larger than the eliminated value)
 
         unsigned f3 = 1;
         Set<unsigned> elements3;
@@ -2164,7 +2170,8 @@ public:
         MaxConstraint max3( f3, elements3 );
 
         // All input variables initially between 1 and 10
-        for ( unsigned i = 2; i < 6; i++ ) {
+        for ( unsigned i = 2; i < 6; i++ )
+        {
             max3.notifyUpperBound( i, 10 );
             max3.notifyLowerBound( i, 1 );
         }
@@ -2177,7 +2184,8 @@ public:
         TS_ASSERT( !max3.phaseFixed() );
 
         // Set x_2 to be at least 6, and x_3 and x_4 to be at most 5
-        for ( unsigned i = 3; i < 5; i++ ) {
+        for ( unsigned i = 3; i < 5; i++ )
+        {
             max3.notifyUpperBound( i, 5 );
         }
 
@@ -2212,11 +2220,11 @@ public:
         // Set x_2 and x_3 to be at least 6, others to be at most 5
         max.notifyLowerBound( 2, 6 );
         max.notifyLowerBound( 3, 6 );
-        for( unsigned i = 5; i < 10; i++ )
+        for ( unsigned i = 5; i < 10; i++ )
             max.notifyUpperBound( i, 5 );
         max.notifyUpperBound( f, 5 );
 
-        max.notifyVariableValue( f, 5);
+        max.notifyVariableValue( f, 5 );
         // Now, phase should be fixed to x_2 and x_3; all other variables should be removed
         TS_ASSERT( max.phaseFixed() );
 
@@ -2316,7 +2324,7 @@ public:
         max2.notifyUpperBound( 3, 8 );
         max2.notifyLowerBound( 3, 6 );
 
-        for( unsigned i = 5; i < 10; i++ )
+        for ( unsigned i = 5; i < 10; i++ )
             max2.notifyUpperBound( i, 5 );
         max2.notifyUpperBound( f2, 5 );
 
@@ -2326,7 +2334,7 @@ public:
 
         TS_ASSERT( !max2.wereVariablesEliminated() );
         // Eliminate single variable x_4 = 9.5
-        max2.eliminateVariable( 4, 9.5);
+        max2.eliminateVariable( 4, 9.5 );
         TS_ASSERT( max2.wereVariablesEliminated() );
 
         TS_ASSERT_EQUALS( max2.getParticipatingVariables().size(), 3U );
@@ -2419,11 +2427,11 @@ public:
         max3.notifyUpperBound( 3, 8 );
         max3.notifyLowerBound( 3, 6 );
 
-        for( unsigned i = 5; i < 10; i++ )
+        for ( unsigned i = 5; i < 10; i++ )
             max3.notifyUpperBound( i, 5 );
         max3.notifyUpperBound( f3, 5 );
 
-        max3.notifyVariableValue( f3, 5);
+        max3.notifyVariableValue( f3, 5 );
         // Now, phase should be fixed to x_2 and x_3; all other variables should be removed
         TS_ASSERT( max3.phaseFixed() );
 
@@ -2527,11 +2535,11 @@ public:
         // Set x_2 and x_3 to be at least 6, others to be at most 5
         max.notifyLowerBound( 2, 6 );
         max.notifyLowerBound( 3, 6 );
-        for( unsigned i = 5; i < 10; i++ )
+        for ( unsigned i = 5; i < 10; i++ )
             max.notifyUpperBound( i, 5 );
         max.notifyUpperBound( f, 5 );
 
-        max.notifyVariableValue( f, 5);
+        max.notifyVariableValue( f, 5 );
         // Now, phase should be fixed to x_2 and x_3; all other variables should be removed
         TS_ASSERT( max.phaseFixed() );
 
@@ -2634,7 +2642,7 @@ public:
         max2.notifyUpperBound( 3, 8 );
         max2.notifyLowerBound( 3, 6 );
 
-        for( unsigned i = 5; i < 10; i++ )
+        for ( unsigned i = 5; i < 10; i++ )
             max2.notifyUpperBound( i, 5 );
         max2.notifyUpperBound( f2, 5 );
 
@@ -2644,7 +2652,7 @@ public:
 
         TS_ASSERT( !max2.wereVariablesEliminated() );
         // Eliminate single variable x_4 = 9.5
-        max2.eliminateVariable( 4, 9.5);
+        max2.eliminateVariable( 4, 9.5 );
         TS_ASSERT( max2.wereVariablesEliminated() );
 
         TS_ASSERT_EQUALS( max2.getParticipatingVariables().size(), 3U );
@@ -2737,11 +2745,11 @@ public:
         max3.notifyUpperBound( 3, 8 );
         max3.notifyLowerBound( 3, 6 );
 
-        for( unsigned i = 5; i < 10; i++ )
+        for ( unsigned i = 5; i < 10; i++ )
             max3.notifyUpperBound( i, 5 );
         max3.notifyUpperBound( f3, 5 );
 
-        max3.notifyVariableValue( f3, 5);
+        max3.notifyVariableValue( f3, 5 );
         // Now, phase should be fixed to x_2 and x_3; all other variables should be removed
         TS_ASSERT( max3.phaseFixed() );
 
@@ -2857,7 +2865,7 @@ public:
         TS_ASSERT_EQUALS( it->_value, 2.5 );
         TS_ASSERT_EQUALS( it->_type, Tightening::LB );
 
-        //From here, the test is going to run tests for the case that f is included in elements.
+        // From here, the test is going to run tests for the case that f is included in elements.
         // also here - with a value eliminated
 
         Set<unsigned> elements2;
@@ -2947,7 +2955,7 @@ public:
         TS_ASSERT_EQUALS( it->_value, 2.5 );
         TS_ASSERT_EQUALS( it->_type, Tightening::LB );
 
-        //From here, the test is going to run tests for the case that f is included in elements.
+        // From here, the test is going to run tests for the case that f is included in elements.
         // also here - with a value eliminated
 
         Set<unsigned> elements2;
@@ -3012,13 +3020,14 @@ public:
         TS_ASSERT_EQUALS( participatingVariables.size(), 9U );
 
         auto it = participatingVariables.begin();
-        for ( unsigned i = 1; i < 10; ++i, ++it ) {
+        for ( unsigned i = 1; i < 10; ++i, ++it )
+        {
             TS_ASSERT( max.participatingVariable( i ) );
             max.notifyVariableValue( i, i );
         }
 
         // Constraint not satisfied
-        TS_ASSERT(!max.satisfied());
+        TS_ASSERT( !max.satisfied() );
 
         // Eliminate variable x_4 = 9.5
         TS_ASSERT( !max.wereVariablesEliminated() );
@@ -3030,7 +3039,7 @@ public:
         TS_ASSERT( !max.satisfied() );
 
         // Constraint satisfied
-        max.notifyVariableValue( f, 9.5);
+        max.notifyVariableValue( f, 9.5 );
         TS_ASSERT( max.satisfied() );
     }
 
@@ -3222,7 +3231,5 @@ public:
         context.pop(); // L1
 
         TS_ASSERT_EQUALS( max.getPhaseStatus(), PHASE_NOT_FIXED );
-
     }
 };
-

--- a/src/engine/tests/Test_MaxConstraint.h
+++ b/src/engine/tests/Test_MaxConstraint.h
@@ -3176,7 +3176,9 @@ public:
             elements.insert( i );
 
         TestMaxConstraint max( f, elements );
-
+        BoundManager bm( context );
+        bm.initialize( 7 );
+        max.registerBoundManager( &bm );
 
         // During pre-processing we eliminate some variables
         max.eliminateVariable( 5, 7 );
@@ -3201,7 +3203,8 @@ public:
         PhaseStatus phase = max.nextFeasibleCase();
         TS_ASSERT_DIFFERS( phase, MAX_PHASE_ELIMINATED );
 
-        max.markInfeasible( phase );
+        TS_ASSERT( !max.isImplication() );
+        max.notifyUpperBound( 4, 6 ); // This should eliminate variable 4;
         TS_ASSERT( max.isImplication() );
         TS_ASSERT_EQUALS( max.nextFeasibleCase(), MAX_PHASE_ELIMINATED );
 

--- a/src/engine/tests/Test_ReluConstraint.h
+++ b/src/engine/tests/Test_ReluConstraint.h
@@ -16,12 +16,12 @@
 #include <cxxtest/TestSuite.h>
 
 #include "InputQuery.h"
+#include "MarabouError.h"
 #include "MockConstraintBoundTightener.h"
 #include "MockErrno.h"
 #include "MockTableau.h"
 #include "PiecewiseLinearCaseSplit.h"
 #include "ReluConstraint.h"
-#include "MarabouError.h"
 #include "context/context.h"
 
 #include <string.h>
@@ -52,7 +52,7 @@ class ReluConstraintTestSuite : public CxxTest::TestSuite
 public:
     MockForReluConstraint *mock;
     Context ctx;
-    BoundManager* bm;
+    BoundManager *bm;
 
     void setUp()
     {
@@ -433,9 +433,9 @@ public:
 
         relu.notifyUpperBound( 4, -1.0 );
         TS_ASSERT_THROWS_EQUALS( splits = relu.getCaseSplits(),
-                                  const MarabouError &e,
-                                  e.getCode(),
-                                  MarabouError::REQUESTED_CASE_SPLITS_FROM_FIXED_CONSTRAINT );
+                                 const MarabouError &e,
+                                 e.getCode(),
+                                 MarabouError::REQUESTED_CASE_SPLITS_FROM_FIXED_CONSTRAINT );
 
         relu.unregisterAsWatcher( &tableau );
     }
@@ -1092,7 +1092,7 @@ public:
             TS_ASSERT( tightenings.empty() );
         }
 
-        {   // As above, but with registered BoundManager
+        { // As above, but with registered BoundManager
             ReluConstraint relu = prepareRelu( b, f, aux, &tightener, true );
 
             relu.notifyLowerBound( b, -20 );
@@ -1309,7 +1309,6 @@ public:
             ++itFix;
             TS_ASSERT_EQUALS( itFix->_variable, b );
             TS_ASSERT_EQUALS( itFix->_value, 1 );
-
         }
         // b in [-2, 3], polarity should be 0.2, the direction should be RELU_PHASE_ACTIVE,
         // the active case should be the first element of the returned list by
@@ -1363,8 +1362,8 @@ public:
 
         List<PiecewiseLinearCaseSplit> splits = relu.getCaseSplits();
         TS_ASSERT_EQUALS( splits.size(), 2u );
-        TS_ASSERT_EQUALS( splits.front(), relu.getCaseSplit( RELU_PHASE_INACTIVE ) ) ;
-        TS_ASSERT_EQUALS( splits.back(), relu.getCaseSplit( RELU_PHASE_ACTIVE ) ) ;
+        TS_ASSERT_EQUALS( splits.front(), relu.getCaseSplit( RELU_PHASE_INACTIVE ) );
+        TS_ASSERT_EQUALS( splits.back(), relu.getCaseSplit( RELU_PHASE_ACTIVE ) );
     }
 
     /*
@@ -1379,7 +1378,6 @@ public:
         TestReluConstraint relu( b, f );
 
         relu.initializeCDOs( &context );
-
 
 
         TS_ASSERT_EQUALS( relu.getPhaseStatus(), PHASE_NOT_FIXED );
@@ -1484,4 +1482,3 @@ public:
         TS_ASSERT_THROWS_NOTHING( delete relu1 );
     }
 };
-

--- a/src/engine/tests/Test_ReluConstraint.h
+++ b/src/engine/tests/Test_ReluConstraint.h
@@ -1483,14 +1483,5 @@ public:
 
         TS_ASSERT_THROWS_NOTHING( delete relu1 );
     }
-
 };
-
-//
-// Local Variables:
-// compile-command: "make -C ../../.. "
-// tags-file-name: "../../../TAGS"
-// c-basic-offset: 4
-// End:
-//
 

--- a/src/engine/tests/Test_SignConstraint.h
+++ b/src/engine/tests/Test_SignConstraint.h
@@ -1303,7 +1303,7 @@ public:
        * 1. Check that all cases are returned by SignConstraint::getAllCases
        * 2. Check that SignConstraint::getCaseSplit( case ) returns the correct case
        */
-      void test_relu_get_cases()
+      void test_sign_get_cases()
       {
         SignConstraint sign( 4, 6 );
 

--- a/src/engine/tests/Test_SignConstraint.h
+++ b/src/engine/tests/Test_SignConstraint.h
@@ -32,7 +32,7 @@ public:
 };
 
 /*
-   Exposes protected members of AbsConstraint for testing.
+   Exposes protected members of SignConstraint for testing.
  */
 class TestSignConstraint : public SignConstraint
 {
@@ -152,7 +152,7 @@ public:
 
         sign.notifyVariableValue( newB, -0.1 );
 
-        TS_ASSERT( sign.satisfied());
+        TS_ASSERT( sign.satisfied() );
     }
 
     void test_sign_fixes()
@@ -192,7 +192,7 @@ public:
         TS_ASSERT_EQUALS( it->_variable, f );
         TS_ASSERT_EQUALS( it->_value, 1 );
 
-        sign.notifyVariableValue( b, -2);
+        sign.notifyVariableValue( b, -2 );
         sign.notifyVariableValue( f, 1 );
 
         fixes = sign.getPossibleFixes();
@@ -733,7 +733,7 @@ public:
 
             // negative phase - because of f
             TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
-            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB) )  );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
             TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
             TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
             TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
@@ -821,7 +821,7 @@ public:
             SignConstraint sign( b, f );
             Context context;
             BoundManager boundManager( context );
-            boundManager.initialize( 500  );
+            boundManager.initialize( 500 );
             sign.registerBoundManager( &boundManager );
 
             MockConstraintBoundTightener tightener;
@@ -878,7 +878,7 @@ public:
 
             // negative phase - because of f
             TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
-            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB) )  );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
             TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
             TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
             TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
@@ -951,7 +951,7 @@ public:
             TS_ASSERT( entailedTightenings2.exists( Tightening( f2, -1, Tightening::LB ) ) );
 
             entailedTightenings2.clear();
-            //context.pop(); Incremental test case, no pop
+            // context.pop(); Incremental test case, no pop
             context.push();
 
             // new case
@@ -967,10 +967,9 @@ public:
             entailedTightenings2.clear();
             context.pop();
         }
-
     }
-      SignConstraint prepareSign( unsigned b, unsigned f, IConstraintBoundTightener *tightener )
-      {
+    SignConstraint prepareSign( unsigned b, unsigned f, IConstraintBoundTightener *tightener )
+    {
         SignConstraint sign( b, f );
 
         sign.registerConstraintBoundTightener( tightener );
@@ -986,25 +985,25 @@ public:
         sign.registerConstraintBoundTightener( tightener );
 
         return sign;
-      }
+    }
 
-      void test_notify_bounds()
-      {
-          {
-              unsigned b = 1;
-              unsigned f = 4;
+    void test_notify_bounds()
+    {
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-              MockConstraintBoundTightener tightener;
-              List<Tightening> tightenings;
+            MockConstraintBoundTightener tightener;
+            List<Tightening> tightenings;
 
-              tightener.getConstraintTightenings( tightenings );
+            tightener.getConstraintTightenings( tightenings );
 
-              SignConstraint sign = prepareSign( b, f, &tightener );
+            SignConstraint sign = prepareSign( b, f, &tightener );
 
-              sign.notifyLowerBound( b, -5 );
-              sign.notifyUpperBound( b, 5 );
+            sign.notifyLowerBound( b, -5 );
+            sign.notifyUpperBound( b, 5 );
 
-              {
+            {
                 sign.notifyLowerBound( b, -5 );
                 tightener.getConstraintTightenings( tightenings );
                 TS_ASSERT( tightenings.empty() );
@@ -1037,78 +1036,78 @@ public:
                 sign.notifyLowerBound( b, -2 );
                 tightener.getConstraintTightenings( tightenings );
                 TS_ASSERT( tightenings.empty() );
-              }
+            }
 
-              {
+            {
                 // Tighter lower bound for b/f that is positive
                 SignConstraint sign = prepareSign( b, f, &tightener );
                 sign.notifyLowerBound( b, 1 );
                 tightener.getConstraintTightenings( tightenings );
-                TS_ASSERT_EQUALS( tightenings.size(), 1U);
+                TS_ASSERT_EQUALS( tightenings.size(), 1U );
                 TS_ASSERT( tightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
 
                 sign.notifyUpperBound( f, -0.5 );
                 tightener.getConstraintTightenings( tightenings );
                 TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
-              }
+            }
 
-              {
+            {
                 // Tighter upper bound 0 for f
                 SignConstraint sign = prepareSign( b, f, &tightener );
                 sign.notifyUpperBound( f, 0 );
                 tightener.getConstraintTightenings( tightenings );
-                TS_ASSERT_EQUALS(tightenings.size(), 2U);
+                TS_ASSERT_EQUALS( tightenings.size(), 2U );
                 TS_ASSERT( tightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
                 TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
-              }
+            }
 
-              {
+            {
                 // upper bound 0 for b is inconclusive - because for 0 its +1, for <0 its '-1'
                 SignConstraint sign = prepareSign( b, f, &tightener );
                 sign.notifyUpperBound( b, 0 );
                 tightener.getConstraintTightenings( tightenings );
                 TS_ASSERT( tightenings.empty() );
-              }
+            }
 
-              {
+            {
                 // lower bound 0 for b is '+1'
                 SignConstraint sign = prepareSign( b, f, &tightener );
                 sign.notifyLowerBound( b, 0 );
                 tightener.getConstraintTightenings( tightenings );
                 TS_ASSERT_EQUALS( tightenings.size(), 1U );
                 TS_ASSERT( tightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
-              }
+            }
 
-              {
+            {
                 // Tighter negative upper bound for b
                 SignConstraint sign = prepareSign( b, f, &tightener );
                 sign.notifyUpperBound( f, 0.5 );
                 tightener.getConstraintTightenings( tightenings );
-                TS_ASSERT_EQUALS(tightenings.size(), 2U);
+                TS_ASSERT_EQUALS( tightenings.size(), 2U );
                 TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
                 TS_ASSERT( tightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
-              }
-          }
+            }
+        }
 
-          {   // With Bound Manager
-              unsigned b = 1;
-              unsigned f = 4;
+        { // With Bound Manager
+            unsigned b = 1;
+            unsigned f = 4;
 
-              MockConstraintBoundTightener tightener;
-              List<Tightening> tightenings;
+            MockConstraintBoundTightener tightener;
+            List<Tightening> tightenings;
 
-              tightener.getConstraintTightenings( tightenings );
+            tightener.getConstraintTightenings( tightenings );
 
-              SignConstraint sign = prepareSign( b, f, &tightener );
-              Context context;
-              BoundManager boundManager( context );
-              boundManager.initialize( 5 );
-              sign.registerBoundManager( &boundManager );
+            SignConstraint sign = prepareSign( b, f, &tightener );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 5 );
+            sign.registerBoundManager( &boundManager );
 
-              sign.notifyLowerBound( b, -5 );
-              sign.notifyUpperBound( b, 5 );
+            sign.notifyLowerBound( b, -5 );
+            sign.notifyUpperBound( b, 5 );
 
-              {
+            {
                 sign.notifyLowerBound( b, -5 );
                 tightener.getConstraintTightenings( tightenings );
                 TS_ASSERT( tightenings.empty() );
@@ -1141,62 +1140,62 @@ public:
                 sign.notifyLowerBound( b, -2 );
                 tightener.getConstraintTightenings( tightenings );
                 TS_ASSERT( tightenings.empty() );
-              }
+            }
 
-              {
+            {
                 // Tighter lower bound for b/f that is positive
                 SignConstraint sign = prepareSign( b, f, &tightener );
                 sign.notifyLowerBound( b, 1 );
                 tightener.getConstraintTightenings( tightenings );
-                TS_ASSERT_EQUALS( tightenings.size(), 1U);
+                TS_ASSERT_EQUALS( tightenings.size(), 1U );
                 TS_ASSERT( tightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
 
                 sign.notifyUpperBound( f, -0.5 );
                 tightener.getConstraintTightenings( tightenings );
                 TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
-              }
+            }
 
-              {
+            {
                 // Tighter upper bound 0 for f
                 SignConstraint sign = prepareSign( b, f, &tightener );
                 sign.notifyUpperBound( f, 0 );
                 tightener.getConstraintTightenings( tightenings );
-                TS_ASSERT_EQUALS(tightenings.size(), 2U);
+                TS_ASSERT_EQUALS( tightenings.size(), 2U );
                 TS_ASSERT( tightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
                 TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
-              }
+            }
 
-              {
+            {
                 // upper bound 0 for b is inconclusive - because for 0 its +1, for <0 its '-1'
                 SignConstraint sign = prepareSign( b, f, &tightener );
                 sign.notifyUpperBound( b, 0 );
                 tightener.getConstraintTightenings( tightenings );
                 TS_ASSERT( tightenings.empty() );
-              }
+            }
 
-              {
+            {
                 // lower bound 0 for b is '+1'
                 SignConstraint sign = prepareSign( b, f, &tightener );
                 sign.notifyLowerBound( b, 0 );
                 tightener.getConstraintTightenings( tightenings );
                 TS_ASSERT_EQUALS( tightenings.size(), 1U );
                 TS_ASSERT( tightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
-              }
+            }
 
-              {
+            {
                 // Tighter negative upper bound for b
                 SignConstraint sign = prepareSign( b, f, &tightener );
                 sign.notifyUpperBound( f, 0.5 );
                 tightener.getConstraintTightenings( tightenings );
-                TS_ASSERT_EQUALS(tightenings.size(), 2U);
+                TS_ASSERT_EQUALS( tightenings.size(), 2U );
                 TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
                 TS_ASSERT( tightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
-              }
-          }
-      }
+            }
+        }
+    }
 
-      void test_serialize_and_unserialize()
-      {
+    void test_serialize_and_unserialize()
+    {
         unsigned b = 42;
         unsigned f = 7;
 
@@ -1209,69 +1208,69 @@ public:
 
         TS_ASSERT_EQUALS( originalSign.serializeToString(),
                           recoveredSign.serializeToString() );
-      }
+    }
 
-      void test_polarity()
-      {
+    void test_polarity()
+    {
         unsigned b = 1;
         unsigned f = 4;
 
         // b in [1, 2], polarity should be 1, and direction should be SIGN_PHASE_POSITIVE
         {
-          SignConstraint sign( b, f );
-          sign.notifyLowerBound( b, 1 );
-          sign.notifyUpperBound( b, 2 );
-          TS_ASSERT( sign.computePolarity() == 1 );
+            SignConstraint sign( b, f );
+            sign.notifyLowerBound( b, 1 );
+            sign.notifyUpperBound( b, 2 );
+            TS_ASSERT( sign.computePolarity() == 1 );
 
-          sign.updateDirection();
-          TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
+            sign.updateDirection();
+            TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
         }
         // b in [-2, 0], polarity should be -1, and direction should be SIGN_PHASE_NEGATIVE
         {
-          SignConstraint sign( b, f );
-          sign.notifyLowerBound( b, -2 );
-          sign.notifyUpperBound( b, 0 );
-          TS_ASSERT( sign.computePolarity() == -1 );
+            SignConstraint sign( b, f );
+            sign.notifyLowerBound( b, -2 );
+            sign.notifyUpperBound( b, 0 );
+            TS_ASSERT( sign.computePolarity() == -1 );
 
-          sign.updateDirection();
-          TS_ASSERT( sign.getDirection() == SIGN_PHASE_NEGATIVE );
+            sign.updateDirection();
+            TS_ASSERT( sign.getDirection() == SIGN_PHASE_NEGATIVE );
         }
         // b in [-2, 2], polarity should be 0, the direction should be SIGN_PHASE_NEGATIVE,
         // the inactive case should be the first element of the returned list by
         // the getCaseSplits()
         {
-          SignConstraint sign( b, f );
-          sign.notifyLowerBound( b, -2 );
-          sign.notifyUpperBound( b, 2 );
-          TS_ASSERT( sign.computePolarity() == 0 );
+            SignConstraint sign( b, f );
+            sign.notifyLowerBound( b, -2 );
+            sign.notifyUpperBound( b, 2 );
+            TS_ASSERT( sign.computePolarity() == 0 );
 
-          sign.updateDirection();
-          TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
+            sign.updateDirection();
+            TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
 
-          auto splits = sign.getCaseSplits();
-          auto it = splits.begin();
-          TS_ASSERT( isPositiveSplit( b, f, it ) );
+            auto splits = sign.getCaseSplits();
+            auto it = splits.begin();
+            TS_ASSERT( isPositiveSplit( b, f, it ) );
         }
         // b in [-2, 3], polarity should be 0.2, the direction should be SIGN_PHASE_POSITIVE,
         // the active case should be the first element of the returned list by
         // the getCaseSplits()
         {
-          SignConstraint sign( b, f );
-          sign.notifyLowerBound( b, -2 );
-          sign.notifyUpperBound( b, 3 );
-          TS_ASSERT( sign.computePolarity() == 0.2 );
+            SignConstraint sign( b, f );
+            sign.notifyLowerBound( b, -2 );
+            sign.notifyUpperBound( b, 3 );
+            TS_ASSERT( sign.computePolarity() == 0.2 );
 
-          sign.updateDirection();
-          TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
+            sign.updateDirection();
+            TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
 
-          auto splits = sign.getCaseSplits();
-          auto it = splits.begin();
-          TS_ASSERT( isPositiveSplit( b, f, it ) );
+            auto splits = sign.getCaseSplits();
+            auto it = splits.begin();
+            TS_ASSERT( isPositiveSplit( b, f, it ) );
         }
-      }
+    }
 
-      void test_initialization_of_CDOs()
-      {
+    void test_initialization_of_CDOs()
+    {
         Context context;
         SignConstraint *sign1 = new SignConstraint( 4, 6 );
 
@@ -1296,15 +1295,15 @@ public:
 
 
         TS_ASSERT_THROWS_NOTHING( delete sign1 );
-      }
+    }
 
-      /*
-       * Test Case functionality of SignConstraint
-       * 1. Check that all cases are returned by SignConstraint::getAllCases
-       * 2. Check that SignConstraint::getCaseSplit( case ) returns the correct case
-       */
-      void test_sign_get_cases()
-      {
+    /*
+     * Test Case functionality of SignConstraint
+     * 1. Check that all cases are returned by SignConstraint::getAllCases
+     * 2. Check that SignConstraint::getCaseSplit( case ) returns the correct case
+     */
+    void test_sign_get_cases()
+    {
         SignConstraint sign( 4, 6 );
 
         List<PhaseStatus> cases = sign.getAllCases();
@@ -1315,15 +1314,15 @@ public:
 
         List<PiecewiseLinearCaseSplit> splits = sign.getCaseSplits();
         TS_ASSERT_EQUALS( splits.size(), 2u );
-        TS_ASSERT_EQUALS( splits.front(), sign.getCaseSplit( SIGN_PHASE_NEGATIVE ) ) ;
-        TS_ASSERT_EQUALS( splits.back(), sign.getCaseSplit( SIGN_PHASE_POSITIVE ) ) ;
-      }
+        TS_ASSERT_EQUALS( splits.front(), sign.getCaseSplit( SIGN_PHASE_NEGATIVE ) );
+        TS_ASSERT_EQUALS( splits.back(), sign.getCaseSplit( SIGN_PHASE_POSITIVE ) );
+    }
 
-      /*
-        Test context-dependent Sign state behavior.
-      */
-      void test_sign_context_dependent_state()
-      {
+    /*
+      Test context-dependent Sign state behavior.
+    */
+    void test_sign_context_dependent_state()
+    {
         Context context;
         unsigned b = 1;
         unsigned f = 4;
@@ -1347,5 +1346,5 @@ public:
 
         context.pop();
         TS_ASSERT_EQUALS( sign.getPhaseStatus(), PHASE_NOT_FIXED );
-      }
+    }
 };

--- a/src/engine/tests/Test_SignConstraint.h
+++ b/src/engine/tests/Test_SignConstraint.h
@@ -677,141 +677,300 @@ public:
 
     void test_sign_entailed_tightenings()
     {
-        unsigned b = 1;
-        unsigned f = 4;
+        {
+            unsigned b = 1;
+            unsigned f = 4;
 
-        InputQuery dontCare;
-        dontCare.setNumberOfVariables( 500 );
+            InputQuery dontCare;
+            dontCare.setNumberOfVariables( 500 );
 
-        SignConstraint sign( b, f );
+            SignConstraint sign( b, f );
 
-        MockConstraintBoundTightener tightener;
-        sign.registerConstraintBoundTightener( &tightener );
+            MockConstraintBoundTightener tightener;
+            sign.registerConstraintBoundTightener( &tightener );
 
-        sign.notifyLowerBound( b, -1 );
-        sign.notifyUpperBound( b, 7 );
+            sign.notifyLowerBound( b, -1 );
+            sign.notifyUpperBound( b, 7 );
 
-        sign.notifyLowerBound( f, -1 );
-        sign.notifyUpperBound( f, 1 );
+            sign.notifyLowerBound( f, -1 );
+            sign.notifyUpperBound( f, 1 );
 
-        List<Tightening> entailedTightenings;
-        sign.getEntailedTightenings( entailedTightenings );
+            List<Tightening> entailedTightenings;
+            sign.getEntailedTightenings( entailedTightenings );
 
-        // no phase fixed - only 2 trivial tightening -1<=f, f<=1
-        TS_ASSERT_EQUALS( entailedTightenings.size(), 2U );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
+            // no phase fixed - only 2 trivial tightening -1<=f, f<=1
+            TS_ASSERT_EQUALS( entailedTightenings.size(), 2U );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        sign.notifyLowerBound( b, -1 );
-        // the most important test
-        sign.notifyUpperBound( b, -0.5 );
+            sign.notifyLowerBound( b, -1 );
+            // the most important test
+            sign.notifyUpperBound( b, -0.5 );
 
-        sign.notifyLowerBound( f, -1 );
-        sign.notifyUpperBound( f, 1 );
+            sign.notifyLowerBound( f, -1 );
+            sign.notifyUpperBound( f, 1 );
 
-        sign.getEntailedTightenings( entailedTightenings );
+            sign.getEntailedTightenings( entailedTightenings );
 
-        // negative phase - because of b
-        TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
-        TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
+            // negative phase - because of b
+            TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        sign.notifyLowerBound( b, -1 );
-        sign.notifyUpperBound( b, -0.5 );
-        sign.notifyLowerBound( f, -1 );
-        // the most important test
-        sign.notifyUpperBound( f, 0.5 );
+            sign.notifyLowerBound( b, -1 );
+            sign.notifyUpperBound( b, -0.5 );
+            sign.notifyLowerBound( f, -1 );
+            // the most important test
+            sign.notifyUpperBound( f, 0.5 );
 
-        sign.getEntailedTightenings( entailedTightenings );
+            sign.getEntailedTightenings( entailedTightenings );
 
-        // negative phase - because of f
-        TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB) )  );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
-        TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
+            // negative phase - because of f
+            TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB) )  );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        sign.notifyLowerBound( b, 0 );
-        sign.notifyUpperBound( b, 7 );
-        sign.notifyLowerBound( f, -1 );
-        sign.notifyUpperBound( f, 1 );
+            sign.notifyLowerBound( b, 0 );
+            sign.notifyUpperBound( b, 7 );
+            sign.notifyLowerBound( f, -1 );
+            sign.notifyUpperBound( f, 1 );
 
-        sign.getEntailedTightenings( entailedTightenings );
+            sign.getEntailedTightenings( entailedTightenings );
 
-        // positive phase - because of b
-        TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
-        TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::LB ) ) );
+            // positive phase - because of b
+            TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::LB ) ) );
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        sign.notifyLowerBound( b, -5 );
-        sign.notifyUpperBound( b, 5 );
-        sign.notifyLowerBound( f, -0.5 );
-        sign.notifyUpperBound( f, 1 );
+            sign.notifyLowerBound( b, -5 );
+            sign.notifyUpperBound( b, 5 );
+            sign.notifyLowerBound( f, -0.5 );
+            sign.notifyUpperBound( f, 1 );
 
-        sign.getEntailedTightenings( entailedTightenings );
+            sign.getEntailedTightenings( entailedTightenings );
 
-        // positive phase - because of f
-        TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
-        TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
-        TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::LB ) ) );
+            // positive phase - because of f
+            TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::LB ) ) );
 
-        entailedTightenings.clear();
+            entailedTightenings.clear();
 
-        unsigned b2 = 1;
-        unsigned f2 = 4;
+            unsigned b2 = 1;
+            unsigned f2 = 4;
 
-        InputQuery dontCare2;
-        dontCare.setNumberOfVariables( 500 );
+            InputQuery dontCare2;
+            dontCare.setNumberOfVariables( 500 );
 
-        SignConstraint sign2( b2, f2 );
+            SignConstraint sign2( b2, f2 );
 
-        sign2.registerConstraintBoundTightener( &tightener );
+            sign2.registerConstraintBoundTightener( &tightener );
 
-        sign2.notifyLowerBound( b2, -1 );
-        sign2.notifyUpperBound( b2, 1 );
+            sign2.notifyLowerBound( b2, -1 );
+            sign2.notifyUpperBound( b2, 1 );
 
-        sign2.notifyLowerBound( f2, -1 );
-        sign2.notifyUpperBound( f2, 1 );
+            sign2.notifyLowerBound( f2, -1 );
+            sign2.notifyUpperBound( f2, 1 );
 
-        List<Tightening> entailedTightenings2;
-        sign2.getEntailedTightenings( entailedTightenings2 );
+            List<Tightening> entailedTightenings2;
+            sign2.getEntailedTightenings( entailedTightenings2 );
 
-        // no phase fixed - only 2 trivial tightening -1<=f, f<=1
-        TS_ASSERT_EQUALS( entailedTightenings2.size(), 2U );
-        TS_ASSERT( entailedTightenings2.exists( Tightening( f2, 1, Tightening::UB ) ) );
-        TS_ASSERT( entailedTightenings2.exists( Tightening( f2, -1, Tightening::LB ) ) );
+            // no phase fixed - only 2 trivial tightening -1<=f, f<=1
+            TS_ASSERT_EQUALS( entailedTightenings2.size(), 2U );
+            TS_ASSERT( entailedTightenings2.exists( Tightening( f2, 1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings2.exists( Tightening( f2, -1, Tightening::LB ) ) );
 
-        entailedTightenings2.clear();
+            entailedTightenings2.clear();
 
-        // new case
-        sign2.notifyUpperBound( b, 0 );
+            // new case
+            sign2.notifyUpperBound( b, 0 );
 
-        sign2.getEntailedTightenings( entailedTightenings2 );
+            sign2.getEntailedTightenings( entailedTightenings2 );
 
-        // no phase fixed - only 2 trivial tightening -1<=f, f<=1
-        TS_ASSERT_EQUALS( entailedTightenings2.size(), 2U );
-        TS_ASSERT( entailedTightenings2.exists( Tightening( f2, 1, Tightening::UB ) ) );
-        TS_ASSERT( entailedTightenings2.exists( Tightening( f2, -1, Tightening::LB ) ) );
+            // no phase fixed - only 2 trivial tightening -1<=f, f<=1
+            TS_ASSERT_EQUALS( entailedTightenings2.size(), 2U );
+            TS_ASSERT( entailedTightenings2.exists( Tightening( f2, 1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings2.exists( Tightening( f2, -1, Tightening::LB ) ) );
 
-        entailedTightenings2.clear();
+            entailedTightenings2.clear();
+        }
+
+        {
+            unsigned b = 1;
+            unsigned f = 4;
+
+            InputQuery dontCare;
+            dontCare.setNumberOfVariables( 500 );
+
+            SignConstraint sign( b, f );
+            Context context;
+            BoundManager boundManager( context );
+            boundManager.initialize( 500  );
+            sign.registerBoundManager( &boundManager );
+
+            MockConstraintBoundTightener tightener;
+            sign.registerConstraintBoundTightener( &tightener );
+
+            context.push();
+
+            TS_ASSERT_THROWS_NOTHING( sign.notifyLowerBound( b, -1 ) );
+            TS_ASSERT_THROWS_NOTHING( sign.notifyUpperBound( b, 7 ) );
+
+            TS_ASSERT_THROWS_NOTHING( sign.notifyLowerBound( f, -1 ) );
+            TS_ASSERT_THROWS_NOTHING( sign.notifyUpperBound( f, 1 ) );
+
+            List<Tightening> entailedTightenings;
+            sign.getEntailedTightenings( entailedTightenings );
+
+            // no phase fixed - only 2 trivial tightening -1<=f, f<=1
+            TS_ASSERT_EQUALS( entailedTightenings.size(), 2U );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
+
+            entailedTightenings.clear();
+
+            context.pop();
+            context.push();
+
+            TS_ASSERT_THROWS_NOTHING( sign.notifyLowerBound( b, -1 ) );
+            // the most important test
+            TS_ASSERT_THROWS_NOTHING( sign.notifyUpperBound( b, -0.5 ) );
+
+            TS_ASSERT_THROWS_NOTHING( sign.notifyLowerBound( f, -1 ) );
+            TS_ASSERT_THROWS_NOTHING( sign.notifyUpperBound( f, 1 ) );
+
+            sign.getEntailedTightenings( entailedTightenings );
+
+            // negative phase - because of b
+            TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
+
+            entailedTightenings.clear();
+            context.pop();
+            context.push();
+
+            TS_ASSERT_THROWS_NOTHING( sign.notifyLowerBound( b, -1 ) );
+            TS_ASSERT_THROWS_NOTHING( sign.notifyUpperBound( b, -0.5 ) );
+            TS_ASSERT_THROWS_NOTHING( sign.notifyLowerBound( f, -1 ) );
+            // the most important test
+            TS_ASSERT_THROWS_NOTHING( sign.notifyUpperBound( f, 0.5 ) );
+
+            sign.getEntailedTightenings( entailedTightenings );
+
+            // negative phase - because of f
+            TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB) )  );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
+
+            entailedTightenings.clear();
+            context.pop();
+            context.push();
+
+            TS_ASSERT_THROWS_NOTHING( sign.notifyLowerBound( b, 0 ) );
+            TS_ASSERT_THROWS_NOTHING( sign.notifyUpperBound( b, 7 ) );
+            TS_ASSERT_THROWS_NOTHING( sign.notifyLowerBound( f, -1 ) );
+            TS_ASSERT_THROWS_NOTHING( sign.notifyUpperBound( f, 1 ) );
+
+            sign.getEntailedTightenings( entailedTightenings );
+
+            // positive phase - because of b
+            TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::LB ) ) );
+
+            entailedTightenings.clear();
+            context.pop();
+            context.push();
+
+            sign.notifyLowerBound( b, -5 );
+            sign.notifyUpperBound( b, 5 );
+            sign.notifyLowerBound( f, -0.5 );
+            sign.notifyUpperBound( f, 1 );
+
+            sign.getEntailedTightenings( entailedTightenings );
+
+            // positive phase - because of f
+            TS_ASSERT_EQUALS( entailedTightenings.size(), 4U );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, -1, Tightening::LB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
+            TS_ASSERT( entailedTightenings.exists( Tightening( b, 0, Tightening::LB ) ) );
+
+            entailedTightenings.clear();
+            context.pop();
+            context.push();
+
+            unsigned b2 = 1;
+            unsigned f2 = 4;
+
+            InputQuery dontCare2;
+            dontCare.setNumberOfVariables( 500 );
+            BoundManager boundManager2( context );
+            boundManager2.initialize( 500 );
+
+            SignConstraint sign2( b2, f2 );
+            sign2.registerBoundManager( &boundManager2 );
+
+            sign2.registerConstraintBoundTightener( &tightener );
+
+            sign2.notifyLowerBound( b2, -1 );
+            sign2.notifyUpperBound( b2, 1 );
+
+            sign2.notifyLowerBound( f2, -1 );
+            sign2.notifyUpperBound( f2, 1 );
+
+            List<Tightening> entailedTightenings2;
+            sign2.getEntailedTightenings( entailedTightenings2 );
+
+            // no phase fixed - only 2 trivial tightening -1<=f, f<=1
+            TS_ASSERT_EQUALS( entailedTightenings2.size(), 2U );
+            TS_ASSERT( entailedTightenings2.exists( Tightening( f2, 1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings2.exists( Tightening( f2, -1, Tightening::LB ) ) );
+
+            entailedTightenings2.clear();
+            //context.pop(); Incremental test case, no pop
+            context.push();
+
+            // new case
+            sign2.notifyUpperBound( b, 0 );
+
+            sign2.getEntailedTightenings( entailedTightenings2 );
+
+            // no phase fixed - only 2 trivial tightening -1<=f, f<=1
+            TS_ASSERT_EQUALS( entailedTightenings2.size(), 2U );
+            TS_ASSERT( entailedTightenings2.exists( Tightening( f2, 1, Tightening::UB ) ) );
+            TS_ASSERT( entailedTightenings2.exists( Tightening( f2, -1, Tightening::LB ) ) );
+
+            entailedTightenings2.clear();
+            context.pop();
+        }
+
     }
-
-    SignConstraint prepareSign( unsigned b, unsigned f, IConstraintBoundTightener *tightener )
-    {
+      SignConstraint prepareSign( unsigned b, unsigned f, IConstraintBoundTightener *tightener )
+      {
         SignConstraint sign( b, f );
 
         sign.registerConstraintBoundTightener( tightener );
@@ -827,111 +986,217 @@ public:
         sign.registerConstraintBoundTightener( tightener );
 
         return sign;
-    }
+      }
 
-    void test_notify_bounds()
-    {
-        unsigned b = 1;
-        unsigned f = 4;
+      void test_notify_bounds()
+      {
+          {
+              unsigned b = 1;
+              unsigned f = 4;
 
-        MockConstraintBoundTightener tightener;
-        List<Tightening> tightenings;
+              MockConstraintBoundTightener tightener;
+              List<Tightening> tightenings;
 
-        tightener.getConstraintTightenings( tightenings );
+              tightener.getConstraintTightenings( tightenings );
 
-        SignConstraint sign = prepareSign( b, f, &tightener );
+              SignConstraint sign = prepareSign( b, f, &tightener );
 
-        sign.notifyLowerBound( b, -5 );
-        sign.notifyUpperBound( b, 5 );
+              sign.notifyLowerBound( b, -5 );
+              sign.notifyUpperBound( b, 5 );
 
-        {
-            sign.notifyLowerBound( b, -5 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT( tightenings.empty() );
+              {
+                sign.notifyLowerBound( b, -5 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
 
-            sign.notifyLowerBound( b, -7 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT( tightenings.empty() );
+                sign.notifyLowerBound( b, -7 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
 
-            sign.notifyLowerBound( f, -3 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT( tightenings.empty() );
+                sign.notifyLowerBound( f, -3 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
 
-            sign.notifyUpperBound( b, 20 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT( tightenings.empty() );
+                sign.notifyUpperBound( b, 20 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
 
-            sign.notifyUpperBound( f, 23 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT( tightenings.empty() );
+                sign.notifyUpperBound( f, 23 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
 
-            sign.notifyLowerBound( f, -1 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT( tightenings.empty() );
+                sign.notifyLowerBound( f, -1 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
 
-            sign.notifyUpperBound( f, 1 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT( tightenings.empty() );
+                sign.notifyUpperBound( f, 1 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
 
-            // although higher lower bound - then bounds are reported only if phase is fixed!
-            sign.notifyLowerBound( b, -2 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT( tightenings.empty() );
-        }
+                // although higher lower bound - then bounds are reported only if phase is fixed!
+                sign.notifyLowerBound( b, -2 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
+              }
 
-        {
-            // Tighter lower bound for b/f that is positive
-            SignConstraint sign = prepareSign( b, f, &tightener );
-            sign.notifyLowerBound( b, 1 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT_EQUALS( tightenings.size(), 1U);
-            TS_ASSERT( tightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
+              {
+                // Tighter lower bound for b/f that is positive
+                SignConstraint sign = prepareSign( b, f, &tightener );
+                sign.notifyLowerBound( b, 1 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT_EQUALS( tightenings.size(), 1U);
+                TS_ASSERT( tightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
 
-            sign.notifyUpperBound( f, -0.5 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
-        }
+                sign.notifyUpperBound( f, -0.5 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
+              }
 
-        {
-            // Tighter upper bound 0 for f
-            SignConstraint sign = prepareSign( b, f, &tightener );
-            sign.notifyUpperBound( f, 0 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT_EQUALS(tightenings.size(), 2U);
-            TS_ASSERT( tightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
-            TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
-        }
+              {
+                // Tighter upper bound 0 for f
+                SignConstraint sign = prepareSign( b, f, &tightener );
+                sign.notifyUpperBound( f, 0 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT_EQUALS(tightenings.size(), 2U);
+                TS_ASSERT( tightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
+                TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
+              }
 
-        {
-            // upper bound 0 for b is inconclusive - because for 0 its +1, for <0 its '-1'
-            SignConstraint sign = prepareSign( b, f, &tightener );
-            sign.notifyUpperBound( b, 0 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT( tightenings.empty() );
-        }
+              {
+                // upper bound 0 for b is inconclusive - because for 0 its +1, for <0 its '-1'
+                SignConstraint sign = prepareSign( b, f, &tightener );
+                sign.notifyUpperBound( b, 0 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
+              }
 
-        {
-            // lower bound 0 for b is '+1'
-            SignConstraint sign = prepareSign( b, f, &tightener );
-            sign.notifyLowerBound( b, 0 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT_EQUALS( tightenings.size(), 1U );
-            TS_ASSERT( tightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
-        }
+              {
+                // lower bound 0 for b is '+1'
+                SignConstraint sign = prepareSign( b, f, &tightener );
+                sign.notifyLowerBound( b, 0 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT_EQUALS( tightenings.size(), 1U );
+                TS_ASSERT( tightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
+              }
 
-        {
-            // Tighter negative upper bound for b
-            SignConstraint sign = prepareSign( b, f, &tightener );
-            sign.notifyUpperBound( f, 0.5 );
-            tightener.getConstraintTightenings( tightenings );
-            TS_ASSERT_EQUALS(tightenings.size(), 2U);
-            TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
-            TS_ASSERT( tightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
-        }
-    }
+              {
+                // Tighter negative upper bound for b
+                SignConstraint sign = prepareSign( b, f, &tightener );
+                sign.notifyUpperBound( f, 0.5 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT_EQUALS(tightenings.size(), 2U);
+                TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
+                TS_ASSERT( tightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
+              }
+          }
 
-    void test_serialize_and_unserialize()
-    {
+          {   // With Bound Manager
+              unsigned b = 1;
+              unsigned f = 4;
+
+              MockConstraintBoundTightener tightener;
+              List<Tightening> tightenings;
+
+              tightener.getConstraintTightenings( tightenings );
+
+              SignConstraint sign = prepareSign( b, f, &tightener );
+              Context context;
+              BoundManager boundManager( context );
+              boundManager.initialize( 5 );
+              sign.registerBoundManager( &boundManager );
+
+              sign.notifyLowerBound( b, -5 );
+              sign.notifyUpperBound( b, 5 );
+
+              {
+                sign.notifyLowerBound( b, -5 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
+
+                sign.notifyLowerBound( b, -7 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
+
+                sign.notifyLowerBound( f, -3 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
+
+                sign.notifyUpperBound( b, 20 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
+
+                sign.notifyUpperBound( f, 23 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
+
+                sign.notifyLowerBound( f, -1 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
+
+                sign.notifyUpperBound( f, 1 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
+
+                // although higher lower bound - then bounds are reported only if phase is fixed!
+                sign.notifyLowerBound( b, -2 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
+              }
+
+              {
+                // Tighter lower bound for b/f that is positive
+                SignConstraint sign = prepareSign( b, f, &tightener );
+                sign.notifyLowerBound( b, 1 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT_EQUALS( tightenings.size(), 1U);
+                TS_ASSERT( tightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
+
+                sign.notifyUpperBound( f, -0.5 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
+              }
+
+              {
+                // Tighter upper bound 0 for f
+                SignConstraint sign = prepareSign( b, f, &tightener );
+                sign.notifyUpperBound( f, 0 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT_EQUALS(tightenings.size(), 2U);
+                TS_ASSERT( tightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
+                TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
+              }
+
+              {
+                // upper bound 0 for b is inconclusive - because for 0 its +1, for <0 its '-1'
+                SignConstraint sign = prepareSign( b, f, &tightener );
+                sign.notifyUpperBound( b, 0 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT( tightenings.empty() );
+              }
+
+              {
+                // lower bound 0 for b is '+1'
+                SignConstraint sign = prepareSign( b, f, &tightener );
+                sign.notifyLowerBound( b, 0 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT_EQUALS( tightenings.size(), 1U );
+                TS_ASSERT( tightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
+              }
+
+              {
+                // Tighter negative upper bound for b
+                SignConstraint sign = prepareSign( b, f, &tightener );
+                sign.notifyUpperBound( f, 0.5 );
+                tightener.getConstraintTightenings( tightenings );
+                TS_ASSERT_EQUALS(tightenings.size(), 2U);
+                TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
+                TS_ASSERT( tightenings.exists( Tightening( b, 0, Tightening::UB ) ) );
+              }
+          }
+      }
+
+      void test_serialize_and_unserialize()
+      {
         unsigned b = 42;
         unsigned f = 7;
 
@@ -944,69 +1209,69 @@ public:
 
         TS_ASSERT_EQUALS( originalSign.serializeToString(),
                           recoveredSign.serializeToString() );
-    }
+      }
 
       void test_polarity()
-    {
+      {
         unsigned b = 1;
         unsigned f = 4;
 
         // b in [1, 2], polarity should be 1, and direction should be SIGN_PHASE_POSITIVE
         {
-            SignConstraint sign( b, f );
-            sign.notifyLowerBound( b, 1 );
-            sign.notifyUpperBound( b, 2 );
-            TS_ASSERT( sign.computePolarity() == 1 );
+          SignConstraint sign( b, f );
+          sign.notifyLowerBound( b, 1 );
+          sign.notifyUpperBound( b, 2 );
+          TS_ASSERT( sign.computePolarity() == 1 );
 
-            sign.updateDirection();
-            TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
+          sign.updateDirection();
+          TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
         }
         // b in [-2, 0], polarity should be -1, and direction should be SIGN_PHASE_NEGATIVE
         {
-            SignConstraint sign( b, f );
-            sign.notifyLowerBound( b, -2 );
-            sign.notifyUpperBound( b, 0 );
-            TS_ASSERT( sign.computePolarity() == -1 );
+          SignConstraint sign( b, f );
+          sign.notifyLowerBound( b, -2 );
+          sign.notifyUpperBound( b, 0 );
+          TS_ASSERT( sign.computePolarity() == -1 );
 
-            sign.updateDirection();
-            TS_ASSERT( sign.getDirection() == SIGN_PHASE_NEGATIVE );
+          sign.updateDirection();
+          TS_ASSERT( sign.getDirection() == SIGN_PHASE_NEGATIVE );
         }
         // b in [-2, 2], polarity should be 0, the direction should be SIGN_PHASE_NEGATIVE,
         // the inactive case should be the first element of the returned list by
         // the getCaseSplits()
         {
-            SignConstraint sign( b, f );
-            sign.notifyLowerBound( b, -2 );
-            sign.notifyUpperBound( b, 2 );
-            TS_ASSERT( sign.computePolarity() == 0 );
+          SignConstraint sign( b, f );
+          sign.notifyLowerBound( b, -2 );
+          sign.notifyUpperBound( b, 2 );
+          TS_ASSERT( sign.computePolarity() == 0 );
 
-            sign.updateDirection();
-            TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
+          sign.updateDirection();
+          TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
 
-            auto splits = sign.getCaseSplits();
-            auto it = splits.begin();
-            TS_ASSERT( isPositiveSplit( b, f, it ) );
+          auto splits = sign.getCaseSplits();
+          auto it = splits.begin();
+          TS_ASSERT( isPositiveSplit( b, f, it ) );
         }
         // b in [-2, 3], polarity should be 0.2, the direction should be SIGN_PHASE_POSITIVE,
         // the active case should be the first element of the returned list by
         // the getCaseSplits()
         {
-            SignConstraint sign( b, f );
-            sign.notifyLowerBound( b, -2 );
-            sign.notifyUpperBound( b, 3 );
-            TS_ASSERT( sign.computePolarity() == 0.2 );
+          SignConstraint sign( b, f );
+          sign.notifyLowerBound( b, -2 );
+          sign.notifyUpperBound( b, 3 );
+          TS_ASSERT( sign.computePolarity() == 0.2 );
 
-            sign.updateDirection();
-            TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
+          sign.updateDirection();
+          TS_ASSERT( sign.getDirection() == SIGN_PHASE_POSITIVE );
 
-            auto splits = sign.getCaseSplits();
-            auto it = splits.begin();
-            TS_ASSERT( isPositiveSplit( b, f, it ) );
+          auto splits = sign.getCaseSplits();
+          auto it = splits.begin();
+          TS_ASSERT( isPositiveSplit( b, f, it ) );
         }
-    }
+      }
 
-    void test_initialization_of_CDOs()
-    {
+      void test_initialization_of_CDOs()
+      {
         Context context;
         SignConstraint *sign1 = new SignConstraint( 4, 6 );
 
@@ -1031,15 +1296,15 @@ public:
 
 
         TS_ASSERT_THROWS_NOTHING( delete sign1 );
-    }
+      }
 
-    /*
-     * Test Case functionality of SignConstraint
-     * 1. Check that all cases are returned by SignConstraint::getAllCases
-     * 2. Check that SignConstraint::getCaseSplit( case ) returns the correct case
-     */
-    void test_relu_get_cases()
-    {
+      /*
+       * Test Case functionality of SignConstraint
+       * 1. Check that all cases are returned by SignConstraint::getAllCases
+       * 2. Check that SignConstraint::getCaseSplit( case ) returns the correct case
+       */
+      void test_relu_get_cases()
+      {
         SignConstraint sign( 4, 6 );
 
         List<PhaseStatus> cases = sign.getAllCases();
@@ -1052,13 +1317,13 @@ public:
         TS_ASSERT_EQUALS( splits.size(), 2u );
         TS_ASSERT_EQUALS( splits.front(), sign.getCaseSplit( SIGN_PHASE_NEGATIVE ) ) ;
         TS_ASSERT_EQUALS( splits.back(), sign.getCaseSplit( SIGN_PHASE_POSITIVE ) ) ;
-    }
+      }
 
-    /*
-      Test context-dependent Sign state behavior.
-     */
-    void test_sign_context_dependent_state()
-    {
+      /*
+        Test context-dependent Sign state behavior.
+      */
+      void test_sign_context_dependent_state()
+      {
         Context context;
         unsigned b = 1;
         unsigned f = 4;
@@ -1082,5 +1347,5 @@ public:
 
         context.pop();
         TS_ASSERT_EQUALS( sign.getPhaseStatus(), PHASE_NOT_FIXED );
-    }
+      }
 };


### PR DESCRIPTION
This PR introduces support  in the ContextDependentPiecewiseLinearConstraint 
class to store bounds using a BoundManager object. Like other context-dependent
members, once the BoundManager object is registered, all the bounds are stored and 
retrieved through the BoundManager.

This PR introduces methods to interface between local and global means of
 storing bounds. For this purpose the following methods are introduced in
ContextDependentPiecewiseLinearConstraint class:

bool existsLowerBound( unsigned variable );
unsigned getLowerBound( unsigned variable );
void setLowerBound( unsigned variable );
bool existsUpperBound( unsigned variable );
unsigned getUpperBound( unsigned variable );
void setUpperBound( unsigned variable );

All calls to check, read or write local bound arrays are replaced with calls to
the introduced wrapper methods in all the constraint classes:
 * AbsoluteValueConstraint
 * DisjunctionConstraint
 * MaxConstraint
 * ReluConstraint
 * SignConstraint
    
Respective test classes have been updated to include existing tests in both the
preprocessing and context-dependent mode, preserving existing functionality.

Finally, all modified files have also been reformatted to conform to the style
guidelines. 