### PR TITLE
Access ExitCode from maraboupy 

### DIFF
--- a/maraboupy/Marabou.py
+++ b/maraboupy/Marabou.py
@@ -97,12 +97,13 @@ def solve_query(ipq, filename="", verbose=True, options=None):
 
     Returns:
         (tuple): tuple containing:
+            - exitCode (str): A string representing the exit code (sat/unsat/TIMEOUT/ERROR/UNKNOWN/QUIT_REQUESTED).
             - vals (Dict[int, float]): Empty dictionary if UNSAT, otherwise a dictionary of SATisfying values for variables
             - stats (:class:`~maraboupy.MarabouCore.Statistics`, optional): A Statistics object to how Marabou performed
     """
     if options is None:
         options = createOptions()
-    vals, stats = MarabouCore.solve(ipq, options, filename)
+    exitCode, vals, stats = MarabouCore.solve(ipq, options, filename)
     if verbose:
         if stats.hasTimedOut():
             print ("TO")
@@ -115,7 +116,7 @@ def solve_query(ipq, filename="", verbose=True, options=None):
             for i in range(ipq.getNumOutputVariables()):
                 print("output {} = {}".format(i, vals[ipq.outputVariableByIndex(i)]))
 
-    return [vals, stats]
+    return [exitCode, vals, stats]
 
 def createOptions(numWorkers=1, initialTimeout=5, initialSplits=0, onlineSplits=2,
                   timeoutInSeconds=0, timeoutFactor=1.5, verbosity=2, snc=False,

--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -286,14 +286,36 @@ InputQuery preprocess(InputQuery &inputQuery, MarabouOptions &options, std::stri
     return *(engine.getInputQuery());
 }
 
-
+std::string exitCodeToString( IEngine::ExitCode code )
+{
+    switch ( code )
+    {
+    case IEngine::UNSAT:
+        return "unsat";
+    case IEngine::SAT:
+        return "sat";
+    case IEngine::ERROR:
+        return "ERROR";
+    case IEngine::UNKNOWN:
+        return "UNKNOWN";
+    case IEngine::TIMEOUT:
+        return "TIMEOUT";
+    case IEngine::QUIT_REQUESTED:
+        return "QUIT_REQUESTED";
+    default:
+        return "UNKNOWN";
+    }
+}
 
 /* The default parameters here are just for readability, you should specify
  * them in the to make them work*/
-std::pair<std::map<int, double>, Statistics> solve(InputQuery &inputQuery, MarabouOptions &options,
-                                                   std::string redirect=""){
+std::tuple<std::string, std::map<int, double>, Statistics>
+    solve(InputQuery &inputQuery, MarabouOptions &options,
+          std::string redirect="")
+{
     // Arguments: InputQuery object, filename to redirect output
     // Returns: map from variable number to value
+    std::string resultString = "";
     std::map<int, double> ret;
     Statistics retStats;
     int output=-1;
@@ -307,12 +329,15 @@ std::pair<std::map<int, double>, Statistics> solve(InputQuery &inputQuery, Marab
 
         Engine engine;
 
-        if(!engine.processInputQuery(inputQuery)) return std::make_pair(ret, *(engine.getStatistics()));
+        if(!engine.processInputQuery(inputQuery))
+            return std::make_tuple(exitCodeToString(engine.getExitCode()),
+                                   ret, *(engine.getStatistics()));
         if ( dnc )
         {
             auto dncManager = std::unique_ptr<DnCManager>( new DnCManager( &inputQuery ) );
 
             dncManager->solve();
+            resultString = dncManager->getResultString().ascii();
             switch ( dncManager->getExitCode() )
             {
             case DnCManager::SAT:
@@ -325,30 +350,35 @@ std::pair<std::map<int, double>, Statistics> solve(InputQuery &inputQuery, Marab
             {
                 retStats = Statistics();
                 retStats.timeout();
-                return std::make_pair( ret, retStats );
+                return std::make_tuple( resultString, ret, retStats );
             }
             default:
-                return std::make_pair( ret, Statistics() ); // TODO: meaningful DnCStatistics
+                return std::make_tuple( resultString, ret, Statistics() ); // TODO: meaningful DnCStatistics
             }
         } else
         {
             unsigned timeoutInSeconds = Options::get()->getInt( Options::TIMEOUT );
-            if(!engine.solve(timeoutInSeconds)) return std::make_pair(ret, *(engine.getStatistics()));
+            engine.solve(timeoutInSeconds);
+
+            resultString = exitCodeToString(engine.getExitCode());
 
             if (engine.getExitCode() == Engine::SAT)
                 engine.extractSolution(inputQuery);
-            retStats = *(engine.getStatistics());
             for(unsigned int i=0; i<inputQuery.getNumberOfVariables(); ++i)
                 ret[i] = inputQuery.getSolutionValue(i);
+
+            retStats = *(engine.getStatistics());
         }
     }
     catch(const MarabouError &e){
         printf( "Caught a MarabouError. Code: %u. Message: %s\n", e.getCode(), e.getUserMessage() );
-        return std::make_pair(ret, retStats);
+        return std::make_tuple
+            ("ERROR",
+             ret, retStats);
     }
     if(output != -1)
         restoreOutputStream(output);
-    return std::make_pair(ret, retStats);
+    return std::make_tuple(resultString, ret, retStats);
 }
 
 void saveQuery(InputQuery& inputQuery, std::string filename){
@@ -408,6 +438,7 @@ PYBIND11_MODULE(MarabouCore, m) {
 
         Returns:
             (tuple): tuple containing:
+                - exitCode (str): A string representing the exit code (sat/unsat/TIMEOUT/ERROR/UNKNOWN/QUIT_REQUESTED).
                 - vals (Dict[int, float]): Empty dictionary if UNSAT, otherwise a dictionary of SATisfying values for variables
                 - stats (:class:`~maraboupy.MarabouCore.Statistics`): A Statistics object to how Marabou performed
         )pbdoc",

--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -363,9 +363,11 @@ std::tuple<std::string, std::map<int, double>, Statistics>
             resultString = exitCodeToString(engine.getExitCode());
 
             if (engine.getExitCode() == Engine::SAT)
+            {
                 engine.extractSolution(inputQuery);
-            for(unsigned int i=0; i<inputQuery.getNumberOfVariables(); ++i)
-                ret[i] = inputQuery.getSolutionValue(i);
+                for(unsigned int i=0; i<inputQuery.getNumberOfVariables(); ++i)
+                    ret[i] = inputQuery.getSolutionValue(i);
+            }
 
             retStats = *(engine.getStatistics());
         }

--- a/maraboupy/MarabouNetwork.py
+++ b/maraboupy/MarabouNetwork.py
@@ -270,20 +270,17 @@ class MarabouNetwork:
 
         Returns:
             (tuple): tuple containing:
+                - exitCode (str): A string representing the exit code (sat/unsat/TIMEOUT/ERROR/UNKNOWN/QUIT_REQUESTED).
                 - vals (Dict[int, float]): Empty dictionary if UNSAT, otherwise a dictionary of SATisfying values for variables
                 - stats (:class:`~maraboupy.MarabouCore.Statistics`): A Statistics object to how Marabou performed
         """
         ipq = self.getMarabouQuery()
         if options == None:
             options = MarabouCore.Options()
