### PR TITLE
Do not reindex output variables in python ONNX parser by default 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Command-line ONNX parser now supports networks with multiple outputs.
 * Command-line ONNX parser now supports the following operators: Cast, Squeeze.
 * Errors now are printed on `stderr` rather than `stdout`
+* Not reindexing output variables to immediately follow after input variables in the MarabouNetworkONNX class
 
 ## Version 1.0.0
 * Initial versioned release

--- a/maraboupy/Marabou.py
+++ b/maraboupy/Marabou.py
@@ -61,7 +61,7 @@ def read_tf(filename, inputNames=None, outputNames=None, modelType="frozen", sav
     """
     return MarabouNetworkTF(filename, inputNames, outputNames, modelType, savedModelTags)
 
-def read_onnx(filename, inputNames=None, outputNames=None, reindexOutputVars=True):
+def read_onnx(filename, inputNames=None, outputNames=None, reindexOutputVars=False):
     """Constructs a MarabouNetworkONNX object from an ONNX file
 
     Args:

--- a/maraboupy/MarabouNetworkONNX.py
+++ b/maraboupy/MarabouNetworkONNX.py
@@ -38,7 +38,7 @@ class MarabouNetworkONNX(MarabouNetwork.MarabouNetwork):
     Returns:
         :class:`~maraboupy.Marabou.marabouNetworkONNX.marabouNetworkONNX`
     """
-    def __init__(self, filename, inputNames=None, outputNames=None, reindexOutputVars=True):
+    def __init__(self, filename, inputNames=None, outputNames=None, reindexOutputVars=False):
         super().__init__()
         self.readONNX(filename, inputNames, outputNames, reindexOutputVars=reindexOutputVars)
 
@@ -69,7 +69,7 @@ class MarabouNetworkONNX(MarabouNetwork.MarabouNetwork):
         self.outputNames = None
         self.graph = None
 
-    def readONNX(self, filename, inputNames, outputNames, reindexOutputVars=True):
+    def readONNX(self, filename, inputNames, outputNames, reindexOutputVars=False):
         """Read an ONNX file and create a MarabouNetworkONNX object
 
         Args:
@@ -120,6 +120,9 @@ class MarabouNetworkONNX(MarabouNetwork.MarabouNetwork):
             # If this is skipped, the output variables will be the last variables defined.
             self.reassignOutputVariables()
         else:
+            for outputName in self.outputNames:
+                if outputName in self.constantMap:
+                    raise RuntimeError("Output variable %s is a constant, not the output of equations!" % outputName)
             self.outputVars = [self.varMap[outputName] for outputName in self.outputNames]
 
     def splitNetworkAtNode(self, nodeName, networkNamePreSplit=None,

--- a/maraboupy/test/test_onnx.py
+++ b/maraboupy/test/test_onnx.py
@@ -297,6 +297,38 @@ def test_errors():
         network = Marabou.read_onnx(filename, inputNames = ['X'], outputNames = ['11'])
         network.evaluateWithoutMarabou([])
 
+def test_errors_do_not_reindex():
+    """
+    This function tests that the ONNX parser catches errors when reindex flag is on.
+
+    NOTE: we plan to remove the reindexOuputVars feature in the long run.
+    This test can be removed at that point.
+    """
+    filename =  "conv_mp1.onnx"
+    filename = os.path.join(os.path.dirname(__file__), NETWORK_FOLDER, filename)
+
+    # Test that we catch if inputNames or outputNames are not in the model
+    with pytest.raises(RuntimeError, match=r"Input.*not found"):
+        Marabou.read_onnx(filename, inputNames = ['BAD_NAME'], outputNames = ['Y'], reindexOutputVars=True)
+    with pytest.raises(RuntimeError, match=r"Output.*not found"):
+        Marabou.read_onnx(filename, outputNames = ['BAD_NAME'])
+
+    # The layer "12" is in the graph, but refers to a constant, so it should not be used
+    # as the network input or output.
+    with pytest.raises(RuntimeError, match=r"input variables could not be found"):
+        Marabou.read_onnx(filename, inputNames = ['12'], outputNames = ['Y'], reindexOutputVars=True)
+    with pytest.raises(RuntimeError, match=r"Output variable.*is a constant"):
+        Marabou.read_onnx(filename, outputNames = ['12'])
+
+    # Evaluating with ONNX instead of Marabou gives errors when using a layer that is not already
+    # defined as part of the model inputs or outputs.
+    with pytest.raises(NotImplementedError, match=r"ONNX does not allow.*as inputs"):
+        network = Marabou.read_onnx(filename, inputNames = ['11'], outputNames = ['Y'], reindexOutputVars=True)
+        network.evaluateWithoutMarabou([])
+    with pytest.raises(NotImplementedError, match=r"ONNX does not allow.*the output"):
+        network = Marabou.read_onnx(filename, inputNames = ['X'], outputNames = ['11'], reindexOutputVars=True)
+        network.evaluateWithoutMarabou([])
+
 def evaluateFile(filename, inputNames = None, outputNames = None, testInputs = None, numPoints = NUM_RAND):
     """
     Load network and evaluate testInputs with and without Marabou


### PR DESCRIPTION
Also fix a minor bug exposed by the test.