### PR TITLE
Add export/import Assignment features for debugging

### DIFF
--- a/src/configuration/OptionParser.cpp
+++ b/src/configuration/OptionParser.cpp
@@ -43,7 +43,7 @@ void OptionParser::initialize()
     _positional.add_options()
         ( "input",
           boost::program_options::value<std::string>( &(*_stringOptions)[Options::INPUT_FILE_PATH] )->default_value( (*_stringOptions)[Options::INPUT_FILE_PATH] ),
-          "Neural netowrk file." )
+          "Neural network file." )
         ( "property",
           boost::program_options::value<std::string>( &(*_stringOptions)[Options::PROPERTY_FILE_PATH] )->default_value( (*_stringOptions)[Options::PROPERTY_FILE_PATH] ),
           "Property file." )
@@ -94,6 +94,18 @@ void OptionParser::initialize()
         ( "summary-file",
           boost::program_options::value<std::string>( &((*_stringOptions)[Options::SUMMARY_FILE]) )->default_value( (*_stringOptions)[Options::SUMMARY_FILE] ),
           "Produce a summary file of the run." )
+        ( "export-assignment",
+          boost::program_options::bool_switch( &((*_boolOptions)[Options::EXPORT_ASSIGNMENT]) )->default_value( (*_boolOptions)[Options::EXPORT_ASSIGNMENT] ),
+          "Export a satisfying assignment if found." )
+        ( "export-assignment-file",
+          boost::program_options::value<std::string>( &(*_stringOptions)[Options::EXPORT_ASSIGNMENT_FILE_PATH] )->default_value( (*_stringOptions)[Options::EXPORT_ASSIGNMENT_FILE_PATH] ),
+          "Specifies a file to export the assignment." )
+        ( "debug-assignment",
+          boost::program_options::bool_switch( &((*_boolOptions)[Options::DEBUG_ASSIGNMENT]) )->default_value( (*_boolOptions)[Options::DEBUG_ASSIGNMENT] ),
+          "Import an assignment for debugging." )
+        ( "debug-assignment-file",
+          boost::program_options::value<std::string>( &(*_stringOptions)[Options::EXPORT_ASSIGNMENT_FILE_PATH] )->default_value( (*_stringOptions)[Options::EXPORT_ASSIGNMENT_FILE_PATH] ),
+          "Specifies a file to import the assignment for debugging." )
 #ifdef ENABLE_GUROBI
 #endif // ENABLE_GUROBI
         ;

--- a/src/configuration/Options.cpp
+++ b/src/configuration/Options.cpp
@@ -49,6 +49,8 @@ void Options::initializeDefaultValues()
     _boolOptions[SOLVE_WITH_MILP] = false;
     _boolOptions[PERFORM_LP_TIGHTENING_AFTER_SPLIT] = false;
     _boolOptions[NO_PARALLEL_DEEPSOI] = false;
+    _boolOptions[EXPORT_ASSIGNMENT] = false;
+    _boolOptions[DEBUG_ASSIGNMENT] = false;
 
     /*
       Int options
@@ -86,6 +88,8 @@ void Options::initializeDefaultValues()
     _stringOptions[SYMBOLIC_BOUND_TIGHTENING_TYPE] = "deeppoly";
     _stringOptions[MILP_SOLVER_BOUND_TIGHTENING_TYPE] = "none";
     _stringOptions[QUERY_DUMP_FILE] = "";
+    _stringOptions[IMPORT_ASSIGNMENT_FILE_PATH] = "assignment.txt";
+    _stringOptions[EXPORT_ASSIGNMENT_FILE_PATH] = "assignment.txt";
     _stringOptions[SOI_SEARCH_STRATEGY] = "mcmc";
     _stringOptions[SOI_INITIALIZATION_STRATEGY] = "input-assignment";
     _stringOptions[LP_SOLVER] = gurobiEnabled() ? "gurobi" : "native";

--- a/src/configuration/Options.h
+++ b/src/configuration/Options.h
@@ -64,6 +64,12 @@ public:
         // with a different random seed on each thread. The problem is solved once
         // any of the thread finishes.
         NO_PARALLEL_DEEPSOI,
+
+        // Export SAT assignment into a file, use EXPORT_ASSIGNMENT_FILE to specify the file (default: assignment.txt)
+        EXPORT_ASSIGNMENT,
+
+        // Import assignment for debugging purposes, use IMPORT_ASSIGNMENT_FILE to specify the file (default: assignment.txt)
+        DEBUG_ASSIGNMENT,
     };
 
     enum IntOptions {
@@ -90,7 +96,7 @@ public:
 
         // The random seed used throughout the execution.
         SEED,
-      
+
         // The number of threads to use for OpenBLAS matrix multiplication.
         NUM_BLAS_THREADS,
     };
@@ -119,6 +125,8 @@ public:
         SYMBOLIC_BOUND_TIGHTENING_TYPE,
         MILP_SOLVER_BOUND_TIGHTENING_TYPE,
         QUERY_DUMP_FILE,
+        EXPORT_ASSIGNMENT_FILE_PATH,
+        IMPORT_ASSIGNMENT_FILE_PATH,
 
         // The strategy used for soi minimization
         SOI_SEARCH_STRATEGY,
@@ -127,6 +135,7 @@ public:
 
         // The procedure/solver for solving the LP
         LP_SOLVER,
+
     };
 
     /*

--- a/src/engine/Marabou.h
+++ b/src/engine/Marabou.h
@@ -52,6 +52,16 @@ private:
     void displayResults( unsigned long long microSecondsElapsed ) const;
 
     /*
+      Export assignment as per Options
+     */
+    void exportAssignment() const;
+
+    /*
+      Import assignment for debugging as per Options
+     */
+    void importDebuggingSolution();
+
+    /*
       ACAS network parser
     */
     AcasParser *_acasParser;


### PR DESCRIPTION
This PR exposes functionality to debug a solution to the command line. See --help for detailed command line arguments.
This feature is intended for developers, but can be used to report bugs by the users as well. 
The basic use case scenario: a satisfying assignment is cut off (unsoundly) during the search on the development branch. 
The user can then export the satisfying assignment using the sound version of the tool and import it into the unsound version to obtain information at which point in the search is the satisfying assignment cut off.