### PR TITLE
Add BoundManager to RowBoundTightener and Tableau

### DIFF
--- a/src/engine/RowBoundTightener.h
+++ b/src/engine/RowBoundTightener.h
@@ -16,6 +16,7 @@
 #ifndef __RowBoundTightener_h__
 #define __RowBoundTightener_h__
 
+#include "BoundManager.h"
 #include "Equation.h"
 #include "IRowBoundTightener.h"
 #include "ITableau.h"
@@ -50,6 +51,55 @@ public:
     */
     void notifyLowerBound( unsigned variable, double bound );
     void notifyUpperBound( unsigned variable, double bound );
+
+    /*
+       Method obtains lower bound of *var*.
+     */
+    inline double getLowerBound( unsigned var ) const
+    {
+        return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( var )
+                                            : _lowerBounds[var];
+    }
+
+    /*
+       Method obtains upper bound of *var*.
+     */
+    inline double getUpperBound( unsigned var ) const
+    {
+        return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( var )
+                                            : _upperBounds[var];
+    }
+
+    /*
+       Method sets the lower bound of *var* to *value*.
+     */
+    inline void setLowerBound( unsigned var, double value )
+    {
+        ( _boundManager != nullptr ) ? _boundManager->setLowerBound( var, value )
+                                     : _lowerBounds[var] = value;
+    }
+
+    /*
+       Method sets the upper bound of *var* to *value*.
+     */
+    inline void setUpperBound( unsigned var, double value )
+    {
+        ( _boundManager != nullptr ) ? _boundManager->setUpperBound( var, value )
+                                     : _upperBounds[var] = value;
+    }
+
+    /*
+     * Local register new bound functions
+     * NOTE: Used post integration, currently these methods are not used anywhere atm.
+     */
+    inline unsigned registerTighterLowerBound( unsigned variable, double newLowerBound)
+    {
+        return _boundManager->tightenLowerBound( variable, newLowerBound ) ? 1u : 0u;
+    }
+    inline unsigned registerTighterUpperBound( unsigned variable, double newLowerBound)
+    {
+        return _boundManager->tightenUpperBound( variable, newLowerBound ) ? 1u : 0u;
+    }
 
     /*
       Callback from the Tableau, to inform of a change in dimensions
@@ -113,6 +163,7 @@ private:
     double *_upperBounds;
     bool *_tightenedLower;
     bool *_tightenedUpper;
+    BoundManager *_boundManager;
 
     /*
       Work space for the inverted basis matrix tighteners

--- a/src/engine/RowBoundTightener.h
+++ b/src/engine/RowBoundTightener.h
@@ -163,6 +163,11 @@ private:
     double *_upperBounds;
     bool *_tightenedLower;
     bool *_tightenedUpper;
+
+    /*
+       BoundManager object stores bounds of all variables.
+       NOT YET IN USE
+     */
     BoundManager *_boundManager;
 
     /*

--- a/src/engine/Tableau.cpp
+++ b/src/engine/Tableau.cpp
@@ -53,6 +53,7 @@ Tableau::Tableau()
     , _nonBasicAssignment( NULL )
     , _lowerBounds( NULL )
     , _upperBounds( NULL )
+    , _boundManager( nullptr )
     , _boundsValid( true )
     , _basicAssignment( NULL )
     , _basicStatus( NULL )
@@ -470,7 +471,10 @@ void Tableau::computeBasicStatus( unsigned basicIndex )
 void Tableau::setLowerBound( unsigned variable, double value )
 {
     ASSERT( variable < _n );
-    _lowerBounds[variable] = value;
+    if ( _boundManager !=  nullptr )
+        _boundManager->setLowerBound( variable, value );
+    else
+        _lowerBounds[variable] = value;
     notifyLowerBound( variable, value );
     checkBoundsValid( variable );
 }
@@ -478,7 +482,10 @@ void Tableau::setLowerBound( unsigned variable, double value )
 void Tableau::setUpperBound( unsigned variable, double value )
 {
     ASSERT( variable < _n );
-    _upperBounds[variable] = value;
+    if ( _boundManager !=  nullptr )
+        _boundManager->setUpperBound( variable, value );
+    else
+        _upperBounds[variable] = value;
     notifyUpperBound( variable, value );
     checkBoundsValid( variable );
 }
@@ -486,13 +493,15 @@ void Tableau::setUpperBound( unsigned variable, double value )
 double Tableau::getLowerBound( unsigned variable ) const
 {
     ASSERT( variable < _n );
-    return _lowerBounds[variable];
+    return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( variable )
+                                        : _lowerBounds[variable];
 }
 
 double Tableau::getUpperBound( unsigned variable ) const
 {
     ASSERT( variable < _n );
-    return _upperBounds[variable];
+    return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( variable )
+                                        : _upperBounds[variable];
 }
 
 const double *Tableau::getLowerBounds() const

--- a/src/engine/Tableau.h
+++ b/src/engine/Tableau.h
@@ -16,6 +16,7 @@
 #ifndef __Tableau_h__
 #define __Tableau_h__
 
+#include "BoundManager.h"
 #include "IBasisFactorization.h"
 #include "ITableau.h"
 #include "MString.h"
@@ -548,6 +549,12 @@ private:
     */
     double *_lowerBounds;
     double *_upperBounds;
+
+    /*
+       BoundManager object stores bounds of all variables.
+       NOT YET IN USE
+     */
+    BoundManager *_boundManager;
 
     /*
       Whether all variables have valid bounds (l <= u).


### PR DESCRIPTION
This PR adds a BoundManager member to RowBoundTightener and Tableau with with get/set methods that allow smooth semantic switch between local and centralized bound management.

ConstraintBoundTightener is not updated, since it will be subsumed by a central BoundManager.