### PR TITLE
Refactor shared InputQuery preparation into `main.cpp`

### DIFF
--- a/src/engine/DnCMarabou.cpp
+++ b/src/engine/DnCMarabou.cpp
@@ -25,7 +25,7 @@
 #include "QueryLoader.h"
 #include "AcasParser.h"
 
-DnCMarabou::DnCMarabou( InputQuery& inputQuery )
+DnCMarabou::DnCMarabou( InputQuery &inputQuery )
     : _inputQuery( inputQuery )
     , _dncManager( nullptr )
 {

--- a/src/engine/DnCMarabou.cpp
+++ b/src/engine/DnCMarabou.cpp
@@ -25,83 +25,16 @@
 #include "QueryLoader.h"
 #include "AcasParser.h"
 
-DnCMarabou::DnCMarabou()
-    : _dncManager( nullptr )
-    , _inputQuery( InputQuery() )
+DnCMarabou::DnCMarabou( InputQuery& inputQuery )
+    : _inputQuery( inputQuery )
+    , _dncManager( nullptr )
 {
+
 }
 
 void DnCMarabou::run()
 {
-    String inputQueryFilePath = Options::get()->getString( Options::INPUT_QUERY_FILE_PATH );
-    if ( inputQueryFilePath.length() > 0 )
-    {
-        /*
-          Step 1: extract the query
-        */
-        if ( !File::exists( inputQueryFilePath ) )
-        {
-            printf( "Error: the specified inputQuery file (%s) doesn't exist!\n", inputQueryFilePath.ascii() );
-            throw MarabouError( MarabouError::FILE_DOESNT_EXIST, inputQueryFilePath.ascii() );
-        }
-
-        printf( "InputQuery: %s\n", inputQueryFilePath.ascii() );
-        _inputQuery = QueryLoader::loadQuery( inputQueryFilePath );
-        _inputQuery.constructNetworkLevelReasoner();
-    }
-    else
-    {
-        /*
-          Step 1: extract the network
-        */
-        String networkFilePath = Options::get()->getString( Options::INPUT_FILE_PATH );
-        if ( !File::exists( networkFilePath ) )
-        {
-            printf( "Error: the specified network file (%s) doesn't exist!\n",
-                    networkFilePath.ascii() );
-            throw MarabouError( MarabouError::FILE_DOESNT_EXIST,
-                                networkFilePath.ascii() );
-        }
-        printf( "Network: %s\n", networkFilePath.ascii() );
-
-        if ( ((String) networkFilePath).endsWith( ".onnx" ) )
-        {
-            OnnxParser* _onnxParser = new OnnxParser( networkFilePath );
-            _onnxParser->generateQuery( _inputQuery );
-        }
-        else
-        {
-            AcasParser* _acasParser = new AcasParser( networkFilePath );
-            _acasParser->generateQuery( _inputQuery );
-        }
-
-        _inputQuery.constructNetworkLevelReasoner();
-
-        /*
-          Step 2: extract the property in question
-        */
-        String propertyFilePath = Options::get()->getString( Options::PROPERTY_FILE_PATH );
-        if ( propertyFilePath != "" )
-        {
-            printf( "Property: %s\n", propertyFilePath.ascii() );
-            PropertyParser().parse( propertyFilePath, _inputQuery );
-        }
-        else
-            printf( "Property: None\n" );
-    }
-    printf( "\n" );
-
-    String queryDumpFilePath = Options::get()->getString( Options::QUERY_DUMP_FILE );
-    if ( queryDumpFilePath.length() > 0 )
-    {
-        _inputQuery.saveQuery( queryDumpFilePath );
-        printf( "\nInput query successfully dumped to file\n" );
-        exit( 0 );
-    }
-
-    /*
-      Step 3: initialize the DNC core
-    */
+    // Initialize the DNC core
     _dncManager = std::unique_ptr<DnCManager>
         ( new DnCManager( &_inputQuery ) );
 

--- a/src/engine/DnCMarabou.h
+++ b/src/engine/DnCMarabou.h
@@ -31,7 +31,7 @@ public:
     void run();
 
 private:
-    InputQuery& _inputQuery;
+    InputQuery &_inputQuery;
     std::unique_ptr<DnCManager> _dncManager;
     /*
       Display the results

--- a/src/engine/DnCMarabou.h
+++ b/src/engine/DnCMarabou.h
@@ -23,7 +23,7 @@
 class DnCMarabou
 {
 public:
-    DnCMarabou();
+    DnCMarabou( InputQuery& inputQuery );
 
     /*
       Entry point of this class
@@ -31,8 +31,8 @@ public:
     void run();
 
 private:
+    InputQuery& _inputQuery;
     std::unique_ptr<DnCManager> _dncManager;
-    InputQuery _inputQuery;
     /*
       Display the results
     */

--- a/src/engine/Marabou.h
+++ b/src/engine/Marabou.h
@@ -24,7 +24,7 @@
 class Marabou
 {
 public:
-    Marabou();
+    Marabou( InputQuery& inputQuery );
     ~Marabou();
 
     /*
@@ -35,11 +35,6 @@ public:
 private:
     InputQuery _inputQuery;
 
-    /*
-      Extract the options and input files (network and property), and
-      use them to generate the input query
-    */
-    void prepareInputQuery();
     void extractSplittingThreshold();
 
     /*
@@ -61,16 +56,6 @@ private:
       Import assignment for debugging as per Options
      */
     void importDebuggingSolution();
-
-    /*
-      ACAS network parser
-    */
-    AcasParser *_acasParser;
-
-    /*
-      ONNX network parser
-    */
-    OnnxParser *_onnxParser;
 
     /*
       The solver

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -83,6 +83,8 @@ InputQuery prepareInputQueryFromQueryFile( String inputQueryFilePath )
 */
 InputQuery prepareInputQueryFromNetworkAndPropertyFile()
 {
+    // TODO it would be good to time this and report the time (e.g. as in Marabou::run())
+
     InputQuery inputQuery = InputQuery();
 
     /*
@@ -178,6 +180,8 @@ int main( int argc, char **argv )
             printf( "Proof production is not yet supported with MILP solvers, turning SOLVE_WITH_MILP off.\n" );
         }
 
+        // TODO it would be good to pass a reference to the InputQuery object directly, rather
+        // than returning it here and incurring the overhead of the copy constructor.
         InputQuery inputQuery = prepareInputQuery();
         String queryDumpFilePath = Options::get()->getString( Options::QUERY_DUMP_FILE );
         if ( queryDumpFilePath.length() > 0 )

--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -17,6 +17,9 @@
 #include "Error.h"
 #include "Marabou.h"
 #include "Options.h"
+#include "File.h"
+#include "QueryLoader.h"
+#include "PropertyParser.h"
 
 #ifdef ENABLE_OPENBLAS
 #include "cblas.h"
@@ -57,6 +60,86 @@ void printHelpMessage()
     Options::get()->printHelpMessage();
 }
 
+InputQuery prepareInputQueryFromQueryFile( String inputQueryFilePath )
+{
+    /*
+        Step 1: extract the query
+    */
+    if ( !File::exists( inputQueryFilePath ) )
+    {
+        printf( "Error: the specified inputQuery file (%s) doesn't exist!\n", inputQueryFilePath.ascii() );
+        throw MarabouError( MarabouError::FILE_DOESNT_EXIST, inputQueryFilePath.ascii() );
+    }
+
+    printf( "InputQuery: %s\n", inputQueryFilePath.ascii() );
+    InputQuery inputQuery = QueryLoader::loadQuery( inputQueryFilePath );
+    inputQuery.constructNetworkLevelReasoner();
+    return inputQuery;
+}
+
+/*
+    Extract the options and input files (network and property), and
+    use them to generate the input query
+*/
+InputQuery prepareInputQueryFromNetworkAndPropertyFile()
+{
+    InputQuery inputQuery = InputQuery();
+
+    /*
+        Step 1: extract the network
+    */
+    String networkFilePath = Options::get()->getString( Options::INPUT_FILE_PATH );
+
+    if ( !File::exists( networkFilePath ) )
+    {
+        printf( "Error: the specified network file (%s) doesn't exist!\n", networkFilePath.ascii() );
+        throw MarabouError( MarabouError::FILE_DOESNT_EXIST, networkFilePath.ascii() );
+    }
+    printf( "Network: %s\n", networkFilePath.ascii() );
+
+    if ( ((String) networkFilePath).endsWith( ".onnx" ) )
+    {
+        OnnxParser* onnxParser = new OnnxParser( networkFilePath );
+        onnxParser->generateQuery( inputQuery );
+        delete onnxParser;
+        onnxParser = NULL;
+    }
+    else
+    {
+        AcasParser* acasParser = new AcasParser( networkFilePath );
+        acasParser->generateQuery( inputQuery );
+        delete acasParser;
+        acasParser = NULL;
+    }
+
+    inputQuery.constructNetworkLevelReasoner();
+
+    /*
+        Step 2: extract the property in question
+    */
+    String propertyFilePath = Options::get()->getString( Options::PROPERTY_FILE_PATH );
+    if ( propertyFilePath != "" )
+    {
+        printf( "Property: %s\n", propertyFilePath.ascii() );
+        PropertyParser().parse( propertyFilePath, inputQuery );
+    }
+    else
+        printf( "Property: None\n" );
+
+    printf( "\n" );
+
+    return inputQuery;
+}
+
+InputQuery prepareInputQuery()
+{
+    String inputQueryFilePath = Options::get()->getString( Options::INPUT_QUERY_FILE_PATH );
+    if ( inputQueryFilePath.length() > 0 )
+        return prepareInputQueryFromQueryFile( inputQueryFilePath );
+
+    return prepareInputQueryFromNetworkAndPropertyFile();
+}
+
 int main( int argc, char **argv )
 {
     try
@@ -95,18 +178,27 @@ int main( int argc, char **argv )
             printf( "Proof production is not yet supported with MILP solvers, turning SOLVE_WITH_MILP off.\n" );
         }
 
+        InputQuery inputQuery = prepareInputQuery();
+        String queryDumpFilePath = Options::get()->getString( Options::QUERY_DUMP_FILE );
+        if ( queryDumpFilePath.length() > 0 )
+        {
+            inputQuery.saveQuery( queryDumpFilePath );
+            printf( "\nInput query successfully dumped to file\n" );
+            exit( 0 );
+        }
+
         if ( options->getBool( Options::DNC_MODE ) ||
              ( !options->getBool( Options::NO_PARALLEL_DEEPSOI ) &&
                !options->getBool( Options::SOLVE_WITH_MILP ) &&
                options->getInt( Options::NUM_WORKERS ) > 1 ) )
-            DnCMarabou().run();
+            DnCMarabou( inputQuery ).run();
         else
-	{
-#ifdef ENABLE_OPENBLAS
-	    openblas_set_num_threads( options->getInt( Options::NUM_BLAS_THREADS ) );
-#endif
-            Marabou().run();
-	}
+	    {
+            #ifdef ENABLE_OPENBLAS
+                    openblas_set_num_threads( options->getInt( Options::NUM_BLAS_THREADS ) );
+            #endif
+            Marabou( inputQuery ).run();
+	    }
     }
     catch ( const Error &e )
     {


### PR DESCRIPTION
Follows up on the suggestion by @anwu1219 to refactor the input query parsing into `main.cpp` before it branches on whether to use `Marabou` or `DNCMarabou`.