### PR TITLE
Preprocessor refactor

### DIFF
--- a/src/engine/InputQuery.cpp
+++ b/src/engine/InputQuery.cpp
@@ -342,6 +342,12 @@ const Map<unsigned, double> &InputQuery::getUpperBounds() const
     return _upperBounds;
 }
 
+void InputQuery::clearBounds()
+{
+    _lowerBounds.clear();
+    _upperBounds.clear();
+}
+
 void InputQuery::storeDebuggingSolution( unsigned variable, double value )
 {
     _debuggingSolution[variable] = value;

--- a/src/engine/InputQuery.h
+++ b/src/engine/InputQuery.h
@@ -44,6 +44,7 @@ public:
     double getUpperBound( unsigned variable ) const;
     const Map<unsigned, double> &getLowerBounds() const;
     const Map<unsigned, double> &getUpperBounds() const;
+    void clearBounds();
 
     const List<Equation> &getEquations() const;
     List<Equation> &getEquations();

--- a/src/engine/Preprocessor.cpp
+++ b/src/engine/Preprocessor.cpp
@@ -478,20 +478,20 @@ bool Preprocessor::processConstraints()
 {
     bool tighterBoundFound = false;
 
-	for ( auto &constraint : _preprocessed.getPiecewiseLinearConstraints() )
-	{
-		for ( unsigned variable : constraint->getParticipatingVariables() )
-		{
-			constraint->notifyLowerBound( variable, getLowerBound( variable ) );
-			constraint->notifyUpperBound( variable, getUpperBound( variable ) );
-		}
+    for ( auto &constraint : _preprocessed.getPiecewiseLinearConstraints() )
+    {
+        for ( unsigned variable : constraint->getParticipatingVariables() )
+        {
+            constraint->notifyLowerBound( variable, getLowerBound( variable ) );
+            constraint->notifyUpperBound( variable, getUpperBound( variable ) );
+        }
 
         List<Tightening> tightenings;
         constraint->getEntailedTightenings( tightenings );
 
         for ( const auto &tightening : tightenings )
-		{
-			if ( ( tightening._type == Tightening::LB ) &&
+        {
+            if ( ( tightening._type == Tightening::LB ) &&
                  ( FloatUtils::gt( tightening._value, getLowerBound( tightening._variable ) ) ) )
             {
                 tighterBoundFound = true;
@@ -846,7 +846,7 @@ void Preprocessor::eliminateVariables()
     // Let the remaining piecewise-lienar constraints know of any changes in indices.
     for ( const auto &constraint : constraints )
 	{
-		List<unsigned> participatingVariables = constraint->getParticipatingVariables();
+            List<unsigned> participatingVariables = constraint->getParticipatingVariables();
         for ( unsigned variable : participatingVariables )
         {
             if ( _oldIndexToNewIndex.at( variable ) != variable )

--- a/src/engine/Preprocessor.h
+++ b/src/engine/Preprocessor.h
@@ -28,6 +28,8 @@ class Preprocessor
 public:
     Preprocessor();
 
+    ~Preprocessor();
+
     /*
       Main method of this class: preprocess the input query
     */
@@ -56,6 +58,29 @@ public:
     unsigned getNewIndex( unsigned oldIndex ) const;
 
 private:
+
+    void freeMemoryIfNeeded();
+
+    inline double getLowerBound( unsigned var )
+    {
+        return _lowerBounds[var];
+    }
+
+    inline double getUpperBound( unsigned var )
+    {
+        return _upperBounds[var];
+    }
+
+    inline void setLowerBound( unsigned var, double value )
+    {
+        _lowerBounds[var] = value;
+    }
+
+    inline void setUpperBound( unsigned var, double value )
+    {
+        _upperBounds[var] = value;
+    }
+
     /*
       Transform all equations of type GE or LE to type EQ.
     */
@@ -119,6 +144,12 @@ private:
       Statistics collection
     */
     Statistics *_statistics;
+
+    /*
+      Used to store the bounds during the preprocessing.
+    */
+    double *_lowerBounds;
+    double *_upperBounds;
 
     /*
       Variables that have become fixed during preprocessing, and the


### PR DESCRIPTION
During the preprocessing we make a large number of calls to the InputQuery::get{Upper,Lower}Bound() methods. On large networks this makes preprocessing slow.
This PR:
Store the variable upper-/lower- bounds as two local arrays in the Preprocessor object at the beginning of preprocessing, read/update the two arrays during preprocessing (instead of read/update the preprocessed query object). And finally store the updated bounds back to the preprocessed query after preprocessing.