### PR TITLE
export preprocess query to maraboupy

### DIFF
--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -281,9 +281,12 @@ struct MarabouOptions {
 
 /* The default parameters here are just for readability, you should specify
  * them to make them work*/
-InputQuery preprocess(InputQuery &inputQuery, MarabouOptions &options, std::string redirect=""){
+InputQuery preprocess(
+    InputQuery &inputQuery, MarabouOptions &options, std::string redirect="", bool returnFullyProcessedQuery = false
+){
     // Preprocess the input inquery (e.g., one can use it to just compute the gurobi bounds)
     // Arguments: InputQuery object, filename to redirect output
+    //            whether to return the fully processed query (symbolic and more), or just the initially processed query
     // Returns: Preprocessed input query
 
     options.setOptions();
@@ -301,7 +304,10 @@ InputQuery preprocess(InputQuery &inputQuery, MarabouOptions &options, std::stri
     if(output != -1)
         restoreOutputStream(output);
 
-    return *(engine.getInputQuery());
+    if (returnFullyProcessedQuery)
+        return engine.buildQueryFromCurrentState();
+    else
+        return *engine.getInputQuery();
 }
 
 std::string exitCodeToString( IEngine::ExitCode code )
@@ -445,11 +451,12 @@ PYBIND11_MODULE(MarabouCore, m) {
              inputQuery (:class:`~maraboupy.MarabouCore.InputQuery`): Marabou input query to be preproccessed
              options (class:`~maraboupy.MarabouCore.Options`): Object defining the options used for Marabou
              redirect (str, optional): Filepath to direct standard output, defaults to ""
+             returnFullyProcessedQuery (bool, optional): whether to return the fully processed query (symbolic and more), or just the initially processed query, default to False.
 
          Returns:
                  InputQuery (:class:`~maraboupy.MarabouCore.InputQuery`): the preprocessed input query
          )pbdoc",
-         py::arg("inputQuery"), py::arg("options"), py::arg("redirect") = "");
+         py::arg("inputQuery"), py::arg("options"), py::arg("redirect") = "", py::arg("returnFullyProcessedQuery") = false);
     m.def("solve", &solve, R"pbdoc(
         Takes in a description of the InputQuery and returns the solution
 

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -3090,7 +3090,6 @@ bool Engine::consistentBounds() const
     return _boundManager.consistentBounds();
 }
 
-
 InputQuery Engine::buildQueryFromCurrentState() const {
     InputQuery query = _preprocessedQuery;
     for ( unsigned i = 0; i < query.getNumberOfVariables(); ++i ) {

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -3089,3 +3089,13 @@ bool Engine::consistentBounds() const
 {
     return _boundManager.consistentBounds();
 }
+
+
+InputQuery Engine::buildQueryFromCurrentState() const {
+    InputQuery query = _preprocessedQuery;
+    for ( unsigned i = 0; i < query.getNumberOfVariables(); ++i ) {
+        query.setLowerBound( i, _tableau->getLowerBound( i ) );
+        query.setUpperBound( i, _tableau->getUpperBound( i ) );
+    }
+    return query;
+}

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -3091,7 +3091,7 @@ bool Engine::consistentBounds() const
 }
 
 InputQuery Engine::buildQueryFromCurrentState() const {
-    InputQuery query = _preprocessedQuery;
+    InputQuery query = *_preprocessedQuery;
     for ( unsigned i = 0; i < query.getNumberOfVariables(); ++i ) {
         query.setLowerBound( i, _tableau->getLowerBound( i ) );
         query.setUpperBound( i, _tableau->getUpperBound( i ) );

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -126,6 +126,8 @@ public:
 
     InputQuery *getInputQuery();
 
+    InputQuery buildQueryFromCurrentState() const;
+
     /*
       Get the exit code
     */


### PR DESCRIPTION
This add a way to get the current query with the current bound, allowing to return a processed query to maraboupy.