-        vals, stats = MarabouCore.solve(ipq, options, str(filename))
+        exitCode, vals, stats = MarabouCore.solve(ipq, options, str(filename))
         if verbose:
-            if stats.hasTimedOut():
-                print("TO")
-            elif len(vals)==0:
-                print("unsat")
-            else:
-                print("sat")
+            print(exitCode)
+            if exitCode == "sat":
                 for j in range(len(self.inputVars)):
                     for i in range(self.inputVars[j].size):
                         print("input {} = {}".format(i, vals[self.inputVars[j].item(i)]))
@@ -291,7 +288,7 @@ class MarabouNetwork:
                 for i in range(self.outputVars.size):
                     print("output {} = {}".format(i, vals[self.outputVars.item(i)]))
 
-        return [vals, stats]
+        return [exitCode, vals, stats]
 
     def evaluateLocalRobustness(self, input, epsilon, originalClass, verbose=True, options=None, targetClass=None):
         """Function evaluating a specific input is a local robustness within the scope of epslion
@@ -344,7 +341,7 @@ class MarabouNetwork:
                 if outputLayerIndex != originalClass:
                     self.addMaxConstraint(set([outputStartIndex + outputLayerIndex, outputStartIndex + originalClass]), 
                         outputStartIndex + outputLayerIndex)
-                    vals, stats = self.solve(options = options)
+                    exitCode, vals, stats = self.solve(options = options)
                     if (stats.hasTimedOut()):
                         break
                     elif (len(vals) > 0):
@@ -352,7 +349,7 @@ class MarabouNetwork:
                         break
         else:
             self.addMaxConstraint(set(self.outputVars[0]), outputStartIndex + targetClass)
-            vals, stats = self.solve(options = options)
+            exitCode, vals, stats = self.solve(options = options)
             if verbose:
                 if not stats.hasTimedOut() and len(vals) > 0:
                     maxClass = targetClass
@@ -412,7 +409,7 @@ class MarabouNetwork:
 
         if options == None:
             options = MarabouCore.Options()
-        outputDict, _ = MarabouCore.solve(ipq, options, str(filename))
+        exitCode, outputDict, _ = MarabouCore.solve(ipq, options, str(filename))
 
         # When the query is UNSAT an empty dictionary is returned
         if outputDict == {}:

--- a/maraboupy/examples/0_NNetExample.py
+++ b/maraboupy/examples/0_NNetExample.py
@@ -34,7 +34,7 @@ net1.setLowerBound(net1.outputVars[0][0], .5)
 
 # %%
 # Solve Marabou query
-vals1, stats1 = net1.solve()
+exitCode, vals1, stats1 = net1.solve()
 
 
 # %%

--- a/maraboupy/examples/1_TensorflowExample.py
+++ b/maraboupy/examples/1_TensorflowExample.py
@@ -48,4 +48,4 @@ network.setUpperBound(outputVars[1], 210.0)
 
 # %%
 # Call to C++ Marabou solver
-vals, stats = network.solve("marabou.log")
+exitCode, vals, stats = network.solve("marabou.log")

--- a/maraboupy/examples/2_ONNXExample.py
+++ b/maraboupy/examples/2_ONNXExample.py
@@ -55,7 +55,7 @@ network.setUpperBound(outputVars[1], 210.0)
 
 # %%
 # Call to Marabou solver
-vals, stats = network.solve(options = options)
+exitCode, vals, stats = network.solve(options = options)
 
 
 # %%
@@ -87,7 +87,8 @@ network.setLowerBound(outputVars[0], 6.0)
 # %%
 # Call to Marabou solver (should be SAT)
 print("Check query with less restrictive output constraint (Should be SAT)")
-vals, stats = network.solve(options = options)
+exitCode, vals, stats = network.solve(options = options)
+assert( exitCode == "sat")
 assert len(vals) > 0
 
 # %%
@@ -97,7 +98,8 @@ network.setLowerBound(outputVars[0], 7.0)
 # %%
 # Call to Marabou solver (should be UNSAT)
 print("Check query with more restrictive output constraint (Should be UNSAT)")
-vals, stats = network.solve(options = options)
+exitCode, vals, stats = network.solve(options = options)
+assert( exitCode == "unsat")
 assert len(vals) == 0
 
 

--- a/maraboupy/examples/3_MarabouCoreExample.py
+++ b/maraboupy/examples/3_MarabouCoreExample.py
@@ -104,9 +104,7 @@ MarabouCore.addReluConstraint(inputQuery, 3, 4)
 # Run Marabou to solve the query
 # This should return "sat"
 options = createOptions()
-vars, stats = MarabouCore.solve(inputQuery, options, "")
-if len(vars) > 0:
-    print("SAT")
+exitCode, vars, stats = MarabouCore.solve(inputQuery, options, "")
+print(exitCode)
+if exitCode == "sat":
     print(vars)
-else:
-    print("UNSAT")

--- a/maraboupy/examples/4_DncExample.py
+++ b/maraboupy/examples/4_DncExample.py
@@ -30,5 +30,7 @@ net.setLowerBound(net.outputVars[0][0], .5)
 # %%
 # Solve the query with DNC mode turned on, which should return satisfying variable values
 options = Marabou.createOptions(snc=True, verbosity=0, initialSplits=2);
-vals, stats = net.solve(options=options)
+exitCode, vals, stats = net.solve(options=options)
+print(exitCode)
+assert(exitCode == "sat")
 assert len(vals) > 0

--- a/maraboupy/examples/5_DisjunctionConstraintExample.py
+++ b/maraboupy/examples/5_DisjunctionConstraintExample.py
@@ -54,8 +54,7 @@ for var in net1.inputVars[0]:
 
 # %%
 # Solve Marabou query
-vals1, stats1 = net1.solve()
-
+exitCode1, vals1, stats1 = net1.solve()
 
 # %%
 # Example statistics

--- a/maraboupy/test/test_core.py
+++ b/maraboupy/test/test_core.py
@@ -18,10 +18,11 @@ def test_solve_partial_arguments():
     """
     ipq = define_ipq(-2.0)
     # Test partial arguments to solve
