### PR TITLE
Refactored PropertyParser and improved error messages

### DIFF
--- a/src/input_parsers/InputParserError.h
+++ b/src/input_parsers/InputParserError.h
@@ -28,6 +28,8 @@ public:
         UNSUPPORTED_BOUND_TYPE = 3,
         NETWORK_LEVEL_REASONING_DISABLED = 4,
         HIDDEN_VARIABLE_DOESNT_EXIST_IN_NLR = 5,
+        INVALID_VARIABLE_NAME = 6,
+        INVALID_HIDDEN_VARIABLE_INDICES = 7,
     };
 
     InputParserError( InputParserError::Code code ) : Error( "InputParserError", (int)code )

--- a/src/input_parsers/PropertyParser.h
+++ b/src/input_parsers/PropertyParser.h
@@ -32,8 +32,9 @@ public:
     void parse( const String &propertyFilePath, InputQuery &inputQuery );
 
 private:
-    void processSingleLine( const String &line, InputQuery &inputQuery );
-    Equation::EquationType extractRelationSymbol( const String &token );
+    void parseEquation( const String &line, InputQuery &inputQuery );
+    Pair<double, unsigned> parseAddend ( const String &token , InputQuery &inputQuery );
+
 };
 
 #endif // __PropertyParser_h__


### PR DESCRIPTION
This is a no-op refactoring of `PropertyParser` that unifies the variable parsing code between the case when we're parsing a bound and the case when we're parsing a full equation. This is in preparation for fixing #625, but that fix is not in this PR.

The only piece of functionality change is that the parser now skips empty lines.