### PR TITLE
move binding of EquationType

### DIFF
--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -488,15 +488,15 @@ PYBIND11_MODULE(MarabouCore, m) {
         .value("Disjunction", PiecewiseLinearFunctionType::DISJUNCTION)
         .export_values();
     py::class_<Equation> eq(m, "Equation");
-    eq.def(py::init());
-    eq.def(py::init<Equation::EquationType>());
-    eq.def("addAddend", &Equation::addAddend);
-    eq.def("setScalar", &Equation::setScalar);
     py::enum_<Equation::EquationType>(eq, "EquationType")
         .value("EQ", Equation::EquationType::EQ)
         .value("GE", Equation::EquationType::GE)
         .value("LE", Equation::EquationType::LE)
         .export_values();
+    eq.def(py::init());
+    eq.def(py::init<Equation::EquationType>());
+    eq.def("addAddend", &Equation::addAddend);
+    eq.def("setScalar", &Equation::setScalar);
     py::class_<Statistics>(m, "Statistics")
         .def("getMaxStackDepth", &Statistics::getMaxStackDepth)
         .def("getNumPops", &Statistics::getNumPops)

--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -354,6 +354,27 @@ InputQuery loadQuery(std::string filename){
 // Describes which classes and functions are exposed to API
 PYBIND11_MODULE(MarabouCore, m) {
     m.doc() = "Maraboupy bindings to the C++ Marabou via pybind11";
+    py::class_<MarabouOptions>(m, "Options")
+        .def(py::init())
+        .def_readwrite("_numWorkers", &MarabouOptions::_numWorkers)
+        .def_readwrite("_initialTimeout", &MarabouOptions::_initialTimeout)
+        .def_readwrite("_initialDivides", &MarabouOptions::_initialDivides)
+        .def_readwrite("_onlineDivides", &MarabouOptions::_onlineDivides)
+        .def_readwrite("_timeoutInSeconds", &MarabouOptions::_timeoutInSeconds)
+        .def_readwrite("_timeoutFactor", &MarabouOptions::_timeoutFactor)
+        .def_readwrite("_preprocessorBoundTolerance", &MarabouOptions::_preprocessorBoundTolerance)
+        .def_readwrite("_milpSolverTimeout", &MarabouOptions::_milpSolverTimeout)
+        .def_readwrite("_verbosity", &MarabouOptions::_verbosity)
+        .def_readwrite("_splitThreshold", &MarabouOptions::_splitThreshold)
+        .def_readwrite("_snc", &MarabouOptions::_snc)
+        .def_readwrite("_solveWithMILP", &MarabouOptions::_solveWithMILP)
+        .def_readwrite("_dumpBounds", &MarabouOptions::_dumpBounds)
+        .def_readwrite("_restoreTreeStates", &MarabouOptions::_restoreTreeStates)
+        .def_readwrite("_splittingStrategy", &MarabouOptions::_splittingStrategyString)
+        .def_readwrite("_sncSplittingStrategy", &MarabouOptions::_sncSplittingStrategyString)
+        .def_readwrite("_tighteningStrategy", &MarabouOptions::_tighteningStrategyString)
+        .def_readwrite("_milpTightening", &MarabouOptions::_milpTighteningString)
+        .def_readwrite("_numSimulations", &MarabouOptions::_numSimulations);
     m.def("createInputQuery", &createInputQuery, "Create input query from network and property file");
     m.def("preprocess", &preprocess, R"pbdoc(
          Takes a reference to an InputQuery and preproccesses it with Marabou preprocessor.
@@ -460,27 +481,6 @@ PYBIND11_MODULE(MarabouCore, m) {
         .def("markInputVariable", &InputQuery::markInputVariable)
         .def("markOutputVariable", &InputQuery::markOutputVariable)
         .def("outputVariableByIndex", &InputQuery::outputVariableByIndex);
-    py::class_<MarabouOptions>(m, "Options")
-        .def(py::init())
-        .def_readwrite("_numWorkers", &MarabouOptions::_numWorkers)
-        .def_readwrite("_initialTimeout", &MarabouOptions::_initialTimeout)
-        .def_readwrite("_initialDivides", &MarabouOptions::_initialDivides)
-        .def_readwrite("_onlineDivides", &MarabouOptions::_onlineDivides)
-        .def_readwrite("_timeoutInSeconds", &MarabouOptions::_timeoutInSeconds)
-        .def_readwrite("_timeoutFactor", &MarabouOptions::_timeoutFactor)
-        .def_readwrite("_preprocessorBoundTolerance", &MarabouOptions::_preprocessorBoundTolerance)
-        .def_readwrite("_milpSolverTimeout", &MarabouOptions::_milpSolverTimeout)
-        .def_readwrite("_verbosity", &MarabouOptions::_verbosity)
-        .def_readwrite("_splitThreshold", &MarabouOptions::_splitThreshold)
-        .def_readwrite("_snc", &MarabouOptions::_snc)
-        .def_readwrite("_solveWithMILP", &MarabouOptions::_solveWithMILP)
-        .def_readwrite("_dumpBounds", &MarabouOptions::_dumpBounds)
-        .def_readwrite("_restoreTreeStates", &MarabouOptions::_restoreTreeStates)
-        .def_readwrite("_splittingStrategy", &MarabouOptions::_splittingStrategyString)
-        .def_readwrite("_sncSplittingStrategy", &MarabouOptions::_sncSplittingStrategyString)
-        .def_readwrite("_tighteningStrategy", &MarabouOptions::_tighteningStrategyString)
-        .def_readwrite("_milpTightening", &MarabouOptions::_milpTighteningString)
-        .def_readwrite("_numSimulations", &MarabouOptions::_numSimulations);
     py::enum_<PiecewiseLinearFunctionType>(m, "PiecewiseLinearFunctionType")
         .value("ReLU", PiecewiseLinearFunctionType::RELU)
         .value("AbsoluteValue", PiecewiseLinearFunctionType::ABSOLUTE_VALUE)


### PR DESCRIPTION
it is necessary for tools like pybind11-stubgen to generate the stubs correctly, because EquationType is used in Equation::init