### PR TITLE
Fix bug in ONNX parser with network with duplicate names

### DIFF
--- a/maraboupy/test_requirements.txt
+++ b/maraboupy/test_requirements.txt
@@ -1,6 +1,6 @@
 pytest>=7.2.1
 pytest-cov>=4.0.0
-codecov==2.1.0
+codecov>=2.1.0
 numpy==1.21.0
 tensorflow==2.10.0
 onnx==1.12.0

--- a/src/input_parsers/OnnxParser.cpp
+++ b/src/input_parsers/OnnxParser.cpp
@@ -19,6 +19,7 @@
  **   rather than passing references to onnx::NodeProto as one might expect.
  **   Likewise, this is why we store the shape data in a separate data structure
  **   rather than simply retrieving it when needed.
+ **   - Node names are not unique, and do not necessarily even exist.
 **/
 
 #include "OnnxParser.h"
@@ -54,7 +55,7 @@ OnnxParser::OnnxParser( const String &path )
     model.ParseFromArray( buffer.data(), size );
     _network = model.graph();
 
-    initializeMaps();
+    initializeConstantMap();
 }
 /**
  * @brief Generates the variables for a query over the whole network.
@@ -327,49 +328,51 @@ Vector<int> getIntsAttribute( onnx::NodeProto& node, String name, Vector<int>& d
  *******************/
 
 /**
- * @brief Initialises the mapping from node names to nodes and
+ * @brief Initialises the mapping from initializer names to values and
  * checks the invariant that there are no duplicate names.
  */
-void OnnxParser::initializeMaps()
+void OnnxParser::initializeConstantMap()
 {
-    Set<std::string> names;
-    for ( const onnx::NodeProto& node : _network.node() )
-    {
-        const std::string name = node.name();
-        if ( names.exists( name) )
-        {
-            String errorMessage = "Nodes in Onnx network must have a unique name";
-            throw MarabouError( MarabouError::ONNX_PARSER_ERROR, errorMessage.ascii() );
-        }
-        else
-        {
-            _nodeMap.insert( name, &node );
-            names.insert( name );
-        }
-    }
-
     for ( const onnx::TensorProto& initializer : _network.initializer() )
     {
         const std::string name = initializer.name();
-        if ( names.exists( name ) )
+        if ( _constantMap.exists( name ) )
         {
-            String errorMessage = "Nodes in Onnx network must have a unique name";
+            String errorMessage = Stringf( "Initializers in Onnx network must have a unique name but found duplicate name '%s'", name.c_str() );
             throw MarabouError( MarabouError::ONNX_PARSER_ERROR, errorMessage.ascii() );
         }
         else
         {
             _constantMap.insert( name, &initializer );
-            names.insert( name );
         }
     }
 }
 
 void OnnxParser::validateUserInputNames( Set<String>& inputNames )
 {
+    // Collate all input nodes
+    Set<String> allInputNames;
+    for ( const onnx::ValueInfoProto& node : _network.input() )
+    {
+        const std::string name = node.name();
+        if ( _constantMap.exists( name ))
+            continue;
+
+        if ( allInputNames.exists( name ) )
+        {
+            String errorMessage = Stringf( "Input nodes in Onnx network must have a unique name but found duplicate name '%s'", name.c_str() );
+            throw MarabouError( MarabouError::ONNX_PARSER_ERROR, errorMessage.ascii() );
+        }
+        else
+        {
+            allInputNames.insert( name );
+        }
+    }
+
     // Validate the provided inputs
     for ( String inputName : inputNames )
     {
-        if ( !_nodeMap.exists( inputName ) )
+        if ( !allInputNames.exists( inputName ) )
         {
             String errorMessage = Stringf( "Input %s not found in graph!", inputName.ascii() );
             throw MarabouError( MarabouError::ONNX_PARSER_ERROR, errorMessage.ascii() );

--- a/src/input_parsers/OnnxParser.h
+++ b/src/input_parsers/OnnxParser.h
@@ -42,7 +42,6 @@ private:
     Set<String> _processedNodes;
     unsigned _numberOfFoundInputs;
 
-    Map<String, const onnx::NodeProto*> _nodeMap;
     Map<String, const onnx::TensorProto*> _constantMap;
 
     Map<String, TensorShape> _shapeMap;
@@ -51,7 +50,7 @@ private:
     void readNetwork( const String& path );
     Set<String> readInputNames();
     String readOutputName();
-    void initializeMaps();
+    void initializeConstantMap();
     void initializeShapeMap();
     void validateUserInputNames( Set<String>& inputNames) ;
     void validateUserOutputNames( String& outputName );


### PR DESCRIPTION
Node names are not necessarily unique, and actually don't need to be for the parser code to work. Only input node names need to be unique