### PR TITLE
Context-dependent SmtCore

### DIFF
--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -501,7 +501,7 @@ PYBIND11_MODULE(MarabouCore, m) {
     eq.def("addAddend", &Equation::addAddend);
     eq.def("setScalar", &Equation::setScalar);
     py::class_<Statistics>(m, "Statistics")
-        .def("getMaxStackDepth", &Statistics::getMaxStackDepth)
+        .def("getMaxStackDepth", &Statistics::getMaxDecisionLevel)
         .def("getNumPops", &Statistics::getNumPops)
         .def("getNumVisitedTreeStates", &Statistics::getNumVisitedTreeStates)
         .def("getNumSplits", &Statistics::getNumSplits)

--- a/src/common/Statistics.cpp
+++ b/src/common/Statistics.cpp
@@ -31,8 +31,8 @@ Statistics::Statistics()
     , _timeMainLoopMicro( 0 )
     , _timeConstraintFixingStepsMicro( 0 )
     , _numConstraintFixingSteps( 0 )
-    , _currentStackDepth( 0 )
-    , _maxStackDepth( 0 )
+    , _currentDecisionLevel( 0 )
+    , _maxDecisionLevel( 0 )
     , _numSplits( 0 )
     , _numPops( 0 )
     , _numVisitedTreeStates( 1 )
@@ -248,12 +248,12 @@ void Statistics::print()
 
     printf( "\t--- SMT Core Statistics ---\n" );
     printf( "\tTotal depth is %u. Total visited states: %u. Number of splits: %u. Number of pops: %u\n"
-            , _currentStackDepth
+            , _currentDecisionLevel
             , _numVisitedTreeStates
             , _numSplits
             , _numPops );
     printf( "\tMax stack depth: %u\n"
-            , _maxStackDepth );
+            , _maxDecisionLevel );
 
     printf( "\t--- Bound Tightening Statistics ---\n" );
     printf( "\tNumber of tightened bounds: %llu.\n", _numTightenedBounds );
@@ -365,17 +365,17 @@ unsigned long long Statistics::getNumMainLoopIterations() const
     return _numMainLoopIterations;
 }
 
-void Statistics::setCurrentStackDepth( unsigned depth )
+void Statistics::setCurrentDecisionLevel( unsigned decisionLevel )
 {
-    _currentStackDepth = depth;
+    _currentDecisionLevel = decisionLevel;
 
-    if ( _currentStackDepth > _maxStackDepth )
-        _maxStackDepth = _currentStackDepth;
+    if ( _currentDecisionLevel > _maxDecisionLevel )
+        _maxDecisionLevel = _currentDecisionLevel;
 }
 
-unsigned Statistics::getMaxStackDepth() const
+unsigned Statistics::getMaxDecisionLevel() const
 {
-    return _maxStackDepth;
+    return _maxDecisionLevel;
 }
 
 void Statistics::incNumSplits()

--- a/src/common/Statistics.h
+++ b/src/common/Statistics.h
@@ -89,12 +89,12 @@ public:
     /*
       Smt core related statistics.
     */
-    void setCurrentStackDepth( unsigned depth );
+    void setCurrentDecisionLevel( unsigned depth );
     void incNumSplits();
     void incNumPops();
     void addTimeSmtCore( unsigned long long time );
     void incNumVisitedTreeStates();
-    unsigned getMaxStackDepth() const;
+    unsigned getMaxDecisionLevel() const;
     unsigned getNumPops() const;
     unsigned getNumVisitedTreeStates() const;
     unsigned getNumSplits() const;
@@ -188,8 +188,8 @@ private:
     unsigned long long _numConstraintFixingSteps;
 
     // Current and max stack depth in the SMT core
-    unsigned _currentStackDepth;
-    unsigned _maxStackDepth;
+    unsigned _currentDecisionLevel;
+    unsigned _maxDecisionLevel;
 
     // Total number of splits so far
     unsigned _numSplits;

--- a/src/engine/CDSmtCore.cpp
+++ b/src/engine/CDSmtCore.cpp
@@ -302,7 +302,7 @@ void CDSmtCore::interruptIfCompliantWithDebugSolution()
 }
 
 
