### PR TITLE
Prevent access to Tableau internals when not in native mode

### DIFF
--- a/src/engine/Tableau.cpp
+++ b/src/engine/Tableau.cpp
@@ -1748,6 +1748,9 @@ bool Tableau::allBoundsValid() const
 
 void Tableau::updateVariableToComplyWithLowerBoundUpdate( unsigned variable, double value )
 {
+    if ( _lpSolverType == LPSolverType::GUROBI )
+      return;
+
     unsigned index = _variableToIndex[variable];
     if ( !_basicVariables.exists( variable ) )
     {
@@ -1767,6 +1770,9 @@ void Tableau::updateVariableToComplyWithLowerBoundUpdate( unsigned variable, dou
 
 void Tableau::updateVariableToComplyWithUpperBoundUpdate( unsigned variable, double value )
 {
+    if ( _lpSolverType == LPSolverType::GUROBI )
+      return;
+
     unsigned index = _variableToIndex[variable];
     if ( !_basicVariables.exists( variable ) )
     {


### PR DESCRIPTION
In Tableau::updateVariableToComplyWith*Bounds methods