### PR TITLE
Setup trusted publishing to PyPI on tag

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -33,6 +33,10 @@ defaults:
     shell: sh
 
 jobs:
+  ################################################################################
+  # Build and test binary release for Python package
+  ################################################################################
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -56,3 +60,60 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
+
+  ################################################################################
+  # Publish package to GitHub Releases
+  ################################################################################
+
+  publish_package_to_github_releases:
+    name: Publish package to GitHub Releases
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - build_wheels
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download wheelhouse
+        uses: actions/download-artifact@v3
+        with:
+          name: wheelhouse
+          path: wheelhouse
+
+      - name: Publish to GitHub Releases
+        uses: softprops/action-gh-release@v1
+        with:
+          files: wheelhouse/*.whl
+          fail_on_unmatched_files: true
+
+  ################################################################################
+  # Publish package to PyPI
+  ################################################################################
+
+  publish_package_to_pypi:
+    name: Publish package to PyPI
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - build_wheels
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/vehicle-lang
+
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+      - name: Download wheelhouse
+        uses: actions/download-artifact@v3
+        with:
+          name: wheelhouse
+          path: wheelhouse
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -59,6 +59,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
+          name: wheelhouse
           path: ./wheelhouse/*.whl
 
   ################################################################################


### PR DESCRIPTION
This PR sets up trusted publishing to PyPI so that new releases for x86_64 architectures are automatically pushed to PyPI when a new version tag is created.