### PR TITLE
Remove output variable reindexing in Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@
   - `MarabouONNXNetwork` no longer has a `shallowCopy` method. Instead of calling this method,
     you should set the new parameter `preserveExistingConstraints` in the method `readONNX` to
     `True` which has the same effect.
-  - The method `getMarabouQuery` on `MarabouNetwork` has been renamed `getInputQuery`.
+  - The constructor `MarabouONNXNetwork()` and method `MarabouNetwork.readONNX` no longer take
+    a `reindexOutputVars` parameter (was intended to be used for internal testing purposes only).
+  - The method `MarabouNetwork.getMarabouQuery` has been renamed `getInputQuery`.
 
 * Added support for creating constraints using the overloaded syntax `<=`, `==` etc. in
   the Python backend. See `maraboupy/examples/7_PythonicAPI.py` for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Dependency changes:
   - Dropped support for Python 3.7
-  - Now use ONNX 1.15.0 (up from 0.12.0) in both C++ and Python backends.
+  - Now use ONNX 1.15.0 (up from 1.12.0) in both C++ and Python backends.
   - The class `MarabouONNXNetwork` no longer depends on `torch` in Python backend.
 
 * Marabou now prints errors on `stderr` rather than `stdout`

--- a/maraboupy/Marabou.py
+++ b/maraboupy/Marabou.py
@@ -61,19 +61,18 @@ def read_tf(filename, inputNames=None, outputNames=None, modelType="frozen", sav
     """
     return MarabouNetworkTF(filename, inputNames, outputNames, modelType, savedModelTags)
 
-def read_onnx(filename, inputNames=None, outputNames=None, reindexOutputVars=False):
+def read_onnx(filename, inputNames=None, outputNames=None):
     """Constructs a MarabouNetworkONNX object from an ONNX file
 
     Args:
         filename (str): Path to the ONNX file
         inputNames (list of str, optional): List of node names corresponding to inputs
         outputNames (list of str, optional): List of node names corresponding to outputs
-        reindexOutputVars (bool): Reindex the variables so that the output variables are immediate after input variables
 
     Returns:
         :class:`~maraboupy.MarabouNetworkONNX.MarabouNetworkONNX`
     """
-    return MarabouNetworkONNX(filename, inputNames, outputNames, reindexOutputVars=reindexOutputVars)
+    return MarabouNetworkONNX(filename, inputNames, outputNames)
 
 def load_query(filename):
     """Load the serialized inputQuery from the given filename

--- a/maraboupy/MarabouNetworkONNX.py
+++ b/maraboupy/MarabouNetworkONNX.py
@@ -31,11 +31,11 @@ class MarabouNetworkONNX(MarabouNetwork):
     Returns:
         :class:`~maraboupy.Marabou.marabouNetworkONNX.marabouNetworkONNX`
     """
-    def __init__(self, filename, inputNames=None, outputNames=None, reindexOutputVars=False):
+    def __init__(self, filename, inputNames=None, outputNames=None):
         super().__init__()
-        self.readONNX(filename, inputNames, outputNames, reindexOutputVars)
+        self.readONNX(filename, inputNames, outputNames)
 
-    def readONNX(self, filename, inputNames=None, outputNames=None, reindexOutputVars=True, preserveExistingConstraints=False):
+    def readONNX(self, filename, inputNames=None, outputNames=None, preserveExistingConstraints=False):
         if not preserveExistingConstraints:
             self.clear()
 
@@ -71,7 +71,7 @@ class MarabouNetworkONNX(MarabouNetwork):
             initNames = [node.name for node in self.graph.initializer]
             self.outputNames = [out.name for out in self.graph.output if out.name not in initNames]
 
-        ONNXParser.parse(self, self.graph, self.inputNames, self.outputNames, reindexOutputVars=reindexOutputVars)
+        ONNXParser.parse(self, self.graph, self.inputNames, self.outputNames)
 
     def getNode(self, nodeName):
         """Find the node in the graph corresponding to the given name

--- a/maraboupy/test/test_onnx.py
+++ b/maraboupy/test/test_onnx.py
@@ -207,11 +207,11 @@ def test_multiOutput():
 def test_preserve_existing_constraints_clear():
     filename = "tanh_test.onnx"
     filename = os.path.join(os.path.dirname(__file__), NETWORK_FOLDER, filename)
-    network = Marabou.read_onnx(filename, reindexOutputVars=False)
+    network = Marabou.read_onnx(filename)
     numVar1 = network.numVars
     numEq1 = len(network.equList)
     numSigmoid1 = len(network.sigmoidList)
-    network.readONNX(filename, None, None, reindexOutputVars=False, preserveExistingConstraints=True)
+    network.readONNX(filename, None, None, preserveExistingConstraints=True)
     numVar2 = network.numVars
     numEq2 = len(network.equList)
     numSigmoid2 = len(network.sigmoidList)
@@ -308,24 +308,24 @@ def test_errors_do_not_reindex():
 
     # Test that we catch if inputNames or outputNames are not in the model
     with pytest.raises(RuntimeError, match=r"Input.*not found"):
-        Marabou.read_onnx(filename, inputNames = ['BAD_NAME'], outputNames = ['Y'], reindexOutputVars=True)
+        Marabou.read_onnx(filename, inputNames = ['BAD_NAME'], outputNames = ['Y'])
     with pytest.raises(RuntimeError, match=r"Output.*not found"):
         Marabou.read_onnx(filename, outputNames = ['BAD_NAME'])
 
     # The layer "12" is in the graph, but refers to a constant, so it should not be used
     # as the network input or output.
     with pytest.raises(RuntimeError, match=r"input variables could not be found"):
-        Marabou.read_onnx(filename, inputNames = ['12'], outputNames = ['Y'], reindexOutputVars=True)
+        Marabou.read_onnx(filename, inputNames = ['12'], outputNames = ['Y'])
     with pytest.raises(RuntimeError, match=r"Output variable.*is a constant"):
         Marabou.read_onnx(filename, outputNames = ['12'])
 
     # Evaluating with ONNX instead of Marabou gives errors when using a layer that is not already
     # defined as part of the model inputs or outputs.
     with pytest.raises(NotImplementedError, match=r"ONNX does not allow.*as inputs"):
-        network = Marabou.read_onnx(filename, inputNames = ['11'], outputNames = ['Y'], reindexOutputVars=True)
+        network = Marabou.read_onnx(filename, inputNames = ['11'], outputNames = ['Y'])
         network.evaluateWithoutMarabou([])
     with pytest.raises(NotImplementedError, match=r"ONNX does not allow.*the output"):
-        network = Marabou.read_onnx(filename, inputNames = ['X'], outputNames = ['11'], reindexOutputVars=True)
+        network = Marabou.read_onnx(filename, inputNames = ['X'], outputNames = ['11'])
         network.evaluateWithoutMarabou([])
 
 def evaluateFile(filename, inputNames = None, outputNames = None, testInputs = None, numPoints = NUM_RAND):


### PR DESCRIPTION
As discussed, removes the option to reindex the output variables as it is no longer needed. It was used to test the output of these parsers against the now defunct nnet format parser.