### PR TITLE
export sdk path when installing OpenBLAS on Mac.

### DIFF
--- a/tools/download_boost.sh
+++ b/tools/download_boost.sh
@@ -12,6 +12,11 @@ echo "unzipping boost"
 tar xzvf boost_1_68_0.tar.gz >> /dev/null
 echo "installing boost"
 cd boost_1_68_0;
+
+if [[ $OSTYPE == 'darwin'* ]]; then
+    export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+fi
+
 mkdir installed
 ./bootstrap.sh --prefix=`pwd`/installed --with-libraries=program_options,timer,chrono,thread >> /dev/null ;
 ./b2 cxxflags=-fPIC link=static install >> /dev/null

--- a/tools/download_openBLAS.sh
+++ b/tools/download_openBLAS.sh
@@ -10,6 +10,11 @@ echo "Unzipping openBLAS"
 tar -xzf OpenBLASv0.3.9.tar.gz >> /dev/null
 echo "Installing openBLAS"
 cd OpenBLAS-0.3.9
+
+if [[ $OSTYPE == 'darwin'* ]]; then
+    export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+fi
+
 make NO_SHARED=1 CBLAS_ONLY=1 USE_THREAD=0 >> /dev/null
 mkdir installed/
 make PREFIX=installed NO_SHARED=1 install >> /dev/null


### PR DESCRIPTION
Fixing the OpenBlas installation failure on Mac following this post: https://stackoverflow.com/questions/51761599/cannot-find-stdio-h