-PiecewiseLinearCaseSplit CDSmtCore::getDecision( unsigned decisionLevel )
+PiecewiseLinearCaseSplit CDSmtCore::getDecision( unsigned decisionLevel ) const
 {
     ASSERT( decisionLevel <= getDecisionLevel() );
     ASSERT( decisionLevel > 0 );

--- a/src/engine/CDSmtCore.cpp
+++ b/src/engine/CDSmtCore.cpp
@@ -2,7 +2,7 @@
 /*! \file CDSmtCore.cpp
  ** \verbatim
  ** Top contributors (to current version):
- **   Guy Katz, Aleksandar Zeljic,  Parth Shah
+ **   Guy Katz, Aleksandar Zeljic, Parth Shah
  ** This file is part of the Marabou project.
  ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
@@ -131,7 +131,7 @@ void CDSmtCore::decide()
     decideSplit( _constraintForSplitting );
 }
 
-void CDSmtCore::decideSplit( PiecewiseLinearConstraint * constraint )
+void CDSmtCore::decideSplit( PiecewiseLinearConstraint *constraint )
 {
     struct timespec start = TimeUtils::sampleMicro();
 

--- a/src/engine/CDSmtCore.cpp
+++ b/src/engine/CDSmtCore.cpp
@@ -306,16 +306,9 @@ bool CDSmtCore::checkSkewFromDebuggingSolution()
         }
         else
         {
-            // If the active split is non-compliant but there are alternatives, that's fine
+            // If the active split is non-compliant but there are alternatives, i.e. it was a decision, that's fine
             if ( isDecision && !splitAllowsStoredSolution( caseSplit, error ) )
             {
-                if ( !trailEntry.isFeasible() )
-                {
-                    printf( "Error! Have a split that is non-compliant with the stored solution, "
-                            "without alternatives:\n\t%s\n", error.ascii() );
-                    throw MarabouError( MarabouError::DEBUGGING_ERROR );
-                }
-
                 // Active split is non-compliant but this is fine, because there are alternatives. We're done.
                 return false;
             }

--- a/src/engine/CDSmtCore.cpp
+++ b/src/engine/CDSmtCore.cpp
@@ -1,0 +1,541 @@
+/*********************                                                        */
+/*! \file CDSmtCore.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Aleksandar Zeljic, Guy Katz, Parth Shah, Duligur Ibeling
+ ** This file is part of the Marabou project.
+ ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved. See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** The CDSmtCore implements a CDCL-style loop, using context-dependent data types
+ ** and state-based PiecewiseLinearConstraint to store the search state in an
+ ** incremental and easy-to-backtrack way.
+
+ **/
+
+#include "Debug.h"
+#include "DivideStrategy.h"
+#include "EngineState.h"
+#include "FloatUtils.h"
+#include "GlobalConfiguration.h"
+#include "IEngine.h"
+#include "MStringf.h"
+#include "MarabouError.h"
+#include "ReluConstraint.h"
+#include "CDSmtCore.h"
+
+using namespace CVC4::context;
+
+CDSmtCore::CDSmtCore( IEngine *engine, Context &ctx )
+    : _statistics( NULL )
+    , _context( ctx )
+    , _trail( &_context )
+    , _decisions( &_context)
+    , _engine( engine )
+    , _needToSplit( false )
+    , _constraintForSplitting( NULL )
+    , _stateId( 0 )
+    , _constraintViolationThreshold
+      ( Options::CONSTRAINT_VIOLATION_THRESHOLD )
+{
+}
+
+CDSmtCore::~CDSmtCore()
+{
+}
+
+void CDSmtCore::reportViolatedConstraint( PiecewiseLinearConstraint *constraint )
+{
+    ASSERT( !constraint->phaseFixed() );
+
+    if ( !_constraintToViolationCount.exists( constraint ) )
+        _constraintToViolationCount[constraint] = 0;
+
+    ++_constraintToViolationCount[constraint];
+
+    if ( _constraintToViolationCount[constraint] >=
+         _constraintViolationThreshold )
+    {
+        _needToSplit = true;
+        if ( GlobalConfiguration::SPLITTING_HEURISTICS ==
+             DivideStrategy::ReLUViolation || !pickSplitPLConstraint() )
+            // If pickSplitConstraint failed to pick one, use the native
+            // relu-violation based splitting heuristic.
+            _constraintForSplitting = constraint;
+        ASSERT( !_constraintForSplitting->phaseFixed() );
+    }
+}
+
+unsigned CDSmtCore::getViolationCounts( PiecewiseLinearConstraint *constraint ) const
+{
+    if ( !_constraintToViolationCount.exists( constraint ) )
+        return 0;
+
+    return _constraintToViolationCount[constraint];
+}
+
+bool CDSmtCore::needToSplit() const
+{
+    return _needToSplit;
+}
+
+void CDSmtCore::pushDecision( PiecewiseLinearConstraint *constraint,  PhaseStatus decision )
+{
+    //ASSERT( static_cast<size_t>( _context.getLevel() ) == _decisions.size() );
+    SMT_LOG( "New decision level ..." );
+
+    _context.push();
+
+    TrailEntry te( constraint, decision );
+    _trail.push_back(te);
+    _decisions.push_back( te );
+
+    _engine->applySplit( constraint->getCaseSplit( decision ) );
+
+    SMT_LOG( Stringf( "Decision push @ %d DONE", _context.getLevel() ).ascii() );
+    //ASSERT( static_cast<size_t>( _context.getLevel() ) == _decisions.size() );
+}
+
+void CDSmtCore::pushImplication( PiecewiseLinearConstraint *constraint, PhaseStatus phase )
+{
+    SMT_LOG( Stringf( "Push implication on trail @%d ... ", _context.getLevel() ).ascii() );
+
+    TrailEntry te( constraint, phase );
+
+    _trail.push_back(te);
+
+    _engine->applySplit( constraint->getCaseSplit( phase ) );
+
+    SMT_LOG( "Push implication on trail DONE"  );
+}
+
+void CDSmtCore::decide()
+{
+    ASSERT( _needToSplit );
+    SMT_LOG( "Performing a ReLU split" );
+
+    // Maybe the constraint has already become inactive - if so, ignore
+    // TODO: Ideally we will not ever reach this point
+    // This should be a list of all constraints above the threshold
+    // If one is no longer active, we should proceed with the next one
+    if ( !_constraintForSplitting->isActive() )
+        {
+            _needToSplit = false;
+            _constraintToViolationCount[_constraintForSplitting] = 0;
+            _constraintForSplitting = nullptr;
+            return;
+    }
+
+    ASSERT( _constraintForSplitting->isActive() );
+    _needToSplit = false;
+    _constraintForSplitting->setActiveConstraint( false );
+
+    decideSplit( _constraintForSplitting );
+}
+
+void CDSmtCore::decideSplit( PiecewiseLinearConstraint * constraint )
+{
+    struct timespec start = TimeUtils::sampleMicro();
+
+    if ( _statistics )
+    {
+        _statistics->incNumSplits();
+        _statistics->incNumVisitedTreeStates();
+    }
+
+    if ( !constraint->isFeasible() )
+        throw MarabouError( MarabouError::DEBUGGING_ERROR );
+    ASSERT( constraint->isFeasible() );
+
+    ASSERT( !constraint->isImplication() );
+
+    // TODO: DecisionMakingLogic
+    PhaseStatus decision = constraint->nextFeasibleCase();
+    pushDecision( constraint, decision );
+
+    if ( _statistics )
+    {
+        _statistics->setCurrentDecisionLevel( _context.getLevel() );
+        struct timespec end = TimeUtils::sampleMicro();
+        _statistics->addTimeSmtCore( TimeUtils::timePassed( start, end ) );
+    }
+    SMT_LOG( "Performing a ReLU split - DONE");
+}
+
+
+// bool CDSmtCore::checkStackTrailEquivalence()
+// {
+//     std::cout << "Checking STEQ ... ";
+//     bool result = true;
+//     // Trail post-condition: TRAIL - STACK equivalence
+//     // How are things present on the stack?
+//     List<PiecewiseLinearCaseSplit> stackCaseSplits;
+//     allSplitsSoFar( stackCaseSplits );
+
+//     std::cout << "Collected all splits on stack" <<std::endl;
+//     List<PiecewiseLinearCaseSplit> trailCaseSplits;
+//     std::cout << "Trail size: " << _trail.size() <<std::endl;
+//     for ( TrailEntry trailEntry : _trail )
+//         trailCaseSplits.append( trailEntry.getPiecewiseLinearCaseSplit() );
+
+//     std::cout << "Collected case splits: " << trailCaseSplits.size() <<std::endl;
+//     std::cout << "Collected all splits on trail" <<std::endl;
+//    // Equivalence check, assumes the order of stack and trail is identical
+//     result = result && ( trailCaseSplits.size() == stackCaseSplits.size() );
+
+//     if ( !result )
+//     {
+//         std::cout << "ASSERTION VIOLATION: ";
+//         std::cout << "Trail ( " << trailCaseSplits.size();
+//         std::cout << ")and Stack (" << stackCaseSplits.size();
+//         std::cout << ") have different number of elements!" << std::endl;
+
+//         std::cout << "Trail:" << std::endl;
+//         for ( auto split : trailCaseSplits )
+//             split.dump();
+
+//         std::cout << "Stack:" << std::endl;
+//         for ( auto split : stackCaseSplits )
+//             split.dump();
+
+//     }
+
+//     std::cout << "Size matches!" <<std::endl;
+//     PiecewiseLinearCaseSplit tCaseSplit, sCaseSplit;
+//     int ind = trailCaseSplits.size();
+//     while ( result && !stackCaseSplits.empty() )
+//     {
+//         tCaseSplit = trailCaseSplits.back();
+//         sCaseSplit = stackCaseSplits.back();
+//         result = result && ( tCaseSplit == sCaseSplit );
+//         if ( !result )
+//         {
+//             std::cout << "FAILED at position " << ind << "!!!!" <<std::endl;
+//             std::cout << "Trail case split: ";
+//             tCaseSplit.dump();
+
+//             auto sloc = find_if( stackCaseSplits.begin(),
+//                                 stackCaseSplits.end(),
+//                                 [&](PiecewiseLinearCaseSplit c) { return c == tCaseSplit; } );
+
+//             if ( stackCaseSplits.end() == sloc )
+//                 std::cout << "Missing from the stack!" << std::endl;
+
+//             std::cout << "Stack case split: ";
+//             sCaseSplit.dump();
+//             auto tloc = find_if( trailCaseSplits.begin(),
+//                                 trailCaseSplits.end(),
+//                                 [&](PiecewiseLinearCaseSplit c) { return c == sCaseSplit; } );
+
+//             if ( trailCaseSplits.end() == tloc )
+//                 std::cout << "Missing from the trail!" << std::endl;
+
+//         }
+
+//         --ind;
+
+//         trailCaseSplits.popBack();
+//         stackCaseSplits.popBack();
+//     }
+
+//     if ( result )
+//         std::cout << "OK" << std::endl;
+//     std::cout << "--------------------------------------------------------" << std::endl;
+//     return result;
+// }
+
+
+
+// bool CDSmtCore::popSplit()
+// {
+//     if ( _stack.empty() )
+//         return false;
+
+//     if ( _statistics )
+//         _statistics->incNumPops();
+
+//     delete _stack.back()->_engineState;
+//     delete _stack.back();
+//     _stack.popBack();
+//     return true;
+// }
+
+// bool CDSmtCore::popSplitFromStack( List<PiecewiseLinearCaseSplit> &alternativeSplits )
+// {
+//     alternativeSplits.clear();
+//     alternativeSplits.assign( _stack.back()->_alternativeSplits.begin(), _stack.back()->_alternativeSplits.end() );
+
+//     return popSplit();
+// }
+
+unsigned CDSmtCore::getDecisionLevel() const
+{
+    //ASSERT ( (int)( _decisions.size() ) == (int)( _context.getLevel() ) );
+    return _decisions.size();
+}
+
+//TODO _decision bookkeeping
+bool CDSmtCore::popDecisionLevel( TrailEntry &lastDecision )
+{
+    //ASSERT( static_cast<size_t>( _context.getLevel() ) == _decisions.size() );
+    if ( _decisions.empty() )
+        return false;
+
+    SMT_LOG( "Backtracking context ..." );
+
+    lastDecision = _decisions.back();
+
+    _context.pop();
+    //ASSERT( static_cast<size_t>( _context.getLevel() ) == _decisions.size() );
+    _engine->recomputeBasicStatus();
+    SMT_LOG( Stringf( "Backtracking context - %d DONE", _context.getLevel() ).ascii() );
+    return true;
+}
+
+void CDSmtCore::interruptIfCompliantWithDebugSolution()
+{
+    if ( checkSkewFromDebuggingSolution() )
+    {
+        SMT_LOG( "Error! Popping from a compliant stack\n" );
+        throw MarabouError( MarabouError::DEBUGGING_ERROR );
+    }
+}
+
+
+PiecewiseLinearCaseSplit CDSmtCore::getDecision( unsigned decisionLevel )
+{
+    ASSERT( decisionLevel <= getDecisionLevel() );
+    ASSERT( decisionLevel > 0 );
+    return _decisions[decisionLevel - 1].getPiecewiseLinearCaseSplit() ;
+}
+
+bool CDSmtCore::backtrackAndContinue()
+{
+    SMT_LOG( "Performing a pop" );
+
+    if ( getDecisionLevel() == 0 )
+        return false;
+
+    struct timespec start = TimeUtils::sampleMicro();
+
+    if ( _statistics )
+        _statistics->incNumVisitedTreeStates();
+
+    TrailEntry lastDecision( NULL, PHASE_NOT_FIXED );
+
+    popDecisionLevel( lastDecision );
+    lastDecision.markInfeasible();
+
+    while ( !lastDecision._pwlConstraint->isFeasible() )
+    {
+        interruptIfCompliantWithDebugSolution();
+
+        if ( !popDecisionLevel( lastDecision ) )
+            return false;
+
+        lastDecision.markInfeasible();
+    }
+
+    interruptIfCompliantWithDebugSolution();
+
+    PiecewiseLinearConstraint *pwlc = lastDecision._pwlConstraint;
+    ASSERT( pwlc->isFeasible() );
+
+    if ( pwlc->isImplication() )
+        pushImplication( pwlc, pwlc->nextFeasibleCase() );
+    else
+        decideSplit( pwlc );
+
+    if ( _statistics )
+    {
+        _statistics->setCurrentDecisionLevel( getDecisionLevel() );
+        struct timespec end = TimeUtils::sampleMicro();
+        _statistics->addTimeSmtCore( TimeUtils::timePassed( start, end ) );
+    }
+
+    checkSkewFromDebuggingSolution();
+    return true;
+}
+
+void CDSmtCore::resetReportedViolations()
+{
+    _constraintToViolationCount.clear();
+    _needToSplit = false;
+}
+
+void CDSmtCore::allSplitsSoFar( List<PiecewiseLinearCaseSplit> &result ) const
+{
+    result.clear();
+
+    for ( auto trailEntry : _trail )
+        result.append( trailEntry.getPiecewiseLinearCaseSplit() );
+}
+
+void CDSmtCore::setStatistics( Statistics *statistics )
+{
+    _statistics = statistics;
+}
+
+void CDSmtCore::storeDebuggingSolution( const Map<unsigned, double> &debuggingSolution )
+{
+    _debuggingSolution = debuggingSolution;
+}
+
+// Return true if stack is currently compliant, false otherwise
+// If there is no stored solution, return false --- incompliant.
+bool CDSmtCore::checkSkewFromDebuggingSolution()
+{
+    if ( _debuggingSolution.empty() )
+        return false;
+
+    String error;
+
+    // First check that the valid splits implied at the root level are okay
+    for ( const auto &split : _impliedValidSplitsAtRoot )
+    {
+        if ( !splitAllowsStoredSolution( split, error ) )
+        {
+            printf( "Error with one of the splits implied at root level:\n\t%s\n", error.ascii() );
+            throw MarabouError( MarabouError::DEBUGGING_ERROR );
+        }
+    }
+
+    // Now go over the stack from oldest to newest and check that each level is compliant
+    // for ( const auto &stackEntry : _stack )
+    // {
+    //     // If the active split is non-compliant but there are alternatives, that's fine
+    //     if ( !splitAllowsStoredSolution( stackEntry->_activeSplit, error ) )
+    //     {
+    //         if ( stackEntry->_alternativeSplits.empty() )
+    //         {
+    //             printf( "Error! Have a split that is non-compliant with the stored solution, "
+    //                     "without alternatives:\n\t%s\n", error.ascii() );
+    //             throw MarabouError( MarabouError::DEBUGGING_ERROR );
+    //         }
+
+    //         // Active split is non-compliant but this is fine, because there are alternatives. We're done.
+    //         return false;
+    //     }
+
+    //     // Did we learn any valid splits that are non-compliant?
+    //     for ( auto const &split : stackEntry->_impliedValidSplits )
+    //     {
+    //         if ( !splitAllowsStoredSolution( split, error ) )
+    //         {
+    //             printf( "Error with one of the splits implied at this stack level:\n\t%s\n",
+    //                     error.ascii() );
+    //             throw MarabouError( MarabouError::DEBUGGING_ERROR );
+    //         }
+    //     }
+    // }
+
+    // No problems were detected, the stack is compliant with the stored solution
+    return true;
+}
+
+bool CDSmtCore::splitAllowsStoredSolution( const PiecewiseLinearCaseSplit &split, String &error ) const
+{
+    // False if the split prevents one of the values in the stored solution, true otherwise.
+    error = "";
+    if ( _debuggingSolution.empty() )
+        return true;
+
+    for ( const auto bound : split.getBoundTightenings() )
+    {
+        unsigned variable = bound._variable;
+
+        // If the possible solution doesn't care about this variable,
+        // ignore it
+        if ( !_debuggingSolution.exists( variable ) )
+            continue;
+
+        // Otherwise, check that the bound is consistent with the solution
+        double solutionValue = _debuggingSolution[variable];
+        double boundValue = bound._value;
+
+        if ( ( bound._type == Tightening::LB ) && FloatUtils::gt( boundValue, solutionValue ) )
+        {
+            error = Stringf( "Variable %u: new LB is %.5lf, which contradicts possible solution %.5lf",
+                             variable,
+                             boundValue,
+                             solutionValue );
+            return false;
+        }
+        else if ( ( bound._type == Tightening::UB ) && FloatUtils::lt( boundValue, solutionValue ) )
+        {
+            error = Stringf( "Variable %u: new UB is %.5lf, which contradicts possible solution %.5lf",
+                             variable,
+                             boundValue,
+                             solutionValue );
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void CDSmtCore::setConstraintViolationThreshold( unsigned threshold )
+{
+    _constraintViolationThreshold = threshold;
+}
+
+PiecewiseLinearConstraint *CDSmtCore::chooseViolatedConstraintForFixing( List<PiecewiseLinearConstraint *> &_violatedPlConstraints ) const
+{
+    ASSERT( !_violatedPlConstraints.empty() );
+
+    if ( !GlobalConfiguration::USE_LEAST_FIX )
+        return *_violatedPlConstraints.begin();
+
+    PiecewiseLinearConstraint *candidate;
+
+    // Apply the least fix heuristic
+    auto it = _violatedPlConstraints.begin();
+
+    candidate = *it;
+    unsigned minFixes = getViolationCounts( candidate );
+
+    PiecewiseLinearConstraint *contender;
+    unsigned contenderFixes;
+    while ( it != _violatedPlConstraints.end() )
+    {
+        contender = *it;
+        contenderFixes = getViolationCounts( contender );
+        if ( contenderFixes < minFixes )
+        {
+            minFixes = contenderFixes;
+            candidate = contender;
+        }
+
+        ++it;
+    }
+
+    return candidate;
+}
+
+bool CDSmtCore::pickSplitPLConstraint()
+{
+    if ( _needToSplit )
+        _constraintForSplitting = _engine->pickSplitPLConstraint();
+    return _constraintForSplitting != NULL;
+}
+
+void CDSmtCore::reset()
+{
+    _context.popto( 0 );
+    _engine->recomputeBasicStatus();
+    _impliedValidSplitsAtRoot.clear();
+    _needToSplit = false;
+    _constraintForSplitting = NULL;
+    _stateId = 0;
+    _constraintToViolationCount.clear();
+}
+
+//
+// Local Variables:
+// compile-command: "make -C ../.. "
+// tags-file-name: "../../TAGS"
+// c-basic-offset: 4
+// End:
+//

--- a/src/engine/CDSmtCore.cpp
+++ b/src/engine/CDSmtCore.cpp
@@ -161,118 +161,11 @@ void CDSmtCore::decideSplit( PiecewiseLinearConstraint * constraint )
 }
 
 
-// bool CDSmtCore::checkStackTrailEquivalence()
-// {
-//     std::cout << "Checking STEQ ... ";
-//     bool result = true;
-//     // Trail post-condition: TRAIL - STACK equivalence
-//     // How are things present on the stack?
-//     List<PiecewiseLinearCaseSplit> stackCaseSplits;
-//     allSplitsSoFar( stackCaseSplits );
-
-//     std::cout << "Collected all splits on stack" <<std::endl;
-//     List<PiecewiseLinearCaseSplit> trailCaseSplits;
-//     std::cout << "Trail size: " << _trail.size() <<std::endl;
-//     for ( TrailEntry trailEntry : _trail )
-//         trailCaseSplits.append( trailEntry.getPiecewiseLinearCaseSplit() );
-
-//     std::cout << "Collected case splits: " << trailCaseSplits.size() <<std::endl;
-//     std::cout << "Collected all splits on trail" <<std::endl;
-//    // Equivalence check, assumes the order of stack and trail is identical
-//     result = result && ( trailCaseSplits.size() == stackCaseSplits.size() );
-
-//     if ( !result )
-//     {
-//         std::cout << "ASSERTION VIOLATION: ";
-//         std::cout << "Trail ( " << trailCaseSplits.size();
-//         std::cout << ")and Stack (" << stackCaseSplits.size();
-//         std::cout << ") have different number of elements!" << std::endl;
-
-//         std::cout << "Trail:" << std::endl;
-//         for ( auto split : trailCaseSplits )
-//             split.dump();
-
-//         std::cout << "Stack:" << std::endl;
-//         for ( auto split : stackCaseSplits )
-//             split.dump();
-
-//     }
-
-//     std::cout << "Size matches!" <<std::endl;
-//     PiecewiseLinearCaseSplit tCaseSplit, sCaseSplit;
-//     int ind = trailCaseSplits.size();
-//     while ( result && !stackCaseSplits.empty() )
-//     {
-//         tCaseSplit = trailCaseSplits.back();
-//         sCaseSplit = stackCaseSplits.back();
-//         result = result && ( tCaseSplit == sCaseSplit );
-//         if ( !result )
-//         {
-//             std::cout << "FAILED at position " << ind << "!!!!" <<std::endl;
-//             std::cout << "Trail case split: ";
-//             tCaseSplit.dump();
-
-//             auto sloc = find_if( stackCaseSplits.begin(),
-//                                 stackCaseSplits.end(),
-//                                 [&](PiecewiseLinearCaseSplit c) { return c == tCaseSplit; } );
-
-//             if ( stackCaseSplits.end() == sloc )
-//                 std::cout << "Missing from the stack!" << std::endl;
-
-//             std::cout << "Stack case split: ";
-//             sCaseSplit.dump();
-//             auto tloc = find_if( trailCaseSplits.begin(),
-//                                 trailCaseSplits.end(),
-//                                 [&](PiecewiseLinearCaseSplit c) { return c == sCaseSplit; } );
-
-//             if ( trailCaseSplits.end() == tloc )
-//                 std::cout << "Missing from the trail!" << std::endl;
-
-//         }
-
-//         --ind;
-
-//         trailCaseSplits.popBack();
-//         stackCaseSplits.popBack();
-//     }
-
-//     if ( result )
-//         std::cout << "OK" << std::endl;
-//     std::cout << "--------------------------------------------------------" << std::endl;
-//     return result;
-// }
-
-
-
-// bool CDSmtCore::popSplit()
-// {
-//     if ( _stack.empty() )
-//         return false;
-
-//     if ( _statistics )
-//         _statistics->incNumPops();
-
-//     delete _stack.back()->_engineState;
-//     delete _stack.back();
-//     _stack.popBack();
-//     return true;
-// }
-
-// bool CDSmtCore::popSplitFromStack( List<PiecewiseLinearCaseSplit> &alternativeSplits )
-// {
-//     alternativeSplits.clear();
-//     alternativeSplits.assign( _stack.back()->_alternativeSplits.begin(), _stack.back()->_alternativeSplits.end() );
-
-//     return popSplit();
-// }
-
 unsigned CDSmtCore::getDecisionLevel() const
 {
-    //ASSERT ( (int)( _decisions.size() ) == (int)( _context.getLevel() ) );
     return _decisions.size();
 }
 
-//TODO _decision bookkeeping
 bool CDSmtCore::popDecisionLevel( TrailEntry &lastDecision )
 {
     //ASSERT( static_cast<size_t>( _context.getLevel() ) == _decisions.size() );
@@ -280,11 +173,8 @@ bool CDSmtCore::popDecisionLevel( TrailEntry &lastDecision )
         return false;
 
     SMT_LOG( "Backtracking context ..." );
-
     lastDecision = _decisions.back();
-
     _context.pop();
-    //ASSERT( static_cast<size_t>( _context.getLevel() ) == _decisions.size() );
     _engine->recomputeBasicStatus();
     SMT_LOG( Stringf( "Backtracking context - %d DONE", _context.getLevel() ).ascii() );
     return true;

--- a/src/engine/CDSmtCore.cpp
+++ b/src/engine/CDSmtCore.cpp
@@ -173,7 +173,7 @@ bool CDSmtCore::popDecisionLevel( TrailEntry &lastDecision )
     SMT_LOG( "Popping trail ..." );
     lastDecision = _decisions.back();
     _context.pop();
-    _engine->recomputeBasicStatus();
+    _engine->postContextPopHook();
     SMT_LOG( Stringf( "to %d DONE", _context.getLevel() ).ascii() );
     return true;
 }
@@ -420,7 +420,7 @@ bool CDSmtCore::pickSplitPLConstraint()
 void CDSmtCore::reset()
 {
     _context.popto( 0 );
-    _engine->recomputeBasicStatus();
+    _engine->postContextPopHook();
     _needToSplit = false;
     _constraintForSplitting = NULL;
     _constraintToViolationCount.clear();

--- a/src/engine/CDSmtCore.cpp
+++ b/src/engine/CDSmtCore.cpp
@@ -81,32 +81,30 @@ bool CDSmtCore::needToSplit() const
 
 void CDSmtCore::pushDecision( PiecewiseLinearConstraint *constraint,  PhaseStatus decision )
 {
-    //ASSERT( static_cast<size_t>( _context.getLevel() ) == _decisions.size() );
-    SMT_LOG( "New decision level ..." );
-
-    _context.push();
-
+    SMT_LOG( Stringf( "Decision @ %d )", _context.getLevel() + 1 ).ascii() );
     TrailEntry te( constraint, decision );
-    _trail.push_back(te);
-    _decisions.push_back( te );
-
-    _engine->applySplit( constraint->getCaseSplit( decision ) );
-
+    applyTrailEntry( te, true );
     SMT_LOG( Stringf( "Decision push @ %d DONE", _context.getLevel() ).ascii() );
-    //ASSERT( static_cast<size_t>( _context.getLevel() ) == _decisions.size() );
 }
 
 void CDSmtCore::pushImplication( PiecewiseLinearConstraint *constraint, PhaseStatus phase )
 {
-    SMT_LOG( Stringf( "Push implication on trail @%d ... ", _context.getLevel() ).ascii() );
-
+    SMT_LOG( Stringf( "Implication @ %d ... ", _context.getLevel() ).ascii() );
     TrailEntry te( constraint, phase );
+    applyTrailEntry( te, false );
+    SMT_LOG( Stringf( "Implication @ %d DONE", _context.getLevel() ).ascii() );
+}
+
+void CDSmtCore::applyTrailEntry( TrailEntry &te, bool isDecision )
+{
+    if ( isDecision )
+    {
+        _context.push();
+        _decisions.push_back( te );
+    }
 
     _trail.push_back(te);
-
-    _engine->applySplit( constraint->getCaseSplit( phase ) );
-
-    SMT_LOG( "Push implication on trail DONE"  );
+    _engine->applySplit( te.getPiecewiseLinearCaseSplit() );
 }
 
 void CDSmtCore::decide()

--- a/src/engine/CDSmtCore.cpp
+++ b/src/engine/CDSmtCore.cpp
@@ -34,7 +34,6 @@ CDSmtCore::CDSmtCore( IEngine *engine, Context &ctx )
     , _engine( engine )
     , _needToSplit( false )
     , _constraintForSplitting( NULL )
-    , _stateId( 0 )
     , _constraintViolationThreshold
       ( Options::CONSTRAINT_VIOLATION_THRESHOLD )
 {
@@ -416,10 +415,8 @@ void CDSmtCore::reset()
 {
     _context.popto( 0 );
     _engine->recomputeBasicStatus();
-    _impliedValidSplitsAtRoot.clear();
     _needToSplit = false;
     _constraintForSplitting = NULL;
-    _stateId = 0;
     _constraintToViolationCount.clear();
 }
 

--- a/src/engine/CDSmtCore.cpp
+++ b/src/engine/CDSmtCore.cpp
@@ -30,7 +30,7 @@ CDSmtCore::CDSmtCore( IEngine *engine, Context &ctx )
     : _statistics( NULL )
     , _context( ctx )
     , _trail( &_context )
-    , _decisions( &_context)
+    , _decisions( &_context )
     , _engine( engine )
     , _needToSplit( false )
     , _constraintForSplitting( NULL )
@@ -103,7 +103,7 @@ void CDSmtCore::applyTrailEntry( TrailEntry &te, bool isDecision )
         _decisions.push_back( te );
     }
 
-    _trail.push_back(te);
+    _trail.push_back( te );
     _engine->applySplit( te.getPiecewiseLinearCaseSplit() );
 }
 
@@ -117,11 +117,11 @@ void CDSmtCore::decide()
     // TODO: Maintain a vector of constraints above the threshold
     //       Iterate until we find an active one
     if ( !_constraintForSplitting->isActive() )
-        {
-            _needToSplit = false;
-            _constraintToViolationCount[_constraintForSplitting] = 0;
-            _constraintForSplitting = nullptr;
-            return;
+    {
+        _needToSplit = false;
+        _constraintToViolationCount[_constraintForSplitting] = 0;
+        _constraintForSplitting = nullptr;
+        return;
     }
 
     ASSERT( _constraintForSplitting->isActive() );
@@ -155,7 +155,7 @@ void CDSmtCore::decideSplit( PiecewiseLinearConstraint *constraint )
         struct timespec end = TimeUtils::sampleMicro();
         _statistics->addTimeSmtCore( TimeUtils::timePassed( start, end ) );
     }
-    SMT_LOG( "Performing a ReLU split - DONE");
+    SMT_LOG( "Performing a ReLU split - DONE" );
 }
 
 
@@ -191,7 +191,7 @@ PiecewiseLinearCaseSplit CDSmtCore::getDecision( unsigned decisionLevel ) const
 {
     ASSERT( decisionLevel <= getDecisionLevel() );
     ASSERT( decisionLevel > 0 );
-    return _decisions[decisionLevel - 1].getPiecewiseLinearCaseSplit() ;
+    return _decisions[decisionLevel - 1].getPiecewiseLinearCaseSplit();
 }
 
 bool CDSmtCore::backtrackToFeasibleDecision( TrailEntry &lastDecision )
@@ -221,7 +221,7 @@ bool CDSmtCore::backtrackToFeasibleDecision( TrailEntry &lastDecision )
 
 bool CDSmtCore::backtrackAndContinueSearch()
 {
-    TrailEntry feasibleDecision( nullptr , CONSTRAINT_INFEASIBLE );
+    TrailEntry feasibleDecision( nullptr, CONSTRAINT_INFEASIBLE );
     struct timespec start = TimeUtils::sampleMicro();
 
     if ( !backtrackToFeasibleDecision( feasibleDecision ) )
@@ -282,10 +282,10 @@ bool CDSmtCore::checkSkewFromDebuggingSolution()
 
     String error;
 
-    int decisionLevel = 0 ;
+    int decisionLevel = 0;
     bool isDecision = false;
     // First check that the valid splits implied at the root level are okay
-    for ( const auto &trailEntry: _trail)
+    for ( const auto &trailEntry : _trail )
     {
         if ( trailEntry._pwlConstraint != _decisions[decisionLevel]._pwlConstraint )
             isDecision = false;
@@ -298,7 +298,8 @@ bool CDSmtCore::checkSkewFromDebuggingSolution()
 
         PiecewiseLinearCaseSplit caseSplit = trailEntry.getPiecewiseLinearCaseSplit();
         if ( decisionLevel == 0 )
-        {    if ( !splitAllowsStoredSolution( caseSplit, error ) )
+        {
+            if ( !splitAllowsStoredSolution( caseSplit, error ) )
             {
                 printf( "Error with one of the splits implied at root level:\n\t%s\n", error.ascii() );
                 throw MarabouError( MarabouError::DEBUGGING_ERROR );
@@ -306,10 +307,12 @@ bool CDSmtCore::checkSkewFromDebuggingSolution()
         }
         else
         {
-            // If the active split is non-compliant but there are alternatives, i.e. it was a decision, that's fine
+            // If the active split is non-compliant but there are alternatives,
+            // i.e. it was a decision, that's fine
             if ( isDecision && !splitAllowsStoredSolution( caseSplit, error ) )
             {
-                // Active split is non-compliant but this is fine, because there are alternatives. We're done.
+                // Active split is non-compliant but this is fine, because there
+                // are alternatives. We're done.
                 return false;
             }
             else // Implied split

--- a/src/engine/CDSmtCore.cpp
+++ b/src/engine/CDSmtCore.cpp
@@ -2,18 +2,17 @@
 /*! \file CDSmtCore.cpp
  ** \verbatim
  ** Top contributors (to current version):
- **   Aleksandar Zeljic, Guy Katz, Parth Shah, Duligur Ibeling
+ **   Aleksandar Zeljic, Guy Katz, Parth Shah
  ** This file is part of the Marabou project.
  ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
  ** All rights reserved. See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** The CDSmtCore implements a CDCL-style loop, using context-dependent data types
- ** and state-based PiecewiseLinearConstraint to store the search state in an
- ** incremental and easy-to-backtrack way.
-
+ ** See the description of the class in CDSmtCore.h.
  **/
+
+#include "CDSmtCore.h"
 
 #include "Debug.h"
 #include "DivideStrategy.h"
@@ -24,7 +23,6 @@
 #include "MStringf.h"
 #include "MarabouError.h"
 #include "ReluConstraint.h"
-#include "CDSmtCore.h"
 
 using namespace CVC4::context;
 

--- a/src/engine/CDSmtCore.cpp
+++ b/src/engine/CDSmtCore.cpp
@@ -2,7 +2,7 @@
 /*! \file CDSmtCore.cpp
  ** \verbatim
  ** Top contributors (to current version):
- **   Aleksandar Zeljic, Guy Katz, Parth Shah
+ **   Guy Katz, Aleksandar Zeljic,  Parth Shah
  ** This file is part of the Marabou project.
  ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.

--- a/src/engine/CDSmtCore.h
+++ b/src/engine/CDSmtCore.h
@@ -69,42 +69,42 @@ public:
     bool needToSplit() const;
 
     /*
-      Decide a case split to apply, according to the constraint marked for
-      splitting. Update bounds, add equations and update the stack.
-    */
-    void decide();
-
-    /*
-     * decideSplit - choose a phase of PiecewiseLinearConstraint's alternativeCases to decide.
-     */
-    void decideSplit( PiecewiseLinearConstraint *constraint );
-
-    /*
-     * Push TrailEntry representing the decision onto the trail. Push the decided PiecewiseLinearCaseSplit to the engine.
+       Push TrailEntry representing the decision onto the trail. 
      */
     void pushDecision( PiecewiseLinearConstraint *constraint,  PhaseStatus decision );
 
     /*
-      Let the smt core know of an implied valid case split that was discovered.
+      Inform SmtCore of an implied (formerly valid) case split that was discovered.
     */
-    void implyValidSplit( PiecewiseLinearCaseSplit &validSplit );
+    void pushImplication( PiecewiseLinearConstraint *constraint );
 
     /*
-      Let the smt core trail know of an implied valid case split that was discovered.
-    */
-    void pushImplication( PiecewiseLinearConstraint *constraint, PhaseStatus phase );
-
-    /*
-        Pushes trail element onto trail, handles decision book-keeping and
-        applies the case split to the engine.
+        Pushes trail entry onto trail, handles decision book-keeping and
+        Update bounds and add equations to the engine.
      */
     void applyTrailEntry( TrailEntry &te, bool isDecision = false );
 
     /*
-      Backtrack the search, by popping stacks with no alternatives, and perform
-      a decision or an implication as needed.
+      Decide and apply a case split using the constraint marked for splitting.
     */
-    bool backtrackAndContinue();
+    void decide();
+
+    /*
+      Decide a constraint's feasible case. Update bounds, add equations
+      and trail.
+     */
+    void decideSplit( PiecewiseLinearConstraint *constraint );
+
+    /*
+       Backtracks fully explored decisions and stores the last (feasible decision
+     */
+    bool backtrackToFeasibleDecision( TrailEntry &feasibleDecision );
+
+    /*
+      Return to a feasible state and resume search by asserting the next case
+      (as either a decision or implication)
+    */
+    bool backtrackAndContinueSearch();
 
     /*
       Pop a stack frame. Return true if successful, false if the stack is empty.

--- a/src/engine/CDSmtCore.h
+++ b/src/engine/CDSmtCore.h
@@ -2,7 +2,7 @@
 /*! \file CDSmtCore.h
  ** \verbatim
  ** Top contributors (to current version):
- **   AleksandarZeljic, Guy Katz, Parth Shah
+ **   Guy Katz, AleksandarZeljic,  Parth Shah
  ** This file is part of the Marabou project.
  ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
@@ -15,7 +15,6 @@
  ** class. The exhaustive search relies on correct implementation of the
  ** isFeasible()/nextFeasibleCase() methods in PiecewiseLinearConstraint class.
  **
- ** TODO: Incremental frames
  **/
 
 #ifndef __CDSmtCore_h__

--- a/src/engine/CDSmtCore.h
+++ b/src/engine/CDSmtCore.h
@@ -13,48 +13,53 @@
  ** The CDSmtCore distinguishes between: **decisions** and **implications**.
  **
  ** Decision is a case of PiecewiseLinearConstraint asserted on the trail.
- ** Decision implies that the PiecewiseLinearConstraint has at least one other
- ** feasible case. Decisions represent nodes/search-states in the search tree.
+ ** A decision is a choice between multiple feasible cases of a
+ ** PiecewiseLinearConstraint and represents nodes in the search tree.
  **
- ** Implication is a case of PiecewiseLinearConstraint asserted on the trail.
- ** Implication is the last feasible case of a PiecewiseLinearConstraint.
+ ** Implication is the last feasible case of a PiecewiseLinearConstraint and as
+ ** soon as it is detected it is asserted on the trail.
  **
  ** Case splitting on a PiecewiseLinearConstraint performs a decision.
- ** Fixing  a case of a PiecewiseLinearConstraint (e.g., via bound propagation)
- ** performs an implication.
+ ** Fixing a case of a PiecewiseLinearConstraint (e.g., via bound propagation or
+ ** by exhausting all other cases) performs an implication.
  **
- ** The overall search state is stored in a distributed way: the CDSmtCore
- ** stores the current search state while the PiecewiseLinearConstraints'
- ** infeasible cases enumerates all the explored states w.r.t to the
- ** chronological order on the _trail.
+ ** The overall search state is stored in a distributed way:
+ ** - CDSmtCore::_trail is the current search state in a chronological order
+ ** - PiecewiseLinearConstraints' infeasible cases enumerate all the explored
+ ** states w.r.t to the chronological order on the _trail.
  **
  ** _trail is a chronological list of cases of PiecewiseLinearConstraints
- ** asserted to hold (represented using TrailEntry) - both decisions and
- ** implications. _decisions is a chronological list of decisions stored on the
- ** trail. _trail and _decisions are both context dependent and will synchronize
- ** in unison with the context object.
+ ** asserted to hold (as TrailEntries) - both decisions and implications.
+ ** _decisions is a chronological list of decisions stored on the trail.
+ ** _trail and _decisions are both context dependent and will synchronize in
+ ** unison with the _context object.
  **
- ** When a search state is found to be infeasible, CDSmtCore backtracks lazily
- ** to the last decision and continues the search.
+ ** When a search state is found to be infeasible, CDSmtCore backtracks to the
+ ** last decision and continues the search.
  **
- ** Context management is done automatically when a new decision is pushed and a
- ** decision level is popped. Popping a decision will cause all related context
- ** dependent data structures to backtrack in sync with the _trail. This will
- ** effectively backtrack the entire search state via PiecewiseLinearConstraints
- ** and _boundManager. The only exception is the state of basic/non-basic
- ** variables in the tableau, which may need to be recalculated. However, no
- ** additional memory overhead is incurred in this process.
+ ** PushDecision advances the decision level and context level.
+ ** popDecisionLevel backtracks the last decision and context level.
+ **
+ ** Advancing a context level creates a synchronization point to which all
+ ** context dependent members can backtrack in unison.
+ ** Backtracking a context level restores all context dependent members to the
+ ** state of the last synchronization point. This operation is O(1) complexity.
+ **
+ ** Since the entire search state is context dependent, backtracking the context
+ ** (via popDecisionLevel) backtracks the entire Marabou search state.
+ ** The only exception is the labeling of basic/non-basic variables in the tableau,
+ ** which may need to be recalculated.
  **
  ** Implementation relies on:
  **
- ** * _context is a unique Context object from which all the context-dependent
+ ** - _context is a unique Context object from which all the context-dependent
  ** structures are obtained.
  **
- ** * PiecewiseLinearConstraint class stores its search state in a
+ ** - PiecewiseLinearConstraint class stores its search state in a
  ** context-dependent manner and exposes it using nextFeasibleCase() and
  ** markInfeasible() methods.
  **
- ** * Using BoundManager class to store bounds in a context-dependent manner
+ ** - Using BoundManager class to store bounds in a context-dependent manner
  **/
 
 #ifndef __CDSmtCore_h__
@@ -151,8 +156,8 @@ public:
     bool popSplit();
 
     /*
-      Pop a context level, lazily backtracking trail, bounds, etc. Return true
-      if successful, false if the stack is empty.
+      Pop a context level - lazily backtracking trail, bounds, etc.
+      Return true if successful, false if the stack is empty.
     */
     bool popDecisionLevel( TrailEntry &lastDecision );
 

--- a/src/engine/CDSmtCore.h
+++ b/src/engine/CDSmtCore.h
@@ -2,7 +2,7 @@
 /*! \file CDSmtCore.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Guy Katz, AleksandarZeljic,  Parth Shah
+ **   Guy Katz, AleksandarZeljic, Parth Shah
  ** This file is part of the Marabou project.
  ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
@@ -108,7 +108,7 @@ public:
     bool needToSplit() const;
 
     /*
-       Push TrailEntry representing the decision onto the trail. 
+       Push TrailEntry representing the decision onto the trail.
      */
     void pushDecision( PiecewiseLinearConstraint *constraint,  PhaseStatus decision );
 
@@ -119,7 +119,7 @@ public:
 
     /*
         Pushes trail entry onto trail, handles decision book-keeping and
-        Update bounds and add equations to the engine.
+        update bounds and add equations to the engine.
      */
     void applyTrailEntry( TrailEntry &te, bool isDecision = false );
 
@@ -135,7 +135,7 @@ public:
     void decideSplit( PiecewiseLinearConstraint *constraint );
 
     /*
-       Backtracks fully explored decisions and stores the last (feasible decision
+       Backtracks fully explored decisions and stores the last feasible decision
      */
     bool backtrackToFeasibleDecision( TrailEntry &feasibleDecision );
 
@@ -263,8 +263,6 @@ private:
       Split when some relu has been violated for this many times
     */
     unsigned _constraintViolationThreshold;
-
 };
 
 #endif // __CDSmtCore_h__
-

--- a/src/engine/CDSmtCore.h
+++ b/src/engine/CDSmtCore.h
@@ -2,15 +2,21 @@
 /*! \file CDSmtCore.h
  ** \verbatim
  ** Top contributors (to current version):
- **   Guy Katz, Parth Shah
+ **   AleksandarZeljic, Guy Katz, Parth Shah
  ** This file is part of the Marabou project.
  ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
  ** All rights reserved. See the file COPYING in the top-level source
  ** directory for licensing information.\endverbatim
  **
- ** [[ Add lengthier description here ]]
-**/
+ ** This class implements a context-dependent SmtCore class with lazy
+ ** backtracking of search state. The search state is stored lightly using the
+ ** PhaseStatus enumeration in context-dependent PiecewiseLinearConstraint
+ ** class. The exhaustive search relies on correct implementation of the
+ ** isFeasible()/nextFeasibleCase() methods in PiecewiseLinearConstraint class.
+ **
+ ** TODO: Incremental frames
+ **/
 
 #ifndef __CDSmtCore_h__
 #define __CDSmtCore_h__

--- a/src/engine/CDSmtCore.h
+++ b/src/engine/CDSmtCore.h
@@ -60,14 +60,14 @@
 #ifndef __CDSmtCore_h__
 #define __CDSmtCore_h__
 
-#include "context/context.h"
-#include "context/cdlist.h"
 #include "Options.h"
 #include "PiecewiseLinearCaseSplit.h"
 #include "PiecewiseLinearConstraint.h"
 #include "Stack.h"
 #include "Statistics.h"
 #include "TrailEntry.h"
+#include "context/cdlist.h"
+#include "context/context.h"
 
 #define SMT_LOG( x, ... ) LOG( GlobalConfiguration::SMT_CORE_LOGGING, "CDSmtCore: %s\n", x )
 
@@ -95,7 +95,7 @@ public:
       Get the number of times a specific PL constraint has been reported as
       violated.
     */
-    unsigned getViolationCounts( PiecewiseLinearConstraint* constraint ) const;
+    unsigned getViolationCounts( PiecewiseLinearConstraint *constraint ) const;
 
     /*
       Reset all reported violation counts.
@@ -162,8 +162,8 @@ public:
     unsigned getDecisionLevel() const;
 
     /*
-      Return a list of all splits performed so far, both SMT-originating and valid ones,
-      in the correct order.
+      Return a list of all splits performed so far, both SMT-originating and
+      valid ones, in the correct order.
     */
     void allSplitsSoFar( List<PiecewiseLinearCaseSplit> &result ) const;
 
@@ -226,7 +226,7 @@ private:
     /*
       CVC4 Context, constructed in Engine
     */
-    CVC4::context::Context& _context;
+    CVC4::context::Context &_context;
 
     /*
       Trail is context dependent and contains all the asserted PWLCaseSplits

--- a/src/engine/CDSmtCore.h
+++ b/src/engine/CDSmtCore.h
@@ -1,0 +1,269 @@
+/*********************                                                        */
+/*! \file CDSmtCore.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Guy Katz, Parth Shah
+ ** This file is part of the Marabou project.
+ ** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved. See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** [[ Add lengthier description here ]]
+**/
+
+#ifndef __CDSmtCore_h__
+#define __CDSmtCore_h__
+
+#include "context/context.h"
+#include "context/cdlist.h"
+#include "Options.h"
+#include "PiecewiseLinearCaseSplit.h"
+#include "PiecewiseLinearConstraint.h"
+#include "Stack.h"
+#include "Statistics.h"
+#include "TrailEntry.h"
+
+#define SMT_LOG( x, ... ) LOG( GlobalConfiguration::SMT_CORE_LOGGING, "CDSmtCore: %s\n", x )
+
+class EngineState;
+class Engine;
+class String;
+
+class CDSmtCore
+{
+public:
+    CDSmtCore( IEngine *engine, CVC4::context::Context &context );
+    ~CDSmtCore();
+
+    /*
+      Clear the stack.
+    */
+    void freeMemory();
+
+    /*
+      Inform the SMT core that a PL constraint is violated.
+    */
+    void reportViolatedConstraint( PiecewiseLinearConstraint *constraint );
+
+    /*
+      Get the number of times a specific PL constraint has been reported as
+      violated.
+    */
+    unsigned getViolationCounts( PiecewiseLinearConstraint* constraint ) const;
+
+    /*
+      Reset all reported violation counts.
+    */
+    void resetReportedViolations();
+
+    /*
+      Returns true iff the SMT core wants to perform a case split.
+    */
+    bool needToSplit() const;
+
+    /*
+      Decide a case split to apply, according to the constraint marked for
+      splitting. Update bounds, add equations and update the stack.
+    */
+    void decide();
+
+    /*
+     * decideSplit - choose a phase of PiecewiseLinearConstraint's alternativeCases to decide.
+     */
+    void decideSplit( PiecewiseLinearConstraint *constraint );
+    /*
+     * Push TrailEntry representing the decision onto the trail. Push the decided PiecewiseLinearCaseSplit to the engine.
+     */
+    void pushDecision( PiecewiseLinearConstraint *constraint,  PhaseStatus decision );
+
+    /*
+      Backtrack the search, by popping stacks with no alternatives, and perform
+      a decision or an implication as needed.
+    */
+    bool backtrackAndContinue();
+
+
+    /*
+      Pop a stack frame, copying alternativeSplits if any. Return
+      true if successful, false if the stack is empty.
+    */
+    bool popSplitFromStack( List<PiecewiseLinearCaseSplit> &alternativeSplits );
+
+    /*
+      Pop a stack frame. Return true if successful, false if the stack is empty.
+    */
+    bool popSplit();
+
+    /*
+      Pop a context level, lazily backtracking trail, bounds, etc. Return true
+      if successful, false if the stack is empty.
+    */
+    bool popDecisionLevel( TrailEntry &lastDecision );
+
+    /*
+      The current stack depth.
+    */
+    unsigned getDecisionLevel() const;
+
+    /*
+      Let the smt core know of an implied valid case split that was discovered.
+    */
+    void implyValidSplit( PiecewiseLinearCaseSplit &validSplit );
+
+    /*
+      Let the smt core trail know of an implied valid case split that was discovered.
+    */
+    void pushImplication( PiecewiseLinearConstraint *constraint, PhaseStatus phase );
+
+    /*
+      Return a list of all splits performed so far, both SMT-originating and valid ones,
+      in the correct order.
+    */
+    void allSplitsSoFar( List<PiecewiseLinearCaseSplit> &result ) const;
+
+    /*
+      Get trail begin iterator.
+    */
+    CVC4::context::CDList<TrailEntry>::const_iterator trailBegin() const
+    {
+        return _trail.begin();
+    };
+
+    /*
+      Get trail end iterator.
+    */
+    CVC4::context::CDList<TrailEntry>::const_iterator trailEnd() const
+    {
+        return _trail.end();
+    };
+
+    /*
+      Have the SMT core start reporting statistics.
+    */
+    void setStatistics( Statistics *statistics );
+
+    /*
+      Have the SMT core choose, among a set of violated PL constraints, which
+      constraint should be repaired (without splitting)
+    */
+    PiecewiseLinearConstraint *chooseViolatedConstraintForFixing( List<PiecewiseLinearConstraint *> &_violatedPlConstraints ) const;
+
+    void setConstraintViolationThreshold( unsigned threshold );
+
+    /*
+      Pick the piecewise linear constraint for splitting, returns true
+      if a constraint for splitting is successfully picked
+    */
+    bool pickSplitPLConstraint();
+    /*
+     * For testing purposes
+     */
+    PiecewiseLinearCaseSplit getDecision( unsigned decisionLevel );
+
+    void reset();
+
+    /*
+      For debugging purposes only - store a correct possible solution
+    */
+    void storeDebuggingSolution( const Map<unsigned, double> &debuggingSolution );
+    bool checkSkewFromDebuggingSolution();
+    bool splitAllowsStoredSolution( const PiecewiseLinearCaseSplit &split, String &error ) const;
+    void interruptIfCompliantWithDebugSolution();
+private:
+    /*
+      A stack entry consists of the engine state before the split,
+      the active split, the alternative splits (in case of backtrack),
+      and also any implied splits that were discovered subsequently.
+    */
+    struct StackEntry
+    {
+    public:
+        PiecewiseLinearCaseSplit _activeSplit;
+        PiecewiseLinearConstraint *_sourceConstraint;
+        List<PiecewiseLinearCaseSplit> _impliedValidSplits;
+        List<PiecewiseLinearCaseSplit> _alternativeSplits;
+        EngineState *_engineState;
+    };
+
+
+
+    /*
+      Valid splits that were implied by level 0 of the stack.
+    */
+    List<PiecewiseLinearCaseSplit> _impliedValidSplitsAtRoot;
+
+    /*
+      Collect and print various statistics.
+    */
+    Statistics *_statistics;
+
+
+    /*
+      CVC4 Context, constructed in Engine
+    */
+    CVC4::context::Context& _context;
+
+    /*
+      The case-split stack.
+    */
+    //List<StackEntry *> _stack;
+
+    /*
+      Trail is context dependent and contains all the asserted PWLCaseSplits. 
+      TODO: Abstract from PWLCaseSplits to Literals
+    */
+    CVC4::context::CDList<TrailEntry> _trail;
+
+    /*
+     * _decisions point to the decision at the beginning of each decision level
+     */
+    CVC4::context::CDList<TrailEntry> _decisions;
+
+    /*
+      The engine.
+    */
+    IEngine *_engine;
+
+    /*
+      Do we need to perform a split and on which constraint.
+    */
+    bool _needToSplit;
+    PiecewiseLinearConstraint *_constraintForSplitting;
+
+    /*
+      Count how many times each constraint has been violated.
+    */
+    Map<PiecewiseLinearConstraint *, unsigned> _constraintToViolationCount;
+
+    /*
+      For debugging purposes only
+    */
+    Map<unsigned, double> _debuggingSolution;
+
+    /*
+      A unique ID allocated to every state that is stored, for
+      debugging purposes.
+    */
+    unsigned _stateId;
+
+    /*
+      Split when some relu has been violated for this many times
+    */
+    unsigned _constraintViolationThreshold;
+
+    /*
+      Helper function to establish equivalence between trail and stack information
+     */
+    bool checkStackTrailEquivalence();
+};
+
+#endif // __CDSmtCore_h__
+
+//
+// Local Variables:
+// compile-command: "make -C ../.. "
+// tags-file-name: "../../TAGS"
+// c-basic-offset: 4
+// End:
+//

--- a/src/engine/CDSmtCore.h
+++ b/src/engine/CDSmtCore.h
@@ -78,23 +78,33 @@ public:
      * decideSplit - choose a phase of PiecewiseLinearConstraint's alternativeCases to decide.
      */
     void decideSplit( PiecewiseLinearConstraint *constraint );
+
     /*
      * Push TrailEntry representing the decision onto the trail. Push the decided PiecewiseLinearCaseSplit to the engine.
      */
     void pushDecision( PiecewiseLinearConstraint *constraint,  PhaseStatus decision );
 
     /*
+      Let the smt core know of an implied valid case split that was discovered.
+    */
+    void implyValidSplit( PiecewiseLinearCaseSplit &validSplit );
+
+    /*
+      Let the smt core trail know of an implied valid case split that was discovered.
+    */
+    void pushImplication( PiecewiseLinearConstraint *constraint, PhaseStatus phase );
+
+    /*
+        Pushes trail element onto trail, handles decision book-keeping and
+        applies the case split to the engine.
+     */
+    void applyTrailEntry( TrailEntry &te, bool isDecision = false );
+
+    /*
       Backtrack the search, by popping stacks with no alternatives, and perform
       a decision or an implication as needed.
     */
     bool backtrackAndContinue();
-
-
-    /*
-      Pop a stack frame, copying alternativeSplits if any. Return
-      true if successful, false if the stack is empty.
-    */
-    bool popSplitFromStack( List<PiecewiseLinearCaseSplit> &alternativeSplits );
 
     /*
       Pop a stack frame. Return true if successful, false if the stack is empty.
@@ -111,16 +121,6 @@ public:
       The current stack depth.
     */
     unsigned getDecisionLevel() const;
-
-    /*
-      Let the smt core know of an implied valid case split that was discovered.
-    */
-    void implyValidSplit( PiecewiseLinearCaseSplit &validSplit );
-
-    /*
-      Let the smt core trail know of an implied valid case split that was discovered.
-    */
-    void pushImplication( PiecewiseLinearConstraint *constraint, PhaseStatus phase );
 
     /*
       Return a list of all splits performed so far, both SMT-originating and valid ones,
@@ -162,6 +162,7 @@ public:
       if a constraint for splitting is successfully picked
     */
     bool pickSplitPLConstraint();
+
     /*
      * For testing purposes
      */
@@ -171,6 +172,7 @@ public:
 
     /*
       For debugging purposes only - store a correct possible solution
+      TODO: Create a user interface for this
     */
     void storeDebuggingSolution( const Map<unsigned, double> &debuggingSolution );
     bool checkSkewFromDebuggingSolution();

--- a/src/engine/CDSmtCore.h
+++ b/src/engine/CDSmtCore.h
@@ -165,7 +165,7 @@ public:
     /*
      * For testing purposes
      */
-    PiecewiseLinearCaseSplit getDecision( unsigned decisionLevel );
+    PiecewiseLinearCaseSplit getDecision( unsigned decisionLevel ) const;
 
     void reset();
 

--- a/src/engine/CDSmtCore.h
+++ b/src/engine/CDSmtCore.h
@@ -47,8 +47,9 @@
  **
  ** Since the entire search state is context dependent, backtracking the context
  ** (via popDecisionLevel) backtracks the entire Marabou search state.
- ** The only exception is the labeling of basic/non-basic variables in the tableau,
- ** which may need to be recalculated.
+ ** The only exception is the labeling of basic/non-basic variables in the
+ ** tableau, which may need to be recalculated using Tableau's
+ ** postContextPopHook exposed via Engine.
  **
  ** Implementation relies on:
  **

--- a/src/engine/CDSmtCore.h
+++ b/src/engine/CDSmtCore.h
@@ -180,32 +180,9 @@ public:
     void interruptIfCompliantWithDebugSolution();
 private:
     /*
-      A stack entry consists of the engine state before the split,
-      the active split, the alternative splits (in case of backtrack),
-      and also any implied splits that were discovered subsequently.
-    */
-    struct StackEntry
-    {
-    public:
-        PiecewiseLinearCaseSplit _activeSplit;
-        PiecewiseLinearConstraint *_sourceConstraint;
-        List<PiecewiseLinearCaseSplit> _impliedValidSplits;
-        List<PiecewiseLinearCaseSplit> _alternativeSplits;
-        EngineState *_engineState;
-    };
-
-
-
-    /*
-      Valid splits that were implied by level 0 of the stack.
-    */
-    List<PiecewiseLinearCaseSplit> _impliedValidSplitsAtRoot;
-
-    /*
       Collect and print various statistics.
     */
     Statistics *_statistics;
-
 
     /*
       CVC4 Context, constructed in Engine
@@ -213,18 +190,12 @@ private:
     CVC4::context::Context& _context;
 
     /*
-      The case-split stack.
-    */
-    //List<StackEntry *> _stack;
-
-    /*
-      Trail is context dependent and contains all the asserted PWLCaseSplits. 
-      TODO: Abstract from PWLCaseSplits to Literals
+      Trail is context dependent and contains all the asserted PWLCaseSplits
     */
     CVC4::context::CDList<TrailEntry> _trail;
 
     /*
-     * _decisions point to the decision at the beginning of each decision level
+     * _decisions stores the decision TrailEntries
      */
     CVC4::context::CDList<TrailEntry> _decisions;
 
@@ -249,29 +220,12 @@ private:
     */
     Map<unsigned, double> _debuggingSolution;
 
-    /*
-      A unique ID allocated to every state that is stored, for
-      debugging purposes.
-    */
-    unsigned _stateId;
-
-    /*
+   /*
       Split when some relu has been violated for this many times
     */
     unsigned _constraintViolationThreshold;
 
-    /*
-      Helper function to establish equivalence between trail and stack information
-     */
-    bool checkStackTrailEquivalence();
 };
 
 #endif // __CDSmtCore_h__
 
-//
-// Local Variables:
-// compile-command: "make -C ../.. "
-// tags-file-name: "../../TAGS"
-// c-basic-offset: 4
-// End:
-//

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -127,6 +127,11 @@ public:
     void applySplit( const PiecewiseLinearCaseSplit &split );
 
     /*
+      Recompute status of basic variables
+    */
+    void recomputeBasicStatus() { _tableau->computeBasicStatus(); };
+
+    /*
       Reset the state of the engine, before solving a new query
       (as part of DnC mode).
     */

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -127,9 +127,9 @@ public:
     void applySplit( const PiecewiseLinearCaseSplit &split );
 
     /*
-      Recompute status of basic variables
+      Hook invoked after context pop to update context independent data.
     */
-    void recomputeBasicStatus() { _tableau->computeBasicStatus(); };
+    void postContextPopHook() { _tableau->postContextPopHook(); };
 
     /*
       Reset the state of the engine, before solving a new query

--- a/src/engine/IEngine.h
+++ b/src/engine/IEngine.h
@@ -57,9 +57,9 @@ public:
     virtual void applySnCSplit( PiecewiseLinearCaseSplit split, String queryId ) = 0;
 
     /*
-      Recompute status of basic variables
+      Hook invoked after context pop to update context independent data.
     */
-    virtual void recomputeBasicStatus() = 0;
+    virtual void postContextPopHook() = 0;
 
     /*
       Methods for storing and restoring the state of the engine.

--- a/src/engine/IEngine.h
+++ b/src/engine/IEngine.h
@@ -57,6 +57,11 @@ public:
     virtual void applySnCSplit( PiecewiseLinearCaseSplit split, String queryId ) = 0;
 
     /*
+      Recompute status of basic variables
+    */
+    virtual void recomputeBasicStatus() = 0;
+
+    /*
       Methods for storing and restoring the state of the engine.
     */
     virtual void storeState( EngineState &state, bool storeAlsoTableauState ) const = 0;

--- a/src/engine/ITableau.h
+++ b/src/engine/ITableau.h
@@ -179,6 +179,7 @@ public:
     virtual void mergeColumns( unsigned x1, unsigned x2 ) = 0;
     virtual bool areLinearlyDependent( unsigned x1, unsigned x2, double &coefficient, double &inverseCoefficient ) = 0;
     virtual unsigned getVariableAfterMerging( unsigned variable ) const = 0;
+    virtual void postContextPopHook() = 0;
 };
 
 #endif // __ITableau_h__

--- a/src/engine/SmtCore.cpp
+++ b/src/engine/SmtCore.cpp
@@ -148,7 +148,7 @@ void SmtCore::performSplit()
     _stack.append( stackEntry );
     if ( _statistics )
     {
-        _statistics->setCurrentStackDepth( getStackDepth() );
+        _statistics->setCurrentDecisionLevel( getStackDepth() );
         struct timespec end = TimeUtils::sampleMicro();
         _statistics->addTimeSmtCore( TimeUtils::timePassed( start, end ) );
     }
@@ -226,7 +226,7 @@ bool SmtCore::popSplit()
 
     if ( _statistics )
     {
-        _statistics->setCurrentStackDepth( getStackDepth() );
+        _statistics->setCurrentDecisionLevel( getStackDepth() );
         struct timespec end = TimeUtils::sampleMicro();
         _statistics->addTimeSmtCore( TimeUtils::timePassed( start, end ) );
     }
@@ -429,7 +429,7 @@ void SmtCore::replaySmtStackEntry( SmtStackEntry *stackEntry )
 
     if ( _statistics )
     {
-        _statistics->setCurrentStackDepth( getStackDepth() );
+        _statistics->setCurrentDecisionLevel( getStackDepth() );
         struct timespec end = TimeUtils::sampleMicro();
         _statistics->addTimeSmtCore( TimeUtils::timePassed( start, end ) );
     }

--- a/src/engine/Tableau.h
+++ b/src/engine/Tableau.h
@@ -454,6 +454,13 @@ public:
      */
     unsigned getVariableAfterMerging( unsigned variable ) const;
 
+    /*
+       Hook that is invoked after Context pop, to update context independent
+       data. After backtracking assignments satisfy bounds, but the
+       basic/non-basic status may be out of date, so it is recomputed.
+     */
+    void postContextPopHook() { computeBasicStatus(); };
+
 private:
     /*
       Variable watchers

--- a/src/engine/TrailEntry.h
+++ b/src/engine/TrailEntry.h
@@ -37,6 +37,11 @@ public:
       _pwlConstraint->markInfeasible( _phase );
   }
 
+  inline bool isFeasible()
+  {
+      return _pwlConstraint->isFeasible();
+  }
+
  TrailEntry(PiecewiseLinearConstraint * pwlc, PhaseStatus phase )
      : _pwlConstraint( pwlc )
      , _phase( phase )

--- a/src/engine/TrailEntry.h
+++ b/src/engine/TrailEntry.h
@@ -1,0 +1,56 @@
+/*********************                                                        */
+/*! \file TrailEntry.h
+** \verbatim
+** Top contributors (to current version):
+**  Aleksandar Zeljic
+** This file is part of the Marabou project.
+** Copyright (c) 2017-2019 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved. See the file COPYING in the top-level source
+** directory for licensing information.\endverbatim
+**
+** [[ Add lengthier description here ]]
+**/
+
+#ifndef __TrailEntry_h__
+#define __TrailEntry_h__
+
+#include "PiecewiseLinearCaseSplit.h"
+
+/*
+  A trail entry consists of the pointer to a PiecewiseLinearConstraint and
+  phase designation.
+*/
+class TrailEntry
+{
+public:
+  PiecewiseLinearConstraint * _pwlConstraint;
+  PhaseStatus _phase;
+
+  PiecewiseLinearCaseSplit getPiecewiseLinearCaseSplit() const
+  {
+      return _pwlConstraint->getCaseSplit( _phase );
+  }
+
+  inline void markInfeasible()
+  {
+      _pwlConstraint->markInfeasible( _phase );
+  }
+
+ TrailEntry(PiecewiseLinearConstraint * pwlc, PhaseStatus phase )
+     : _pwlConstraint( pwlc )
+     , _phase( phase )
+    {}
+
+  ~TrailEntry() {};
+};
+
+#endif // TrailEntry.h
+
+//
+// Local Variables:
+// compile-command: "make -C ../.. "
+// tags-file-name: "../../TAGS"
+// c-basic-offset: 4
+// End:
+//

--- a/src/engine/TrailEntry.h
+++ b/src/engine/TrailEntry.h
@@ -37,7 +37,7 @@ public:
       _pwlConstraint->markInfeasible( _phase );
   }
 
-  inline bool isFeasible()
+  inline bool isFeasible() const
   {
       return _pwlConstraint->isFeasible();
   }

--- a/src/engine/TrailEntry.h
+++ b/src/engine/TrailEntry.h
@@ -9,7 +9,10 @@
 ** All rights reserved. See the file COPYING in the top-level source
 ** directory for licensing information.\endverbatim
 **
-** [[ Add lengthier description here ]]
+** TrailEntry represent a case of PiecewiseLinearConstraint asserted on the
+** trail. Current implementation consists of a pointer to the
+** PiecewiseLinearConstraint and the chosen case represented using PhaseStatus
+** enum.
 **/
 
 #ifndef __TrailEntry_h__
@@ -42,7 +45,7 @@ public:
       return _pwlConstraint->isFeasible();
   }
 
- TrailEntry(PiecewiseLinearConstraint * pwlc, PhaseStatus phase )
+ TrailEntry( PiecewiseLinearConstraint *pwlc, PhaseStatus phase )
      : _pwlConstraint( pwlc )
      , _phase( phase )
     {}
@@ -51,11 +54,3 @@ public:
 };
 
 #endif // TrailEntry.h
-
-//
-// Local Variables:
-// compile-command: "make -C ../.. "
-// tags-file-name: "../../TAGS"
-// c-basic-offset: 4
-// End:
-//

--- a/src/engine/TrailEntry.h
+++ b/src/engine/TrailEntry.h
@@ -27,30 +27,31 @@
 class TrailEntry
 {
 public:
-  PiecewiseLinearConstraint * _pwlConstraint;
-  PhaseStatus _phase;
+    PiecewiseLinearConstraint *_pwlConstraint;
+    PhaseStatus _phase;
 
-  PiecewiseLinearCaseSplit getPiecewiseLinearCaseSplit() const
-  {
-      return _pwlConstraint->getCaseSplit( _phase );
-  }
+    PiecewiseLinearCaseSplit getPiecewiseLinearCaseSplit() const
+    {
+        return _pwlConstraint->getCaseSplit( _phase );
+    }
 
-  inline void markInfeasible()
-  {
-      _pwlConstraint->markInfeasible( _phase );
-  }
+    inline void markInfeasible()
+    {
+        _pwlConstraint->markInfeasible( _phase );
+    }
 
-  inline bool isFeasible() const
-  {
-      return _pwlConstraint->isFeasible();
-  }
+    inline bool isFeasible() const
+    {
+        return _pwlConstraint->isFeasible();
+    }
 
- TrailEntry( PiecewiseLinearConstraint *pwlc, PhaseStatus phase )
-     : _pwlConstraint( pwlc )
-     , _phase( phase )
-    {}
+    TrailEntry( PiecewiseLinearConstraint *pwlc, PhaseStatus phase )
+        : _pwlConstraint( pwlc )
+        , _phase( phase )
+    {
+    }
 
-  ~TrailEntry() {};
+    ~TrailEntry(){};
 };
 
 #endif // TrailEntry.h

--- a/src/engine/tests/MockEngine.h
+++ b/src/engine/tests/MockEngine.h
@@ -91,6 +91,8 @@ public:
         }
     }
 