-    vals, stats = MarabouCore.solve(ipq, OPT)
+    exitCode, vals, stats = MarabouCore.solve(ipq, OPT)
     # Assert that Marabou returned UNSAT
     assert not stats.hasTimedOut()
     assert len(vals) == 0
+    assert(exitCode == "unsat")
 
 def test_dump_query():
     """
@@ -36,7 +37,7 @@ def test_dump_query():
     assert ipq.getUpperBound(2) > LARGE
 
     # Solve
-    vals, stats = MarabouCore.solve(ipq, OPT, "")
+    exitCode, vals, stats = MarabouCore.solve(ipq, OPT, "")
 
     # Test dump
     ipq.dump()
@@ -48,6 +49,7 @@ def test_dump_query():
     for var in vals:
         assert vals[var] >= ipq.getLowerBound(var)
         assert vals[var] <= ipq.getUpperBound(var)
+    assert(exitCode == "sat")
 
     # Marabou should find tighter bounds than LARGE after bound propagation, including
     # for variable 2, where no upper bound was explicitly given

--- a/maraboupy/test/test_dnc.py
+++ b/maraboupy/test/test_dnc.py
@@ -28,8 +28,8 @@ def test_dnc_unsat():
     network.setLowerBound(outVar, 0.1)
 
     # Expect UNSAT result
-    vals, stats = network.solve(options = OPT, filename = "", verbose=False)
-    assert len(vals) == 0
+    exitCode, vals, stats = network.solve(options = OPT, filename = "", verbose=False)
+    assert exitCode == "unsat"
     
 def test_dnc_sat():
     """
