### PR TITLE
Put back random seed setting. 

### DIFF
--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -77,6 +77,7 @@ Engine::Engine()
     _activeEntryStrategy = _projectedSteepestEdgeRule;
     _activeEntryStrategy->setStatistics( &_statistics );
     _statistics.stampStartingTime();
+    setRandomSeed( Options::get()->getInt( Options::SEED ) );
 }
 
 Engine::~Engine()


### PR DESCRIPTION
Accidentally removed random seed setting in single-threaded mode.