### PR TITLE
Add .gitattributes file to stop Git from trying to display diffs of ONNX files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Used to stop Git from trying to display diffs of ONNX files.
+*.onnx binary


### PR DESCRIPTION
Fixes https://github.com/NeuralNetworkVerification/Marabou/issues/661