### PR TITLE
Add BoundManager object to the Tableau

### DIFF
--- a/src/engine/AutoTableau.h
+++ b/src/engine/AutoTableau.h
@@ -16,15 +16,17 @@
 #ifndef __AutoTableau_h__
 #define __AutoTableau_h__
 
+#include "BoundManager.h"
+
 #include "ITableau.h"
 #include "T/TableauFactory.h"
 
 class AutoTableau
 {
 public:
-	AutoTableau()
+	AutoTableau( BoundManager &boundManager )
 	{
-		_tableau = T::createTableau();
+		_tableau = T::createTableau( boundManager );
 	}
 
 	~AutoTableau()

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -37,6 +37,7 @@
 Engine::Engine()
     : _context()
     , _boundManager( _context )
+    , _tableau( _boundManager )
     , _rowBoundTightener( *_tableau )
     , _smtCore( this )
     , _numPlConstraintsDisabledByValidSplits( 0 )

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -35,7 +35,9 @@
 #include <random>
 
 Engine::Engine()
-    : _rowBoundTightener( *_tableau )
+    : _context()
+    , _boundManager( _context )
+    , _rowBoundTightener( *_tableau )
     , _smtCore( this )
     , _numPlConstraintsDisabledByValidSplits( 0 )
     , _preprocessingEnabled( false )

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -22,6 +22,7 @@
 #include "AutoRowBoundTightener.h"
 #include "AutoTableau.h"
 #include "BlandsRule.h"
+#include "BoundManager.h"
 #include "DantzigsRule.h"
 #include "DegradationChecker.h"
 #include "DivideStrategy.h"
@@ -42,7 +43,9 @@
 #include "SumOfInfeasibilitiesManager.h"
 #include "SymbolicBoundTighteningType.h"
 
+#include <context/context.h>
 #include <atomic>
+
 
 #ifdef _WIN32
 #undef ERROR
@@ -54,6 +57,9 @@ class EngineState;
 class InputQuery;
 class PiecewiseLinearConstraint;
 class String;
+
+
+using CVC4::context::Context;
 
 class Engine : public IEngine, public SignalHandler::Signalable
 {
@@ -223,6 +229,19 @@ private:
       access to the explicit basis matrix.
     */
     void explicitBasisBoundTightening();
+
+    /*
+       Context is the central object that manages memory and back-tracking
+       across context-dependent components - SMTCore,
+       PiecewiseLinearConstraints, BoundManager, etc.
+     */
+    Context _context;
+
+    /*
+       BoundManager is the centralized context-dependent object that stores
+       derived bounds.
+     */
+    BoundManager _boundManager;
 
     /*
       Collect and print various statistics.
@@ -615,7 +634,7 @@ private:
 
     /*
       Call MILP bound tightening for a single layer.
-    */    
+    */
     void performMILPSolverBoundedTighteningForSingleLayer( unsigned targetIndex );
 
     /*
@@ -681,11 +700,3 @@ private:
 };
 
 #endif // __Engine_h__
-
-//
-// Local Variables:
-// compile-command: "make -C ../.. "
-// tags-file-name: "../../TAGS"
-// c-basic-offset: 4
-// End:
-//

--- a/src/engine/ITableau.h
+++ b/src/engine/ITableau.h
@@ -16,6 +16,8 @@
 #ifndef __ITableau_h__
 #define __ITableau_h__
 
+
+#include "BoundManager.h"
 #include "List.h"
 #include "Set.h"
 
@@ -180,6 +182,7 @@ public:
     virtual bool areLinearlyDependent( unsigned x1, unsigned x2, double &coefficient, double &inverseCoefficient ) = 0;
     virtual unsigned getVariableAfterMerging( unsigned variable ) const = 0;
     virtual void postContextPopHook() = 0;
+    virtual BoundManager &getBoundManager() const = 0;
 
     bool isOptimizing() const
     {

--- a/src/engine/T/TableauFactory.h
+++ b/src/engine/T/TableauFactory.h
@@ -16,6 +16,8 @@
 #ifndef __T__TableauFactory_h__
 #define __T__TableauFactory_h__
 
+#include "BoundManager.h"
+
 #include "cxxtest/Mock.h"
 
 class ITableau;
@@ -23,16 +25,16 @@ class ISelector;
 
 namespace T
 {
-	ITableau *createTableau();
+	ITableau *createTableau( BoundManager &BoundManager );
 	void discardTableau( ITableau *tableau );
 }
 
 CXXTEST_SUPPLY( createTableau,
 				ITableau *,
 				createTableau,
-				(),
+        ( BoundManager &boundManager ),
 				T::createTableau,
-				() );
+				( boundManager ) );
 
 CXXTEST_SUPPLY_VOID( discardTableau,
 					 discardTableau,

--- a/src/engine/Tableau.cpp
+++ b/src/engine/Tableau.cpp
@@ -32,9 +32,11 @@
 
 #include <string.h>
 
-Tableau::Tableau()
-    : _n( 0 )
-    , _m( 0 )
+Tableau::Tableau( BoundManager &boundManager )
+    : _boundManager( boundManager )
+    , _useBoundManager( false )
+    , _n ( 0 )
+    , _m ( 0 )
     , _A( NULL )
     , _sparseColumnsOfA( NULL )
     , _sparseRowsOfA( NULL )
@@ -53,7 +55,6 @@ Tableau::Tableau()
     , _nonBasicAssignment( NULL )
     , _lowerBounds( NULL )
     , _upperBounds( NULL )
-    , _boundManager( nullptr )
     , _boundsValid( true )
     , _basicAssignment( NULL )
     , _basicStatus( NULL )
@@ -474,8 +475,8 @@ void Tableau::computeBasicStatus( unsigned basicIndex )
 void Tableau::setLowerBound( unsigned variable, double value )
 {
     ASSERT( variable < _n );
-    if ( _boundManager !=  nullptr )
-        _boundManager->setLowerBound( variable, value );
+    if ( _useBoundManager )
+        _boundManager.setLowerBound( variable, value );
     else
         _lowerBounds[variable] = value;
     notifyLowerBound( variable, value );
@@ -485,8 +486,8 @@ void Tableau::setLowerBound( unsigned variable, double value )
 void Tableau::setUpperBound( unsigned variable, double value )
 {
     ASSERT( variable < _n );
-    if ( _boundManager !=  nullptr )
-        _boundManager->setUpperBound( variable, value );
+    if ( _useBoundManager )
+        _boundManager.setUpperBound( variable, value );
     else
         _upperBounds[variable] = value;
     notifyUpperBound( variable, value );
@@ -496,14 +497,14 @@ void Tableau::setUpperBound( unsigned variable, double value )
 double Tableau::getLowerBound( unsigned variable ) const
 {
     ASSERT( variable < _n );
-    return ( _boundManager != nullptr ) ? _boundManager->getLowerBound( variable )
+    return ( _useBoundManager ) ? _boundManager.getLowerBound( variable )
                                         : _lowerBounds[variable];
 }
 
 double Tableau::getUpperBound( unsigned variable ) const
 {
     ASSERT( variable < _n );
-    return ( _boundManager != nullptr ) ? _boundManager->getUpperBound( variable )
+    return ( _useBoundManager ) ? _boundManager.getUpperBound( variable )
                                         : _upperBounds[variable];
 }
 
@@ -2645,11 +2646,3 @@ bool Tableau::areLinearlyDependent( unsigned x1, unsigned x2, double &coefficien
 
     return true;
 }
-
-//
-// Local Variables:
-// compile-command: "make -C ../.. "
-// tags-file-name: "../../TAGS"
-// c-basic-offset: 4
-// End:
-//

--- a/src/engine/Tableau.h
+++ b/src/engine/Tableau.h
@@ -153,6 +153,8 @@ public:
     const double *getLowerBounds() const;
     const double *getUpperBounds() const;
 
+    BoundManager &getBoundManager() const { return _boundManager; }
+
     /*
       Recomputes bound valid status for all variables.
     */

--- a/src/engine/Tableau.h
+++ b/src/engine/Tableau.h
@@ -37,7 +37,7 @@ class TableauState;
 class Tableau : public ITableau, public IBasisFactorization::BasisColumnOracle
 {
 public:
-    Tableau();
+    Tableau( BoundManager &boundManager );
     ~Tableau();
 
     /*
@@ -461,6 +461,11 @@ public:
      */
     void postContextPopHook() { computeBasicStatus(); };
 
+    /*
+       Enables use of BoundManager to store Tableau bounds
+     */
+    void enableBoundManager() { _useBoundManager = true; };
+
 private:
     /*
       Variable watchers
@@ -473,6 +478,18 @@ private:
       Resize watchers
     */
     List<ResizeWatcher *> _resizeWatchers;
+
+    /*
+       BoundManager object stores bounds of all variables.
+     */
+    BoundManager &_boundManager;
+
+    /*
+       Flag to indicate whether the BoundManager should be used to manage
+       bounds. Temporary flag to enable updating class signatures without using
+       the features until they are ready
+     */
+    bool _useBoundManager; 
 
     /*
       The dimensions of matrix A
@@ -556,12 +573,6 @@ private:
     */
     double *_lowerBounds;
     double *_upperBounds;
-
-    /*
-       BoundManager object stores bounds of all variables.
-       NOT YET IN USE
-     */
-    BoundManager *_boundManager;
 
     /*
       Whether all variables have valid bounds (l <= u).

--- a/src/engine/real/TableauFactory.cpp
+++ b/src/engine/real/TableauFactory.cpp
@@ -17,9 +17,9 @@
 
 namespace T
 {
-	ITableau *createTableau()
+	ITableau *createTableau( BoundManager &boundManager )
 	{
-		return new Tableau();
+		return new Tableau( boundManager );
 	}
 
 	void discardTableau( ITableau *tableau )

--- a/src/engine/tests/MockTableau.h
+++ b/src/engine/tests/MockTableau.h
@@ -16,6 +16,8 @@
 #ifndef __MockTableau_h__
 #define __MockTableau_h__
 
+#include "BoundManager.h"
+#include "context/context.h"
 #include "FloatUtils.h"
 #include "ITableau.h"
 #include "Map.h"
@@ -45,6 +47,9 @@ public:
         lastCostFunctionManager = NULL;
 
         nextLinearlyDependentResult = false;
+
+        CVC4::context::Context ctx;
+        _boundManager = new BoundManager( ctx );
     }
 
     ~MockTableau()
@@ -78,10 +83,15 @@ public:
             delete[] nextCostFunction;
             nextCostFunction = NULL;
         }
+
+        if ( _boundManager )
+        {
+            delete _boundManager;
+        }
     }
 
-	bool wasCreated;
-	bool wasDiscarded;
+    bool wasCreated;
+    bool wasDiscarded;
 
     List<unsigned> mockCandidates;
     unsigned mockEnteringVariable;
@@ -95,18 +105,18 @@ public:
         mockEnteringVariable = nonBasic;
     }
 
-	void mockConstructor()
-	{
-		TS_ASSERT( !wasCreated );
-		wasCreated = true;
-	}
+    void mockConstructor()
+    {
+        TS_ASSERT( !wasCreated );
+        wasCreated = true;
+    }
 
-	void mockDestructor()
-	{
-		TS_ASSERT( wasCreated );
-		TS_ASSERT( !wasDiscarded );
-		wasDiscarded = true;
-	}
+    void mockDestructor()
+    {
+        TS_ASSERT( wasCreated );
+        TS_ASSERT( !wasDiscarded );
+        wasDiscarded = true;
+    }
 
     bool setDimensionsCalled;
     unsigned lastM;
@@ -598,6 +608,12 @@ public:
     }
 
     void postContextPopHook() {}
+
+    BoundManager *_boundManager;
+    BoundManager &getBoundManager() const
+    {
+        return *_boundManager;
+    }
 };
 
 #endif // __MockTableau_h__

--- a/src/engine/tests/MockTableauFactory.h
+++ b/src/engine/tests/MockTableauFactory.h
@@ -16,6 +16,8 @@
 #ifndef __MockTableauFactory_h__
 #define __MockTableauFactory_h__
 
+#include "BoundManager.h"
+
 #include "MockTableau.h"
 #include "T/TableauFactory.h"
 
@@ -34,7 +36,7 @@ public:
 		}
 	}
 
-	ITableau *createTableau()
+	ITableau *createTableau( BoundManager &/*boundManager*/ )
 	{
 		mockTableau.mockConstructor();
 		return &mockTableau;

--- a/src/engine/tests/Test_Tableau.h
+++ b/src/engine/tests/Test_Tableau.h
@@ -16,6 +16,8 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "BoundManager.h"
+#include "context/context.h"
 #include "Equation.h"
 #include "MockCostFunctionManager.h"
 #include "MockErrno.h"
@@ -25,6 +27,8 @@
 #include "TableauState.h"
 
 #include <string.h>
+
+using namespace CVC4::context;
 
 class MockForTableau
 {
@@ -111,9 +115,12 @@ public:
     void test_initialize_bounds()
     {
         Tableau *tableau = NULL;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         initializeTableauValues( *tableau );
 
@@ -129,9 +136,12 @@ public:
     void test_initalize_basis_get_value()
     {
         Tableau *tableau = NULL;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         initializeTableauValues( *tableau );
 
@@ -174,9 +184,12 @@ public:
     void test_watcher__value_changes()
     {
         Tableau *tableau = NULL;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         initializeTableauValues( *tableau );
 
@@ -231,9 +244,12 @@ public:
     {
         Tableau *tableau = NULL;
         MockCostFunctionManager costFunctionManager;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         tableau->registerCostFunctionManager( &costFunctionManager );
         initializeTableauValues( *tableau );
@@ -283,9 +299,12 @@ public:
     {
         Tableau *tableau = NULL;
         MockCostFunctionManager costFunctionManager;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         tableau->registerCostFunctionManager( &costFunctionManager );
         initializeTableauValues( *tableau );
@@ -335,8 +354,12 @@ public:
     {
         Tableau *tableau = NULL;
         MockCostFunctionManager costFunctionManager;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
+
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
 
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         tableau->registerCostFunctionManager( &costFunctionManager );
@@ -446,9 +469,12 @@ public:
     {
         Tableau *tableau = NULL;
         MockCostFunctionManager costFunctionManager;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         tableau->registerCostFunctionManager( &costFunctionManager );
         initializeTableauValues( *tableau );
@@ -508,9 +534,12 @@ public:
     {
         Tableau *tableau = NULL;
         MockCostFunctionManager costFunctionManager;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         tableau->registerCostFunctionManager( &costFunctionManager );
         initializeTableauValues( *tableau );
@@ -586,9 +615,12 @@ public:
     {
         Tableau *tableau = NULL;
         MockCostFunctionManager costFunctionManager;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         tableau->registerCostFunctionManager( &costFunctionManager );
         initializeTableauValues( *tableau );
@@ -795,9 +827,12 @@ public:
     {
         Tableau *tableau = NULL;
         MockCostFunctionManager costFunctionManager;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         tableau->registerCostFunctionManager( &costFunctionManager );
         initializeTableauValues( *tableau );
@@ -996,9 +1031,12 @@ public:
     {
         Tableau *tableau = NULL;
         MockCostFunctionManager costFunctionManager;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         // Initialization steps
 
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
@@ -1126,9 +1164,12 @@ public:
     {
         Tableau *tableau = NULL;
         MockCostFunctionManager costFunctionManager;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         tableau->registerCostFunctionManager( &costFunctionManager );
         initializeTableauValues( *tableau );
@@ -1283,9 +1324,12 @@ public:
     {
         Tableau *tableau = NULL;
         MockCostFunctionManager costFunctionManager;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         tableau->registerCostFunctionManager( &costFunctionManager );
         initializeTableauValues( *tableau );
@@ -1360,9 +1404,12 @@ public:
     {
         Tableau *tableau = NULL;
         MockCostFunctionManager costFunctionManager;
+        Context context;
+        BoundManager boundManager( context );
 
-        TS_ASSERT( tableau = new Tableau );
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
+        TS_ASSERT_THROWS_NOTHING( boundManager.initialize( 7 ) );
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         tableau->registerCostFunctionManager( &costFunctionManager );
         initializeTableauValues( *tableau );
@@ -1536,7 +1583,10 @@ public:
         Tableau *tableau = NULL;
         MockCostFunctionManager costFunctionManager;
 
-        TS_ASSERT( tableau = new Tableau );
+        Context context;
+        BoundManager boundManager( context );
+
+        TS_ASSERT( tableau = new Tableau( boundManager ) );
 
         TS_ASSERT_THROWS_NOTHING( tableau->setDimensions( 3, 7 ) );
         tableau->registerCostFunctionManager( &costFunctionManager );


### PR DESCRIPTION
This PR passed a BoundManager object to the Tableau which is not used by default. 
The PR introduces  _useBoundManager flag and Tableau::enableBoundManager() 
method (for purposes of testing and integration).