+    void recomputeBasicStatus() {};
+
     mutable EngineState *lastStoredState;
     void storeState( EngineState &state, bool /* storeAlsoTableauState */ ) const
     {

--- a/src/engine/tests/MockEngine.h
+++ b/src/engine/tests/MockEngine.h
@@ -91,7 +91,7 @@ public:
         }
     }
 
-    void recomputeBasicStatus() {};
+    void postContextPopHook() override {};
 
     mutable EngineState *lastStoredState;
     void storeState( EngineState &state, bool /* storeAlsoTableauState */ ) const

--- a/src/engine/tests/MockEngine.h
+++ b/src/engine/tests/MockEngine.h
@@ -91,7 +91,7 @@ public:
         }
     }
 
-    void postContextPopHook() override {};
+    void postContextPopHook() {};
 
     mutable EngineState *lastStoredState;
     void storeState( EngineState &state, bool /* storeAlsoTableauState */ ) const

--- a/src/engine/tests/MockTableau.h
+++ b/src/engine/tests/MockTableau.h
@@ -595,6 +595,8 @@ public:
     {
         return 0;
     }
+
+    void postContextPopHook() override {}
 };
 
 #endif // __MockTableau_h__

--- a/src/engine/tests/MockTableau.h
+++ b/src/engine/tests/MockTableau.h
@@ -582,6 +582,7 @@ public:
                                double &coefficient,
                                double &inverseCoefficient )
     {
+
         lastLinearlyDependentX1 = x1;
         lastLinearlyDependentX2 = x2;
 
@@ -596,7 +597,7 @@ public:
         return 0;
     }
 
