### PR TITLE
Try to fix dangling reference flagged by CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ find_package(Boost ${BOOST_VERSION} COMPONENTS program_options timer chrono thre
 # Find boost
 if (NOT ${Boost_FOUND})
   execute_process(COMMAND ${TOOLS_DIR}/download_boost.${SCRIPT_EXTENSION} ${BOOST_VERSION})
-  find_package(Boost ${BOOST_VERSION} REQUIRED COMPONENTS program_options timer chrono thread)
+  find_package(Boost ${BOOST_VERSION} REQUIRED COMPONENTS program_options timer chrono thread regex)
 endif()
 set(LIBS_INCLUDES ${Boost_INCLUDE_DIRS})
 list(APPEND LIBS ${Boost_LIBRARIES})

--- a/src/basis_factorization/tests/Test_SparseUnsortedArrays.h
+++ b/src/basis_factorization/tests/Test_SparseUnsortedArrays.h
@@ -212,7 +212,7 @@ public:
         SparseUnsortedArrays sv1;
         sv1.initialize( M1, 4, 4 );
 
-        const SparseUnsortedArray *row;
+        const SparseUnsortedArray *row = nullptr;
         TS_ASSERT_THROWS_NOTHING( row = sv1.getRow( 1 ) );
         TS_ASSERT_EQUALS( row->getNnz(), 2U );
         TS_ASSERT_EQUALS( row->get( 0 ), 5.0 );

--- a/src/basis_factorization/tests/Test_SparseUnsortedLists.h
+++ b/src/basis_factorization/tests/Test_SparseUnsortedLists.h
@@ -212,7 +212,7 @@ public:
         SparseUnsortedLists sv1;
         sv1.initialize( M1, 4, 4 );
 
-        const SparseUnsortedList *row;
+        const SparseUnsortedList *row = nullptr;
         TS_ASSERT_THROWS_NOTHING( row = sv1.getRow( 1 ) );
         TS_ASSERT_EQUALS( row->getNnz(), 2U );
         TS_ASSERT_EQUALS( row->get( 0 ), 5.0 );

--- a/src/input_parsers/OnnxParser.cpp
+++ b/src/input_parsers/OnnxParser.cpp
@@ -353,7 +353,7 @@ int getRequiredIntAttribute( onnx::NodeProto &node, String name )
     return attr->i();
 }
 
-const onnx::TensorProto getTensorAttribute( onnx::NodeProto &node, String name )
+const onnx::AttributeProto *getTensorAttribute( onnx::NodeProto &node, String name )
 {
     const onnx::AttributeProto *attr =
         findAttribute( node, name, onnx::AttributeProto_AttributeType_TENSOR );
@@ -361,7 +361,7 @@ const onnx::TensorProto getTensorAttribute( onnx::NodeProto &node, String name )
     {
         missingAttributeError( node, name );
     }
-    return attr->t();
+    return attr;
 }
 
 Vector<int> getIntsAttribute( onnx::NodeProto &node, String name, Vector<int> &defaultValue )
@@ -972,7 +972,7 @@ void OnnxParser::makeMarabouEquations( onnx::NodeProto &node, bool makeEquations
 void OnnxParser::constant( onnx::NodeProto &node )
 {
     String outputNodeName = node.output()[0];
-    const onnx::TensorProto &value = getTensorAttribute( node, "value" );
+    const onnx::TensorProto &value = getTensorAttribute( node, "value" )->t();
     const TensorShape shape = shapeOfConstant( value );
 
     _shapeMap[outputNodeName] = shape;

--- a/src/input_parsers/OnnxParser.cpp
+++ b/src/input_parsers/OnnxParser.cpp
@@ -353,7 +353,7 @@ int getRequiredIntAttribute( onnx::NodeProto &node, String name )
     return attr->i();
 }
 
-const onnx::TensorProto &getTensorAttribute( onnx::NodeProto &node, String name )
+const onnx::TensorProto getTensorAttribute( onnx::NodeProto &node, String name )
 {
     const onnx::AttributeProto *attr =
         findAttribute( node, name, onnx::AttributeProto_AttributeType_TENSOR );

--- a/src/input_parsers/VnnLibParser.cpp
+++ b/src/input_parsers/VnnLibParser.cpp
@@ -20,7 +20,7 @@
 #include "File.h"
 #include "InputParserError.h"
 
-#include <regex>
+#include <boost/regex.hpp>
 
 static double extractScalar( const String &token )
 {
@@ -79,18 +79,24 @@ void VnnLibParser::parse( const String &vnnlibFilePath, IQuery &inputQuery )
 
 void VnnLibParser::parseVnnlib( const String &vnnlibContent, IQuery &inputQuery )
 {
-    std::regex re( R"(\(|\)|[\w\-\\.]+|<=|>=|\+|-|\*)" );
+    boost::regex re( R"(\(|\)|[\w\-\\.]+|<=|>=|\+|-|\*)" );
 
-    auto tokens_begin = std::cregex_token_iterator(
+    // Use a Boost cregex_token_iterator to tokenize a C-string range
+    auto tokens_begin = boost::cregex_token_iterator(
         vnnlibContent.ascii(), vnnlibContent.ascii() + vnnlibContent.length(), re );
-    auto tokens_end = std::cregex_token_iterator();
+    auto tokens_end = boost::cregex_token_iterator();
 
     Vector<String> all_tokens;
 
-    for ( std::cregex_token_iterator it = tokens_begin; it != tokens_end; ++it )
+    // Iterate over all matches
+    for ( boost::cregex_token_iterator it = tokens_begin; it != tokens_end; ++it )
     {
-        auto match = *it;
-        auto match_str = String( match.str().c_str() );
+        // Each match is a boost::csub_match, from which we can get a std::string
+        boost::csub_match match = *it;
+
+        // Convert match.str() to your custom String type
+        // Assuming your String can be constructed from a const char*
+        String match_str( match.str().c_str() );
 
         all_tokens.append( match_str );
     }

--- a/tools/download_boost.sh
+++ b/tools/download_boost.sh
@@ -22,10 +22,10 @@ if [[ $OSTYPE == 'darwin'* ]]; then
     export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
 fi
 mkdir installed
-./bootstrap.sh --prefix=`pwd`/installed --with-libraries=program_options,timer,chrono,thread >> /dev/null ;
+./bootstrap.sh --prefix=`pwd`/installed --with-libraries=program_options,timer,chrono,thread,regex >> /dev/null ;
 ./b2 cxxflags=-fPIC link=static cxxflags=-std=c++11 install >> /dev/null
 mkdir installed32
-./bootstrap.sh --prefix=`pwd`/installed32 --with-libraries=program_options,timer,chrono,thread >> /dev/null ;
+./bootstrap.sh --prefix=`pwd`/installed32 --with-libraries=program_options,timer,chrono,thread,regex >> /dev/null ;
 ./b2 cxxflags=-fPIC link=static cxxflags=-std=c++11 install address-model=32 >> /dev/null
 
 cd $curdir


### PR DESCRIPTION
The CI in various places is failing:
e.g. https://github.com/NeuralNetworkVerification/Marabou/actions/runs/12862710327/job/35858064473#step:12:122

because of a dangling reference. `AttributeProto` object may be deassigned as it is a local, so therefore better simply to return a copy of the `TensorProto` object.