@@ -50,8 +50,8 @@ def test_dnc_sat():
     network.setLowerBound(outVar, 0.0)
 
     # Expect SAT result, which should return a dictionary with a value for every network variable
-    vals, stats = network.solve(options = OPT, filename = "", verbose=False)
-    assert len(vals) == network.numVars
+    exitCode, vals, stats = network.solve(options = OPT, filename = "", verbose=False)
+    assert exitCode == "sat" and len(vals) == network.numVars
 
 def test_dnc_eval():
     """

--- a/maraboupy/test/test_equation.py
+++ b/maraboupy/test/test_equation.py
@@ -30,7 +30,7 @@ def test_equality_output():
         network.addEquality([outputVar], [1.0], outputValue)
 
         # Call to Marabou solver
-        vals, _ = network.solve(options = OPT, verbose = False)
+        exitCode, vals, _ = network.solve(options = OPT, verbose = False)
         assert np.abs(vals[outputVar] - outputValue) < TOL
         
         # Remove inequality constraint, so that a new one can be applied in the next iteration
@@ -57,7 +57,7 @@ def test_equality_input():
     network.setLowerBound(outputVar, minOutputValue)
     
     # Call to Marabou solver
-    vals, _ = network.solve(options = OPT, verbose = False)
+    exitCode, vals, _ = network.solve(options = OPT, verbose = False)
     assert np.abs(np.dot([vals[inVar] for inVar in inputVars], weights) - averageInputValue) < TOL
     assert vals[outputVar] >= minOutputValue
 
@@ -77,7 +77,7 @@ def test_inequality_output():
         network.addInequality(outputVars, weights, outputValue)
 
         # Call to Marabou solver
-        vals, _ = network.solve(options = OPT, verbose = False)
+        exitCode, vals, _ = network.solve(options = OPT, verbose = False)
         assert np.dot([vals[outVar] for outVar in outputVars], weights) <= outputValue
         
         # Remove inequality constraint, so that a new one can be applied in the next iteration
@@ -104,7 +104,7 @@ def test_inequality_input():
     network.setLowerBound(outputVar, minOutputValue)
     
     # Call to Marabou solver
-    vals, _ = network.solve(options = OPT, verbose = False)
+    exitCode, vals, _ = network.solve(options = OPT, verbose = False)
     assert np.dot([vals[inVar] for inVar in inputVars], weights) <= averageInputValue
     assert vals[outputVar] >= minOutputValue
     

--- a/maraboupy/test/test_network.py
+++ b/maraboupy/test/test_network.py
@@ -74,7 +74,7 @@ def test_disjunction_constraint():
         network.setLowerBound(var, 0)
         network.setUpperBound(var, 1)
 
-    vals1, stats1 = network.solve()
+    exitCode1, vals1, stats1 = network.solve()
 
     for var in network.inputVars[0]:
         assert(abs(vals1[var] - 1) < 0.0000001 or abs(vals1[var]) < 0.0000001)
@@ -110,7 +110,7 @@ def test_batch_norm():
     network.setLowerBound(inputVars[1], 1)
     network.setUpperBound(inputVars[1], 1)
 
-    vals, _ = network.solve(options = options)
+    exitCode, vals, _ = network.solve(options = options)
     assert abs(vals[outputVars[0]] - 9.9999799728) < TOL
 
 def test_local_robustness_unsat():

--- a/maraboupy/test/test_query.py
+++ b/maraboupy/test/test_query.py
@@ -36,8 +36,8 @@ def test_sat_query(tmpdir):
     # The result should be the same regardless of verbosity options used, or if a file redirect is used
     tempFile = tmpdir.mkdir("redirect").join("marabouRedirect.log").strpath
     opt = Marabou.createOptions(verbosity = 0)
-    vals_net, _ = network.solve(filename = tempFile)
-    vals_ipq, _ = Marabou.solve_query(ipq, filename = tempFile)
+    exitCode_net, vals_net, _ = network.solve(filename = tempFile)
+    exitCode_ipq, vals_ipq, _ = Marabou.solve_query(ipq, filename = tempFile)
     
     # The two value dictionaries should have the same number of variables, 
     # and the same keys
@@ -64,15 +64,16 @@ def test_unsat_query(tmpdir):
     
     # Solve the query loaded from the file and compare to the solution of the original query
     opt = Marabou.createOptions(verbosity = 0)
-    vals_net, stats_net = network.solve(options = opt)
-    vals_ipq, stats_ipq = Marabou.solve_query(ipq, options = opt)
+    exitCode_net, vals_net, stats_net = network.solve(options = opt)
+    exitCode_ipq, vals_ipq, stats_ipq = Marabou.solve_query(ipq, options = opt)
     
     # Assert the value dictionaries are both empty, and both queries have not timed out (unsat)
     assert len(vals_net) == 0
     assert len(vals_ipq) == 0
     assert not stats_net.hasTimedOut()
     assert not stats_ipq.hasTimedOut()
-    
+    assert(exitCode_net == "unsat" and exitCode_ipq == "unsat")
+
 def test_to_query(tmpdir):
     """
     Test that a query generated from Maraboupy can be saved and loaded correctly and return timeout.