-    void postContextPopHook() override {}
+    void postContextPopHook() {}
 };
 
 #endif // __MockTableau_h__


### PR DESCRIPTION
This PR introduces a class with context-dependent implementation of the SmtCore. 

The CDSmtCore class implementation relies on:
- Access to the unique context object from which all the context-dependent structures are obtained.
- PiecewiseLinearConstraint class stores its search state in a context-dependent manner (already implemented) and 
modifying it using nextFeasibleCase()/markInfeasible() methods.
- Using BoundManager class to store bounds in a context-dependent manner (to be integrated in a future patch).

The CDSmtCore distinguishes between: **decisions** and **implications**. 
Decision is a case of PiecewiseLinearConstraint (represented using PhaseStatus enum), which is being asserted on the trail. The fact that it is a decision implies that the PiecewiseLinearConstraint has at least one other feasible case.
Decisions represent nodes/search-states in the search-space tree.

Implication is a case of PiecewiseLinearConstraint (represented using PhaseStatus enum), which is being asserted on the trail. Implication represents the last feasible case of the PiecewiseLinearConstraint.

_trail is a chronological list of cases of PiecewiseLinearConstraints asserted to hold (represented using TrailEntry) - both decisions and implications.
_decisions is a chronological list of decisions stored on the trail. 
_trail and _decisions are both context dependent and will synchronize in unison with the context object.

When we split on cases of a PiecewiseLinearConstraint a decision is performed.
When a case of PiecewiseLinearConstraint is fixed via bound propagation an implication is performed.
When a search state is found to be infeasible, CDSmtCore backtracks lazily to the last decision and continues the search.

Context management is done automatically when a new decision is pushed and a decision level is popped.
Popping a decision will cause all related context dependent data structures to backtrack in sync with the _trail.
This will effectively backtrack the entire search state via PiecewiseLinearConstraints and boundManager. 
The only exception is the state of basic/non-basic variables in the tableau, which may need to be recalculated. 
However, no additional memory overhead is incurred in this process.

Next steps: Integration of the centralized context object, proper initialization of all context dependent structures and integrating them all through via the Engine and CDSmtCore class.

