### PR TITLE
Fixed deprecated constructors with templates (#855)

### DIFF
--- a/src/common/HashSet.h
+++ b/src/common/HashSet.h
@@ -30,11 +30,11 @@ public:
     typedef typename Super::iterator iterator;
     typedef typename Super::const_iterator const_iterator;
 
-    HashSet<Value>()
+    HashSet()
     {
     }
 
-    HashSet<Value>( const std::initializer_list<Value> &initializerList )
+    HashSet( const std::initializer_list<Value> &initializerList )
         : _container( initializerList )
     {
     }
@@ -44,35 +44,35 @@ public:
         _container.insert( value );
     }
 
-    void insert( const HashSet<Value> &other )
+    void insert( const HashSet &other )
     {
         for ( auto it = other.begin(); it != other.end(); ++it )
             _container.insert( *it );
     }
 
-    void operator+=( const HashSet<Value> &other )
+    void operator+=( const HashSet &other )
     {
         insert( other );
     }
 
-    HashSet<Value> operator+( const HashSet<Value> &other )
+    HashSet operator+( const HashSet &other )
     {
-        HashSet<Value> result = *this;
+        HashSet result = *this;
         result.insert( other );
         return result;
     }
 
-    bool operator==( const HashSet<Value> &other ) const
+    bool operator==( const HashSet &other ) const
     {
         return _container == other._container;
     }
 
-    bool operator!=( const HashSet<Value> &other ) const
+    bool operator!=( const HashSet &other ) const
     {
         return _container != other._container;
     }
 
-    bool operator<( const HashSet<Value> &other ) const
+    bool operator<( const HashSet &other ) const
     {
         return _container < other._container;
     }

--- a/src/common/List.h
+++ b/src/common/List.h
@@ -31,27 +31,27 @@ public:
     typedef typename Super::reverse_iterator reverse_iterator;
     typedef typename Super::const_reverse_iterator const_reverse_iterator;
 
-    List<T>()
+    List()
     {
     }
 
-    List<T>( const std::initializer_list<T> &initializerList )
+    List( const std::initializer_list<T> &initializerList )
         : _container( initializerList )
     {
     }
 
-    List<T>( unsigned size, T value )
+    List( unsigned size, T value )
         : _container( size, value )
     {
     }
 
     template <class InputIt>
-    List<T>( InputIt begin, InputIt end )
+    List( InputIt begin, InputIt end )
         : _container( begin, end )
     {
     }
 
-    void append( const List<T> &other )
+    void append( const List &other )
     {
         for ( const auto &element : other )
             _container.push_back( element );
@@ -67,7 +67,7 @@ public:
         _container.push_front( value );
     }
 
-    void appendHead( const List<T> &other )
+    void appendHead( const List &other )
     {
         _container.insert( begin(), other.begin(), other.end() );
     }
@@ -188,12 +188,12 @@ public:
         _container.remove_if( p );
     }
 
-    bool operator==( const List<T> &other ) const
+    bool operator==( const List &other ) const
     {
         return _container == other._container;
     }
 
-    bool operator!=( const List<T> &other ) const
+    bool operator!=( const List &other ) const
     {
         return _container != other._container;
     }

--- a/src/common/Set.h
+++ b/src/common/Set.h
@@ -36,11 +36,11 @@ public:
     typedef typename Super::const_iterator const_iterator;
     typedef typename Super::const_reverse_iterator const_reverse_iterator;
 
-    Set<Value>()
+    Set()
     {
     }
 
-    Set<Value>( const std::initializer_list<Value> &initializerList )
+    Set( const std::initializer_list<Value> &initializerList )
         : _container( initializerList )
     {
     }
@@ -50,7 +50,7 @@ public:
         _container.insert( value );
     }
 
-    void insert( const Set<Value> &other )
+    void insert( const Set &other )
     {
         for ( auto it = other.begin(); it != other.end(); ++it )
             _container.insert( *it );
@@ -62,43 +62,43 @@ public:
             _container.insert( *it );
     }
 
-    void operator+=( const Set<Value> &other )
+    void operator+=( const Set &other )
     {
         insert( other );
     }
 