@@ -94,13 +95,13 @@ def test_to_query(tmpdir):
     
     # Solve the query loaded from the file and compare to the solution of the original query
     opt = Marabou.createOptions(verbosity = 0, timeoutInSeconds = 1)
-    vals_net, stats_net = network.solve(options = opt)
-    vals_ipq, stats_ipq = Marabou.solve_query(ipq, options = opt)
+    exitCode_net, vals_net, stats_net = network.solve(options = opt)
+    exitCode_ipq, vals_ipq, stats_ipq = Marabou.solve_query(ipq, options = opt)
     
     # Assert timeout
     assert stats_net.hasTimedOut()
     assert stats_ipq.hasTimedOut()
-
+    assert(exitCode_net == "TIMEOUT" and exitCode_ipq == "TIMEOUT")
 
 def test_get_marabou_query(tmpdir):
     '''

--- a/maraboupy/test/test_statistics.py
+++ b/maraboupy/test/test_statistics.py
@@ -17,7 +17,7 @@ def test_statistics():
     ipq.setUpperBound(0, 1)
 
     opt = createOptions(verbosity = 0) # Turn off printing
-    vals, stats = MarabouCore.solve(ipq, opt, "")
+    exitCode, vals, stats = MarabouCore.solve(ipq, opt, "")
     assert(stats.getUnsignedAttribute(MarabouCore.StatisticsUnsignedAttribute.NUM_SPLITS) == 0)
     assert(stats.getLongAttribute(MarabouCore.StatisticsLongAttribute.TIME_MAIN_LOOP_MICRO) == 0)
     assert(stats.getDoubleAttribute(MarabouCore.StatisticsDoubleAttribute.MAX_DEGRADATION) == 0)

--- a/src/configuration/GlobalConfiguration.cpp
+++ b/src/configuration/GlobalConfiguration.cpp
@@ -59,7 +59,7 @@ const double GlobalConfiguration::SYMBOLIC_TIGHTENING_ROUNDING_CONSTANT = 0.0000
 const bool GlobalConfiguration::PREPROCESS_INPUT_QUERY = true;
 const bool GlobalConfiguration::PREPROCESSOR_ELIMINATE_VARIABLES = true;
 const bool GlobalConfiguration::PREPROCESSOR_PL_CONSTRAINTS_ADD_AUX_EQUATIONS = true;
-const double GlobalConfiguration::PREPROCESSOR_ALMOST_FIXED_THRESHOLD = 0.00000001;
+const double GlobalConfiguration::PREPROCESSOR_ALMOST_FIXED_THRESHOLD = 0.00001;
 const bool GlobalConfiguration::PREPROCESSOR_MERGE_CONSECUTIVE_WEIGHTED_SUMS = false;
 
 const bool GlobalConfiguration::WARM_START = false;
@@ -70,8 +70,8 @@ const unsigned GlobalConfiguration::PSE_ITERATIONS_BEFORE_RESET = 1000;
 const double GlobalConfiguration::PSE_GAMMA_ERROR_THRESHOLD = 0.001;
 const double GlobalConfiguration::PSE_GAMMA_UPDATE_TOLERANCE = 0.000000001;
 
-const double GlobalConfiguration::RELU_CONSTRAINT_COMPARISON_TOLERANCE = 0.00000001;
-const double GlobalConfiguration::ABS_CONSTRAINT_COMPARISON_TOLERANCE = 0.00000001;
+const double GlobalConfiguration::RELU_CONSTRAINT_COMPARISON_TOLERANCE = 0.00001;
+const double GlobalConfiguration::ABS_CONSTRAINT_COMPARISON_TOLERANCE = 0.00001;
 
 const bool GlobalConfiguration::ONLY_AUX_INITIAL_BASIS = false;
 

--- a/src/configuration/GlobalConfiguration.cpp
+++ b/src/configuration/GlobalConfiguration.cpp
@@ -59,7 +59,7 @@ const double GlobalConfiguration::SYMBOLIC_TIGHTENING_ROUNDING_CONSTANT = 0.0000
 const bool GlobalConfiguration::PREPROCESS_INPUT_QUERY = true;
 const bool GlobalConfiguration::PREPROCESSOR_ELIMINATE_VARIABLES = true;
 const bool GlobalConfiguration::PREPROCESSOR_PL_CONSTRAINTS_ADD_AUX_EQUATIONS = true;
-const double GlobalConfiguration::PREPROCESSOR_ALMOST_FIXED_THRESHOLD = 0.00001;
+const double GlobalConfiguration::PREPROCESSOR_ALMOST_FIXED_THRESHOLD = 0.00000001;
 const bool GlobalConfiguration::PREPROCESSOR_MERGE_CONSECUTIVE_WEIGHTED_SUMS = false;
 
 const bool GlobalConfiguration::WARM_START = false;
@@ -70,8 +70,8 @@ const unsigned GlobalConfiguration::PSE_ITERATIONS_BEFORE_RESET = 1000;
 const double GlobalConfiguration::PSE_GAMMA_ERROR_THRESHOLD = 0.001;
 const double GlobalConfiguration::PSE_GAMMA_UPDATE_TOLERANCE = 0.000000001;
 
-const double GlobalConfiguration::RELU_CONSTRAINT_COMPARISON_TOLERANCE = 0.00001;
-const double GlobalConfiguration::ABS_CONSTRAINT_COMPARISON_TOLERANCE = 0.00001;
+const double GlobalConfiguration::RELU_CONSTRAINT_COMPARISON_TOLERANCE = 0.00000001;
+const double GlobalConfiguration::ABS_CONSTRAINT_COMPARISON_TOLERANCE = 0.00000001;
 
 const bool GlobalConfiguration::ONLY_AUX_INITIAL_BASIS = false;
 

--- a/src/configuration/GlobalConfiguration.cpp
+++ b/src/configuration/GlobalConfiguration.cpp
@@ -59,7 +59,7 @@ const double GlobalConfiguration::SYMBOLIC_TIGHTENING_ROUNDING_CONSTANT = 0.0000
 const bool GlobalConfiguration::PREPROCESS_INPUT_QUERY = true;
 const bool GlobalConfiguration::PREPROCESSOR_ELIMINATE_VARIABLES = true;
 const bool GlobalConfiguration::PREPROCESSOR_PL_CONSTRAINTS_ADD_AUX_EQUATIONS = true;
-const double GlobalConfiguration::PREPROCESSOR_ALMOST_FIXED_THRESHOLD = 1e-6;
+const double GlobalConfiguration::PREPROCESSOR_ALMOST_FIXED_THRESHOLD = 0.00001;
 const bool GlobalConfiguration::PREPROCESSOR_MERGE_CONSECUTIVE_WEIGHTED_SUMS = false;
 
 const bool GlobalConfiguration::WARM_START = false;
@@ -70,8 +70,8 @@ const unsigned GlobalConfiguration::PSE_ITERATIONS_BEFORE_RESET = 1000;
 const double GlobalConfiguration::PSE_GAMMA_ERROR_THRESHOLD = 0.001;
 const double GlobalConfiguration::PSE_GAMMA_UPDATE_TOLERANCE = 0.000000001;
 
-const double GlobalConfiguration::RELU_CONSTRAINT_COMPARISON_TOLERANCE = 1e-6;
-const double GlobalConfiguration::ABS_CONSTRAINT_COMPARISON_TOLERANCE = 1e-6;
+const double GlobalConfiguration::RELU_CONSTRAINT_COMPARISON_TOLERANCE = 0.00001;
+const double GlobalConfiguration::ABS_CONSTRAINT_COMPARISON_TOLERANCE = 0.00001;
 
 const bool GlobalConfiguration::ONLY_AUX_INITIAL_BASIS = false;
 

--- a/src/configuration/GlobalConfiguration.cpp
+++ b/src/configuration/GlobalConfiguration.cpp
@@ -59,7 +59,7 @@ const double GlobalConfiguration::SYMBOLIC_TIGHTENING_ROUNDING_CONSTANT = 0.0000
 const bool GlobalConfiguration::PREPROCESS_INPUT_QUERY = true;
 const bool GlobalConfiguration::PREPROCESSOR_ELIMINATE_VARIABLES = true;
 const bool GlobalConfiguration::PREPROCESSOR_PL_CONSTRAINTS_ADD_AUX_EQUATIONS = true;
-const double GlobalConfiguration::PREPROCESSOR_ALMOST_FIXED_THRESHOLD = 0.00001;
+const double GlobalConfiguration::PREPROCESSOR_ALMOST_FIXED_THRESHOLD = 1e-6;
 const bool GlobalConfiguration::PREPROCESSOR_MERGE_CONSECUTIVE_WEIGHTED_SUMS = false;
 
 const bool GlobalConfiguration::WARM_START = false;
@@ -70,8 +70,8 @@ const unsigned GlobalConfiguration::PSE_ITERATIONS_BEFORE_RESET = 1000;
 const double GlobalConfiguration::PSE_GAMMA_ERROR_THRESHOLD = 0.001;
 const double GlobalConfiguration::PSE_GAMMA_UPDATE_TOLERANCE = 0.000000001;
 
-const double GlobalConfiguration::RELU_CONSTRAINT_COMPARISON_TOLERANCE = 0.00001;
-const double GlobalConfiguration::ABS_CONSTRAINT_COMPARISON_TOLERANCE = 0.00001;
+const double GlobalConfiguration::RELU_CONSTRAINT_COMPARISON_TOLERANCE = 1e-6;
+const double GlobalConfiguration::ABS_CONSTRAINT_COMPARISON_TOLERANCE = 1e-6;
 
 const bool GlobalConfiguration::ONLY_AUX_INITIAL_BASIS = false;
 


### PR DESCRIPTION
1. Now the solve method of Maraboupy returns the exitcode of the Engine. Before there was no way to differ "error" and "unsat".
2. Extended the tests/examples accordingly.
3. decrease the default value of the numerical tolerance. 
