### PR TITLE
Lower TensorFlow version bound

### DIFF
--- a/maraboupy/test_requirements.txt
+++ b/maraboupy/test_requirements.txt
@@ -1,3 +1,4 @@
+# NOTE: These dependencies must be kept in-sync with the test dependencies in 'pyproject.toml'
 numpy>=1.21.0,<2
 onnx>=1.12.0,<2
 onnxruntime>=1.12.0,<2

--- a/maraboupy/test_requirements.txt
+++ b/maraboupy/test_requirements.txt
@@ -3,5 +3,7 @@ onnx>=1.12.0,<2
 onnxruntime>=1.12.0,<2
 pytest>=7.2.1,<8
 pytest-cov>=4.0.0,<5
-tensorflow>=2.10.0,<3
+# 2023-07-12:
+# Cannot use tensorflow 2.13 because it removes 'tensorflow.python.framework.graph_util.convert_variables_to_constants'
+tensorflow>=2.10,<2.13
 torch>=1.11.0,<3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,17 +14,6 @@ requires-python = ">=3.7,<3.12"
 [project.scripts]
 Marabou = "maraboupy.MarabouMain:main"
 
-[project.optional-dependencies]
-test = [
-  "pytest>=7.2.1,<8",
-  "pytest-cov>=4.0.0,<5",
-  "numpy>=1.21.0,<2",
-  "tensorflow>=2.10.0,<3",
-  "onnx>=1.12.0,<2",
-  "onnxruntime>=1.12.0,<2",
-  "torch>=1.11.0,<2",
-]
-
 [tool.setuptools]
 packages = ["maraboupy"]
 
@@ -55,7 +44,7 @@ skip = [
 ]
 before-test = ["python {package}/setup.py build_ext --inplace"]
 test-command = "pytest {package}/maraboupy/test"
-test-extras = ["test"]
+test-requires = ["-r{package}/maraboupy/test/test_requires.txt"]
 test-skip = [
   # 2023-04-15: onnxruntime does not support Python 3.11
   "cp311-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ skip = [
 ]
 before-test = ["python {package}/setup.py build_ext --inplace"]
 test-command = "pytest {package}/maraboupy/test"
-test-requires = ["-r{package}/maraboupy/test/test_requires.txt"]
+test-extras = ["test"]
 test-skip = [
   # 2023-04-15: onnxruntime does not support Python 3.11
   "cp311-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,20 @@ readme = "README.md"
 license = { file = "COPYING" }
 requires-python = ">=3.7,<3.12"
 
+[project.optional-dependencies]
+test = [
+  # NOTE: These dependencies must be kept in-sync with the legacy requirements file 'maraboupy/test_requirements.txt'
+  "numpy>=1.21.0,<2",
+  "onnx>=1.12.0,<2",
+  "onnxruntime>=1.12.0,<2",
+  "pytest>=7.2.1,<8",
+  "pytest-cov>=4.0.0,<5",
+  # 2023-07-12:
+  # Cannot use tensorflow 2.13 because it removes 'tensorflow.python.framework.graph_util.convert_variables_to_constants'
+  "tensorflow>=2.10,<2.13",
+  "torch>=1.11.0,<3",
+]
+
 [project.scripts]
 Marabou = "maraboupy.MarabouMain:main"
 


### PR DESCRIPTION
This PR lowers the version bound for TensorFlow, because the maraboupy tests fail for version 2.13.

See [this failing test](
https://github.com/NeuralNetworkVerification/Marabou/actions/runs/5522523078/jobs/10072235077#step:3:7592):
```
  # Simplify graph using outputNames, which must be specified for SavedModel
> simp_graph_def = graph_util.convert_variables_to_constants(sess,sess.graph.as_graph_def(),outputNames)
E AttributeError: module 'tensorflow.python.framework.graph_util' has no attribute 'convert_variables_to_constants'
```