-    Set<Value> operator+( const Set<Value> &other )
+    Set operator+( const Set &other )
     {
-        Set<Value> result = *this;
+        Set result = *this;
         result.insert( other );
         return result;
     }
 
-    bool operator==( const Set<Value> &other ) const
+    bool operator==( const Set &other ) const
     {
         return _container == other._container;
     }
 
-    bool operator!=( const Set<Value> &other ) const
+    bool operator!=( const Set &other ) const
     {
         return _container != other._container;
     }
 
-    bool operator<( const Set<Value> &other ) const
+    bool operator<( const Set &other ) const
     {
         return _container < other._container;
     }
 
-    static bool containedIn( const Set<Value> &one, const Set<Value> &two )
+    static bool containedIn( const Set &one, const Set &two )
     // Is one contained in two?
     {
-        return Set<Value>::difference( one, two ).empty();
+        return Set::difference( one, two ).empty();
     }
 
-    static Set<Value> difference( const Set<Value> &one, const Set<Value> &two )
+    static Set difference( const Set &one, const Set &two )
     // Elements that appear in one, but do not appear in two.
     {
-        Set<Value> difference;
+        Set difference;
         std::set_difference( one.begin(),
                              one.end(),
                              two.begin(),
@@ -107,9 +107,9 @@ public:
         return difference;
     }
 
-    static Set<Value> intersection( const Set<Value> &one, const Set<Value> &two )
+    static Set intersection( const Set &one, const Set &two )
     {
-        Set<Value> intersection;
+        Set intersection;
         std::set_intersection( one.begin(),
                                one.end(),
                                two.begin(),

--- a/src/common/Vector.h
+++ b/src/common/Vector.h
@@ -33,29 +33,29 @@ public:
 
     typedef typename Super::const_reverse_iterator const_reverse_iterator;
 
-    Vector<T>()
+    Vector()
     {
     }
 
-    Vector<T>( const Vector<T> &rhs ) = default;
+    Vector( const Vector &rhs ) = default;
 
-    Vector<T>( const std::initializer_list<T> &initializerList )
+    Vector( const std::initializer_list<T> &initializerList )
         : _container( initializerList )
     {
     }
 
-    Vector<T>( unsigned size )
+    Vector( unsigned size )
         : _container( size )
     {
     }
 
-    Vector<T>( unsigned size, T value )
+    Vector( unsigned size, T value )
         : _container( size, value )
     {
     }
 
     template <class InputIt>
-    Vector<T>( InputIt begin, InputIt end )
+    Vector( InputIt begin, InputIt end )
         : _container( begin, end )
     {
     }
@@ -238,9 +238,9 @@ public:
         std::shuffle( _container.begin(), _container.end(), g );
     }
 
-    Vector<T> operator+( const Vector<T> &other )
+    Vector operator+( const Vector &other )
     {
-        Vector<T> output;
+        Vector output;
 
         for ( unsigned i = 0; i < this->size(); ++i )
             output.append( ( *this )[i] );
@@ -251,7 +251,7 @@ public:
         return output;
     }
 
-    Vector<T> &operator+=( const Vector<T> &other )
+    Vector &operator+=( const Vector &other )
     {
         ( *this ) = ( *this ) + other;
         return *this;
@@ -293,12 +293,12 @@ public:
         return value;
     }
 
-    bool operator==( const Vector<T> &other ) const
+    bool operator==( const Vector &other ) const
     {
         if ( size() != other.size() )
             return false;
 
-        Vector<T> copyOfOther = other;
+        Vector copyOfOther = other;
 
         for ( unsigned i = 0; i < size(); ++i )
         {
@@ -311,12 +311,12 @@ public:
         return true;
     }
 
-    bool operator!=( const Vector<T> &other ) const
+    bool operator!=( const Vector &other ) const
     {
         return !( *this == other );
     }
 
-    Vector &operator=( const Vector<T> &other )
+    Vector &operator=( const Vector &other )
     {
         _container = other._container;
         return *this;


### PR DESCRIPTION
This PR removes templates appearing within classes that are either useless or, in the case of constructors, forbidden since C++20.

Resolves #855.