### PR TITLE
Do not include cpuid.h on Apple ARM64.

### DIFF
--- a/src/common/GetCPUData.h
+++ b/src/common/GetCPUData.h
@@ -19,7 +19,7 @@
 #if defined( __linux__ )
 #include <sched.h>
 #define getCPUId( cpu ) { cpu = sched_getcpu(); }
-#elif __APPLE__
+#elif __APPLE__ && (!defined(__arm64__))
 #include <cpuid.h>
 
 #define CPUId( INFO, LEAF, SUBLEAF ) __cpuid_count( LEAF, SUBLEAF, INFO[0],  \


### PR DESCRIPTION
Fixes #593.

On Apple M1 machines, building Marabou fails because `cpuid.h` does not support the ARM64 architecture.
Simply not including `cpuid.h` on ARM64 architectures allows for the build to succeed.

The `getCPUId` macro definition then falls back to always yield `"#"` which should be fine, as the only place where `getCPUId` seems to be used is `DnCManager.cpp` for logging purposes (which in turn does nothing in non-DEBUG builds).