### PR TITLE
Fix encoding bug of disjunction in maraboupy

### DIFF
--- a/maraboupy/MarabouCore.cpp
+++ b/maraboupy/MarabouCore.cpp
@@ -169,7 +169,7 @@ void addDisjunctionConstraint(InputQuery& ipq, const std::list<std::list<Equatio
             {
                 // Add bounds as tightenings
                 unsigned var = eq._addends.front()._variable;
-                unsigned coeff = eq._addends.front()._coefficient;
+                double coeff = eq._addends.front()._coefficient;
                 if ( coeff == 0 )
                     throw CommonError( CommonError::DIVISION_BY_ZERO,
                                        "AddDisjunctionConstraint: zero coefficient encountered" );
@@ -181,9 +181,10 @@ void addDisjunctionConstraint(InputQuery& ipq, const std::list<std::list<Equatio
                     split.storeBoundTightening( Tightening( var, scalar, Tightening::LB ) );
                     split.storeBoundTightening( Tightening( var, scalar, Tightening::UB ) );
                 }
-                else if ( type == Equation::GE || coeff < 0 )
+                else if ( ( type == Equation::GE && coeff > 0 ) ||
+                          ( type == Equation::LE && coeff < 0 ) )
                     split.storeBoundTightening( Tightening( var, scalar, Tightening::LB ) );
-                else if ( type == Equation::LE || coeff < 0 )
+                else
                     split.storeBoundTightening( Tightening( var, scalar, Tightening::UB ) );
             }
             else

--- a/maraboupy/test/test_disjunction.py
+++ b/maraboupy/test/test_disjunction.py
@@ -1,0 +1,111 @@
+# Supress warnings caused by tensorflow
+import warnings
+warnings.filterwarnings('ignore', category = DeprecationWarning)
+warnings.filterwarnings('ignore', category = PendingDeprecationWarning)
+
+import pytest
+from .. import Marabou
+from .. import MarabouCore
+import numpy as np
+import os
+
+# Global settings
+OPT = Marabou.createOptions(verbosity = 0) # Turn off printing
+TOL = 1e-4                                 # Set tolerance for checking Marabou evaluations
+
+# Test adapted from https://github.com/NeuralNetworkVerification/Marabou/issues/607
+def test_unit_equation1():
+    # x0 = 1
+    # Disj(-x0 >= 0)
+
+    inputQuery = MarabouCore.InputQuery()
+    inputQuery.setNumberOfVariables(1)
+
+    inputQuery.setLowerBound(0,-1)
+    inputQuery.setUpperBound(0,1)
+
+    eq0 = MarabouCore.Equation()
+    eq0.addAddend(1,0)
+    eq0.setScalar(1)
+    inputQuery.addEquation(eq0)
+
+    eq1 = MarabouCore.Equation(MarabouCore.Equation.EquationType.GE)
+    eq1.addAddend(-1, 0)
+    eq1.setScalar(0)
+
+    MarabouCore.addDisjunctionConstraint(inputQuery, [[eq1]])
+
+    r, _, _ = MarabouCore.solve(inputQuery, OPT, "")
+    assert(r == "unsat")
+
+def test_unit_equation2():
+    # x0 = 1
+    # Disj(x0 <= 0)
+
+    inputQuery = MarabouCore.InputQuery()
+    inputQuery.setNumberOfVariables(1)
+
+    inputQuery.setLowerBound(0,-1)
+    inputQuery.setUpperBound(0,1)
+
+    eq0 = MarabouCore.Equation()
+    eq0.addAddend(1,0)
+    eq0.setScalar(1)
+    inputQuery.addEquation(eq0)
+
+    eq1 = MarabouCore.Equation(MarabouCore.Equation.EquationType.LE)
+    eq1.addAddend(1, 0)
+    eq1.setScalar(0)
+
+    MarabouCore.addDisjunctionConstraint(inputQuery, [[eq1]])
+
+    r, _, _ = MarabouCore.solve(inputQuery, OPT, "")
+    assert(r == "unsat")
+
+def test_unit_equation3():
+    # x0 = 1
+    # Disj(-x0 <= 0)
+    inputQuery = MarabouCore.InputQuery()
+    inputQuery.setNumberOfVariables(1)
+
+    inputQuery.setLowerBound(0,-1)
+    inputQuery.setUpperBound(0,1)
+
+    eq0 = MarabouCore.Equation()
+    eq0.addAddend(1,0)
+    eq0.setScalar(1)
+    inputQuery.addEquation(eq0)
+
+    eq1 = MarabouCore.Equation(MarabouCore.Equation.EquationType.LE)
+    eq1.addAddend(-1, 0)
+    eq1.setScalar(0)
+
+    MarabouCore.addDisjunctionConstraint(inputQuery, [[eq1]])
+
+    r, vals, _ = MarabouCore.solve(inputQuery, OPT, "")
+    assert(r == "sat")
+    assert(vals[0] == 1)
+
+def test_unit_equation4():
+    # x0 = 1
+    # Disj(x0 >= 0)
+    inputQuery = MarabouCore.InputQuery()
+    inputQuery.setNumberOfVariables(1)
+
+    inputQuery.setLowerBound(0,-1)
+    inputQuery.setUpperBound(0,1)
+
+    eq0 = MarabouCore.Equation()
+    eq0.addAddend(1,0)
+    eq0.setScalar(1)
+    inputQuery.addEquation(eq0)
+
+    eq1 = MarabouCore.Equation(MarabouCore.Equation.EquationType.GE)
+    eq1.addAddend(1, 0)
+    eq1.setScalar(0)
+
+    MarabouCore.addDisjunctionConstraint(inputQuery, [[eq1]])
+
+    r, vals, _ = MarabouCore.solve(inputQuery, OPT, "")
+    assert(r == "sat")
+    assert(vals[0] == 1)

--- a/src/engine/DisjunctionConstraint.cpp
+++ b/src/engine/DisjunctionConstraint.cpp
@@ -15,6 +15,7 @@
 #include "DisjunctionConstraint.h"
 
 #include "Debug.h"
+#include "InfeasibleQueryException.h"
 #include "InputQuery.h"
 #include "MStringf.h"
 #include "MarabouError.h"
@@ -480,6 +481,8 @@ void DisjunctionConstraint::updateFeasibleDisjuncts()
         else if ( _cdInfeasibleCases && !isCaseInfeasible( indToPhaseStatus( ind ) ) )
             markInfeasible( indToPhaseStatus( ind ) );
     }
+
+    if ( _feasibleDisjuncts.size() == 0 ) throw InfeasibleQueryException();
 }
 
 bool DisjunctionConstraint::disjunctIsFeasible( unsigned ind ) const


### PR DESCRIPTION
1. Fix encoding bug of DisjunctionConstraint in python API
2. Throw InfeasibleQueryException() when _feasibleDisjuncts becomes empty 
3. Added some unit tests 